### PR TITLE
添加下载用户数据功能的JSON数据文件的后缀名，添加强制实名认证配置选项，添加实名认证的提示页面、拦截器和错误码，修正插入用户记录的默认用户组为学生用户

### DIFF
--- a/src/main/java/edu/gdei/gdeiassistant/Config/ApplicationWebMvcConfig.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Config/ApplicationWebMvcConfig.java
@@ -113,6 +113,9 @@ public class ApplicationWebMvcConfig extends WebMvcConfigurerAdapter {
         authenticationInterceptorExceptionList.add("/login");
         //用户登录接口
         authenticationInterceptorExceptionList.add("/api/userlogin");
+        authenticationInterceptorExceptionList.add("/rest/userlogin");
+        //权限令牌操作
+        authenticationInterceptorExceptionList.add("/rest/token");
         //实名认证页面和接口
         authenticationInterceptorExceptionList.add("/authentication");
         authenticationInterceptorExceptionList.add("/api/authentication");

--- a/src/main/java/edu/gdei/gdeiassistant/Config/ApplicationWebMvcConfig.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Config/ApplicationWebMvcConfig.java
@@ -3,6 +3,7 @@ package edu.gdei.gdeiassistant.Config;
 import edu.gdei.gdeiassistant.Converter.EnumConvert.StringToAuthenticationTypeEnumConverter;
 import edu.gdei.gdeiassistant.Converter.EnumConvert.StringToLoginMethodEnumConverter;
 import edu.gdei.gdeiassistant.Converter.EnumConvert.StringToQueryMethodEnumConverter;
+import edu.gdei.gdeiassistant.Interceptor.AuthenticationInterceptor;
 import edu.gdei.gdeiassistant.Interceptor.LoginInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -77,30 +78,36 @@ public class ApplicationWebMvcConfig extends WebMvcConfigurerAdapter {
      */
     @Bean
     public List<String> loginInterceptorExceptionList() {
-        List<String> loginInterceptorExceptionList = new ArrayList<>();
-        //退出账号
-        loginInterceptorExceptionList.add("/logout");
-        //登录账号
-        loginInterceptorExceptionList.add("/login");
-        //用户登录接口
-        loginInterceptorExceptionList.add("/api/userlogin");
-        //下载接口
-        loginInterceptorExceptionList.add("/download");
-        //协议与政策
-        loginInterceptorExceptionList.add("/agreement");
-        loginInterceptorExceptionList.add("/policy");
-        loginInterceptorExceptionList.add("/license");
-        //软件说明
-        loginInterceptorExceptionList.add("/about");
+        List<String> loginInterceptorExceptionList = new ArrayList<>(authenticationInterceptorExceptionList());
         //Restful API
         loginInterceptorExceptionList.add("/rest");
-        //微信API接口
-        loginInterceptorExceptionList.add("/wechat");
-        //易班API接口
-        loginInterceptorExceptionList.add("/yiban");
-        //支付宝API接口
-        loginInterceptorExceptionList.add("/alipay");
         return loginInterceptorExceptionList;
+    }
+
+    @Bean
+    public List<String> authenticationInterceptorExceptionList() {
+        List<String> authenticationInterceptorExceptionList = new ArrayList<>();
+        //退出账号
+        authenticationInterceptorExceptionList.add("/logout");
+        //登录账号
+        authenticationInterceptorExceptionList.add("/login");
+        //用户登录接口
+        authenticationInterceptorExceptionList.add("/api/userlogin");
+        //下载接口
+        authenticationInterceptorExceptionList.add("/download");
+        //协议与政策
+        authenticationInterceptorExceptionList.add("/agreement");
+        authenticationInterceptorExceptionList.add("/policy");
+        authenticationInterceptorExceptionList.add("/license");
+        //软件说明
+        authenticationInterceptorExceptionList.add("/about");
+        //微信API接口
+        authenticationInterceptorExceptionList.add("/wechat");
+        //易班API接口
+        authenticationInterceptorExceptionList.add("/yiban");
+        //支付宝API接口
+        authenticationInterceptorExceptionList.add("/alipay");
+        return authenticationInterceptorExceptionList;
     }
 
     /**
@@ -113,6 +120,11 @@ public class ApplicationWebMvcConfig extends WebMvcConfigurerAdapter {
         return new LoginInterceptor(loginInterceptorExceptionList());
     }
 
+    @Bean
+    public AuthenticationInterceptor authenticationInterceptor() {
+        return new AuthenticationInterceptor(authenticationInterceptorExceptionList());
+    }
+
     /**
      * 添加拦截器
      *
@@ -121,6 +133,7 @@ public class ApplicationWebMvcConfig extends WebMvcConfigurerAdapter {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor());
+        registry.addInterceptor(authenticationInterceptor());
     }
 
     /**

--- a/src/main/java/edu/gdei/gdeiassistant/Config/ApplicationWebMvcConfig.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Config/ApplicationWebMvcConfig.java
@@ -78,9 +78,29 @@ public class ApplicationWebMvcConfig extends WebMvcConfigurerAdapter {
      */
     @Bean
     public List<String> loginInterceptorExceptionList() {
-        List<String> loginInterceptorExceptionList = new ArrayList<>(authenticationInterceptorExceptionList());
+        List<String> loginInterceptorExceptionList = new ArrayList<>();
+        //退出账号
+        loginInterceptorExceptionList.add("/logout");
+        //登录账号
+        loginInterceptorExceptionList.add("/login");
+        //用户登录接口
+        loginInterceptorExceptionList.add("/api/userlogin");
+        //下载接口
+        loginInterceptorExceptionList.add("/download");
+        //协议与政策
+        loginInterceptorExceptionList.add("/agreement");
+        loginInterceptorExceptionList.add("/policy");
+        loginInterceptorExceptionList.add("/license");
+        //软件说明
+        loginInterceptorExceptionList.add("/about");
         //Restful API
         loginInterceptorExceptionList.add("/rest");
+        //微信API接口
+        loginInterceptorExceptionList.add("/wechat");
+        //易班API接口
+        loginInterceptorExceptionList.add("/yiban");
+        //支付宝API接口
+        loginInterceptorExceptionList.add("/alipay");
         return loginInterceptorExceptionList;
     }
 
@@ -93,6 +113,9 @@ public class ApplicationWebMvcConfig extends WebMvcConfigurerAdapter {
         authenticationInterceptorExceptionList.add("/login");
         //用户登录接口
         authenticationInterceptorExceptionList.add("/api/userlogin");
+        //实名认证页面和接口
+        authenticationInterceptorExceptionList.add("/authentication");
+        authenticationInterceptorExceptionList.add("/api/authentication");
         //下载接口
         authenticationInterceptorExceptionList.add("/download");
         //协议与政策

--- a/src/main/java/edu/gdei/gdeiassistant/Config/ProfileOptionConfig.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Config/ProfileOptionConfig.java
@@ -1,5 +1,6 @@
 package edu.gdei.gdeiassistant.Config;
 
+import edu.gdei.gdeiassistant.Constant.OptionConstantUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,10 +18,9 @@ public class ProfileOptionConfig {
     @Bean
     public Map<Integer, String> genderMap() {
         Map<Integer, String> genderMap = new HashMap<>();
-        genderMap.put(0, "未选择");
-        genderMap.put(1, "男");
-        genderMap.put(2, "女");
-        genderMap.put(3, "自定义");
+        for (int i = 0; i < OptionConstantUtils.GENDER_OPTIONS.length; i++) {
+            genderMap.put(i, OptionConstantUtils.GENDER_OPTIONS[i]);
+        }
         return genderMap;
     }
 
@@ -32,15 +32,9 @@ public class ProfileOptionConfig {
     @Bean
     public Map<Integer, String> degreeMap() {
         Map<Integer, String> degreeMap = new HashMap<>();
-        degreeMap.put(0, "未选择");
-        degreeMap.put(1, "小学");
-        degreeMap.put(2, "初中");
-        degreeMap.put(3, "中专/职高/技校");
-        degreeMap.put(4, "高中");
-        degreeMap.put(5, "专科");
-        degreeMap.put(6, "本科");
-        degreeMap.put(7, "硕士");
-        degreeMap.put(8, "博士");
+        for (int i = 0; i < OptionConstantUtils.DEGREE_OPTIONS.length; i++) {
+            degreeMap.put(i, OptionConstantUtils.DEGREE_OPTIONS[i]);
+        }
         return degreeMap;
     }
 
@@ -52,23 +46,9 @@ public class ProfileOptionConfig {
     @Bean
     public Map<Integer, String> facultyMap() {
         Map<Integer, String> facultyMap = new HashMap<>();
-        facultyMap.put(0, "未选择");
-        facultyMap.put(1, "教育学院");
-        facultyMap.put(2, "政法系");
-        facultyMap.put(3, "中文系");
-        facultyMap.put(4, "数学系");
-        facultyMap.put(5, "外语系");
-        facultyMap.put(6, "物理与信息工程系");
-        facultyMap.put(7, "化学系");
-        facultyMap.put(8, "生物与食品工程学院");
-        facultyMap.put(9, "体育学院");
-        facultyMap.put(10, "美术学院");
-        facultyMap.put(11, "计算机科学系");
-        facultyMap.put(12, "音乐系");
-        facultyMap.put(13, "教师研修学院");
-        facultyMap.put(14, "成人教育学院");
-        facultyMap.put(15, "网络教育学院");
-        facultyMap.put(16, "马克思主义学院");
+        for (int i = 0; i < OptionConstantUtils.FACULTY_OPTIONS.length; i++) {
+            facultyMap.put(i, OptionConstantUtils.FACULTY_OPTIONS[i]);
+        }
         return facultyMap;
     }
 }

--- a/src/main/java/edu/gdei/gdeiassistant/Config/SettingOptionConfig.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Config/SettingOptionConfig.java
@@ -1,0 +1,31 @@
+package edu.gdei.gdeiassistant.Config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
+
+import javax.servlet.ServletContext;
+import java.util.Objects;
+
+@Configuration
+@PropertySource("classpath:/config/setting/setting.properties")
+public class SettingOptionConfig {
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ServletContext servletContext;
+
+    /**
+     * 检查是否启用强制实名认证
+     */
+    @Bean
+    public void CheckForceAuthentication() {
+        if (Integer.valueOf(Objects.requireNonNull(environment.getProperty("setting.authentication.force"))).equals(1)) {
+            servletContext.setAttribute("authentication.force", true);
+        }
+    }
+}

--- a/src/main/java/edu/gdei/gdeiassistant/Constant/ErrorConstantUtils.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Constant/ErrorConstantUtils.java
@@ -77,6 +77,9 @@ public class ErrorConstantUtils {
     //教务系统会话时间戳校验失败
     public static final int TIMESTAMP_INVALIDATED = 40108;
 
+    //实名认证未通过，禁止进行操作或访问资源
+    public static final int NOT_AUTHENTICATION = 40109;
+
     //自定义课程数量超过限制
     public static final int CUSTOM_SCHEDULE_OVER_LIMIT = 40301;
 

--- a/src/main/java/edu/gdei/gdeiassistant/Constant/OptionConstantUtils.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Constant/OptionConstantUtils.java
@@ -1,0 +1,13 @@
+package edu.gdei.gdeiassistant.Constant;
+
+public class OptionConstantUtils {
+
+    public static final String[] GENDER_OPTIONS = {"未选择", "男", "女", "自定义"};
+
+    public static final String[] DEGREE_OPTIONS = {"未选择", "小学", "初中", "中专/职高/技校", "高中"
+            , "专科", "本科", "硕士", "博士"};
+
+    public static final String[] FACULTY_OPTIONS = {"未选择", "教育学院", "政法系", "中文系", "数学系", "外语系"
+            , "物理与信息工程系", "化学系", "生物与食品工程学院", "体育学院", "美术学院", "计算机科学系", "音乐系"
+            , "教师研修学院", "成人教育学院", "网络教育学院", "马克思主义学院"};
+}

--- a/src/main/java/edu/gdei/gdeiassistant/Controller/Authenticate/Controller/AuthenticateController.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Controller/Authenticate/Controller/AuthenticateController.java
@@ -9,6 +9,16 @@ import org.springframework.web.servlet.ModelAndView;
 public class AuthenticateController {
 
     /**
+     * 进入强制实名认证提示页面
+     *
+     * @return
+     */
+    @RequestMapping(value = "/authentication/tip", method = RequestMethod.GET)
+    public ModelAndView ResolveAuthenticationTipPage() {
+        return new ModelAndView("Authenticate/tip");
+    }
+
+    /**
      * 进入实名认证页面
      *
      * @return

--- a/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
@@ -3,9 +3,9 @@ package edu.gdei.gdeiassistant.Interceptor;
 import com.google.gson.Gson;
 import edu.gdei.gdeiassistant.Constant.ErrorConstantUtils;
 import edu.gdei.gdeiassistant.Pojo.Entity.Authentication;
-import edu.gdei.gdeiassistant.Pojo.Entity.User;
 import edu.gdei.gdeiassistant.Pojo.Result.JsonResult;
 import edu.gdei.gdeiassistant.Service.Authenticate.AuthenticateDataService;
+import edu.gdei.gdeiassistant.Service.Token.LoginTokenService;
 import edu.gdei.gdeiassistant.Tools.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -19,6 +19,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     @Autowired
     private AuthenticateDataService authenticateDataService;
+
+    @Autowired
+    private LoginTokenService loginTokenService;
 
     private List<String> exceptionList;
 
@@ -41,9 +44,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
         String username = null;
         if (uri.startsWith("/rest")) {
-            User user = (User) request.getAttribute("user");
-            if (user != null) {
-                username = user.getUsername();
+            String token = request.getParameter("token");
+            if (StringUtils.isNotBlank(token)) {
+                username = loginTokenService.ParseToken(token).get("username").asString();
             }
         } else {
             username = (String) request.getSession().getAttribute("username");

--- a/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,81 @@
+package edu.gdei.gdeiassistant.Interceptor;
+
+import com.google.gson.Gson;
+import edu.gdei.gdeiassistant.Constant.ErrorConstantUtils;
+import edu.gdei.gdeiassistant.Pojo.Entity.Authentication;
+import edu.gdei.gdeiassistant.Pojo.Result.JsonResult;
+import edu.gdei.gdeiassistant.Service.Authenticate.AuthenticateDataService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    private AuthenticateDataService authenticateDataService;
+
+    private List<String> exceptionList;
+
+    public AuthenticationInterceptor() {
+
+    }
+
+    public AuthenticationInterceptor(List<String> exceptionList) {
+        this.exceptionList = exceptionList;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String username = (String) request.getSession().getAttribute("username");
+        String uri = request.getRequestURI();
+        //若用户访问的URL在例外列表中,则放行
+        for (String string : exceptionList) {
+            if (uri.startsWith(string) || uri.equals("/")) {
+                return true;
+            }
+        }
+        Authentication authentication = authenticateDataService.QueryAuthenticationData(username);
+        if (authentication != null) {
+            //已经通过实名认证
+            return true;
+        } else {
+            //未通过实名认证
+            if (request.getServletContext().getAttribute("authentication.force").equals(true)) {
+                //强制实名认证，跳转到实名认证提示页面或返回错误信息
+                if (uri.equals("/authentication/tip")) {
+                    return true;
+                }
+                //数据接口拒绝操作和访问资源，返回JSON提示信息
+                if (uri.startsWith("/api") || uri.startsWith("/rest")) {
+                    response.setContentType("application/json");
+                    response.setCharacterEncoding("UTF-8");
+                    response.getWriter().print(new Gson().toJson(new JsonResult(ErrorConstantUtils.NOT_AUTHENTICATION
+                            , false, "未完成实名认证，请首先使用广东二师助手网页版进行实名认证")));
+                    response.getWriter().flush();
+                    response.getWriter().close();
+                    return false;
+                }
+                //其他URL跳转到实名认证提示页面
+                response.sendRedirect(request.getContextPath() + "/authentication/tip");
+                return false;
+            }
+            //不启用强制实名认证，不进行拦截
+            return true;
+        }
+
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+
+    }
+}

--- a/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
@@ -3,8 +3,10 @@ package edu.gdei.gdeiassistant.Interceptor;
 import com.google.gson.Gson;
 import edu.gdei.gdeiassistant.Constant.ErrorConstantUtils;
 import edu.gdei.gdeiassistant.Pojo.Entity.Authentication;
+import edu.gdei.gdeiassistant.Pojo.Entity.User;
 import edu.gdei.gdeiassistant.Pojo.Result.JsonResult;
 import edu.gdei.gdeiassistant.Service.Authenticate.AuthenticateDataService;
+import edu.gdei.gdeiassistant.Tools.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
@@ -30,13 +32,24 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        String username = (String) request.getSession().getAttribute("username");
         String uri = request.getRequestURI();
         //若用户访问的URL在例外列表中,则放行
         for (String string : exceptionList) {
             if (uri.startsWith(string) || uri.equals("/")) {
                 return true;
             }
+        }
+        String username = null;
+        if (uri.startsWith("/rest")) {
+            User user = (User) request.getAttribute("user");
+            if (user != null) {
+                username = user.getUsername();
+            }
+        } else {
+            username = (String) request.getSession().getAttribute("username");
+        }
+        if (StringUtils.isBlank(username)) {
+            return true;
         }
         Authentication authentication = authenticateDataService.QueryAuthenticationData(username);
         if (authentication != null) {

--- a/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Interceptor/AuthenticationInterceptor.java
@@ -46,9 +46,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             //未通过实名认证
             if (request.getServletContext().getAttribute("authentication.force").equals(true)) {
                 //强制实名认证，跳转到实名认证提示页面或返回错误信息
-                if (uri.equals("/authentication/tip")) {
-                    return true;
-                }
                 //数据接口拒绝操作和访问资源，返回JSON提示信息
                 if (uri.startsWith("/api") || uri.startsWith("/rest")) {
                     response.setContentType("application/json");

--- a/src/main/java/edu/gdei/gdeiassistant/Repository/Mysql/GdeiAssistant/Mapper/User/UserMapper.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Repository/Mysql/GdeiAssistant/Mapper/User/UserMapper.java
@@ -36,7 +36,7 @@ public interface UserMapper {
     @ResultType(Integer.class)
     Integer selectUserCount() throws Exception;
 
-    @Insert("insert into user (username,password,state,user_group) values (#{username},#{password},1,1)")
+    @Insert("insert into user (username,password,state,user_group) values (#{username},#{password},1,2)")
     void insertUser(User user) throws Exception;
 
     @Update("update user set password=#{password},state=1 where username=#{username}")

--- a/src/main/java/edu/gdei/gdeiassistant/Service/UserData/UserDataService.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Service/UserData/UserDataService.java
@@ -307,7 +307,7 @@ public class UserDataService {
             }
 
             //生成JSON文件
-            userDataInputStreamMap.put("data", new ByteArrayInputStream(JSON.toJSONStringWithDateFormat(map, "yyyy-MM-dd HH:mm:ss")
+            userDataInputStreamMap.put("data.json", new ByteArrayInputStream(JSON.toJSONStringWithDateFormat(map, "yyyy-MM-dd HH:mm:ss")
                     .getBytes(StandardCharsets.UTF_8.displayName())));
 
             //生成UUID序列号

--- a/src/main/resources/config/setting/setting.properties
+++ b/src/main/resources/config/setting/setting.properties
@@ -1,0 +1,2 @@
+#设置是否强制启用实名认证
+setting.authentication.force=1

--- a/src/main/webapp/WEB-INF/view/About/index.jsp
+++ b/src/main/webapp/WEB-INF/view/About/index.jsp
@@ -96,7 +96,6 @@
                         <a class="dropdown-item" href="http://www.moe.gov.cn">教育部门户网</a>
                         <a class="dropdown-item" href="http://edu.gd.gov.cn">广东省教育厅</a>
                         <a class="dropdown-item" href="http://www.gzedu.gov.cn">广州市教育局</a>
-                        <a class="dropdown-item" href="http://www.cnki.net">中国知网平台</a>
                         <div class="dropdown-divider"></div>
                         <a class="dropdown-item" href="http://www.sysu.edu.cn">中山大学</a>
                         <a class="dropdown-item" href="https://www.jnu.edu.cn">暨南大学</a>

--- a/src/main/webapp/WEB-INF/view/Authenticate/authenticate.jsp
+++ b/src/main/webapp/WEB-INF/view/Authenticate/authenticate.jsp
@@ -91,6 +91,12 @@
         </div>
         <div class="weui-cell__ft"></div>
     </a>
+    <a class="weui-cell weui-cell_access" href="javascript:" onclick="authenticateByCustomerService()">
+        <div class="weui-cell__bd">
+            <p>联系客服进行认证</p>
+        </div>
+        <div class="weui-cell__ft"></div>
+    </a>
 </div>
 
 <div id="cameraPopup" class="weui-popup__container">

--- a/src/main/webapp/WEB-INF/view/Authenticate/tip.jsp
+++ b/src/main/webapp/WEB-INF/view/Authenticate/tip.jsp
@@ -1,0 +1,44 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>未完成实名认证</title>
+    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="black" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <!-- 如果使用双核浏览器，强制使用webkit来进行页面渲染 -->
+    <meta name="renderer" content="webkit"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=0">
+    <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/logo.png">
+    <link rel="shortcut icon" type="image/png" sizes="64x64" href="/img/favicon/logo.png">
+    <c:if test="${applicationScope.get('grayscale')}">
+        <link rel="stylesheet" href="/css/common/grayscale.css">
+    </c:if>
+</head>
+<body>
+
+<div class="weui-msg">
+    <div class="weui-msg__icon-area"><i class="weui-icon-warn weui-icon_msg"></i></div>
+    <div class="weui-msg__text-area">
+        <h2 class="weui-msg__title">未完成实名认证</h2>
+        <p class="weui-msg__desc">
+            根据《中华人民共和国网络安全法》第二十四条的规定要求，从2019年8月1日起，用户使用广东二师助手需要首先完成实名认证，完成实名认证后用户才可使用正常使用广东二师助手。</p>
+    </div>
+    <div class="weui-msg__opr-area">
+        <p class="weui-btn-area">
+            <a onclick="window.location.href='/authentication'" href="javascript:"
+               class="weui-btn weui-btn_primary">进入实名认证</a>
+        </p>
+        <p class="weui-btn-area">
+            <a onclick="window.location.href='/index'" href="javascript:"
+               class="weui-btn weui-btn_default">已完成实名认证</a>
+        </p>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/main/webapp/js/authenticate/authenticate.jsp
+++ b/src/main/webapp/js/authenticate/authenticate.jsp
@@ -148,10 +148,21 @@
         </c:choose>
     }
 
+    //其他证件类型，联系客服进行认证
+    function authenticateByCustomerService() {
+        $.alert({
+            text: '当前认证方式仅限于使用护照、回乡证、台胞证、军官证等非居民身份证的证件类型或其余认证方式不可用时进行认证，否则你的认证申请可能会遭到拒绝。请你注意，若你持有港澳台居民居住证，可以直接使用上传身份证照片认证的认证方式进行认证。',
+            title: '注意事项',
+            onOK: function () {
+                window.location.href = "mailto:support@gdeiassistant.cn";
+            }
+        });
+    }
+
     //弹出调用摄像头拍照的提示
     function showCameraTip() {
         $.alert({
-            text: '请使用摄像头拍摄身份证个人信息页，并上传供广东二师助手进行实名认证',
+            text: '请使用摄像头拍摄身份证个人信息页，并上传供广东二师助手进行实名认证。注意，该方式仅支持中华人民共和国第二代居民身份证和港澳台居民居住证',
             title: '申请访问摄像头权限',
             onOK: function () {
                 getVideoMedia();


### PR DESCRIPTION
## 下载用户数据

- 添加JSON数据文件的后缀名

## 实名认证

- 添加强制实名认证的配置选项
- 添加实名认证的提示页面、拦截器和错误码
- 添加联系客服进行认证的认证方式
- 修改部分实名认证的提示框信息

## 首页

- 友情链接移除中国知网平台项

## 数据层

- 调整插入用户记录的SQL语句，默认的用户组为学生用户

## 常量表

- 个人资料选项参数值写入常量表