### PR TITLE
注销成功后清空本地缓存，实名认证提示页面添加退出当前账号按钮，添加用户主题颜色设置功能，修改页面加载模式，退出账号菜单选项移动到个人中心

### DIFF
--- a/src/main/java/edu/gdei/gdeiassistant/Config/ThemeOptionConfig.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Config/ThemeOptionConfig.java
@@ -40,18 +40,6 @@ public class ThemeOptionConfig implements EnvironmentAware {
         }
     }
 
-    /**
-     * 设置主题颜色，默认主题为绿色
-     */
-    @Bean
-    public void SetUpThemeColor() {
-        if (Integer.valueOf(Objects.requireNonNull(environment.getProperty("theme.pink"))).equals(1)) {
-            servletContext.setAttribute("themecolor", "_pink");
-        } else if (Integer.valueOf(Objects.requireNonNull(environment.getProperty("theme.blue"))).equals(1)) {
-            servletContext.setAttribute("themecolor", "_blue");
-        }
-    }
-
     @Override
     public void setEnvironment(Environment environment) {
         this.environment = environment;

--- a/src/main/java/edu/gdei/gdeiassistant/Controller/Theme/ThemeController.java
+++ b/src/main/java/edu/gdei/gdeiassistant/Controller/Theme/ThemeController.java
@@ -1,0 +1,20 @@
+package edu.gdei.gdeiassistant.Controller.Theme;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+public class ThemeController {
+
+    /**
+     * 进入主题设置页面
+     *
+     * @return
+     */
+    @RequestMapping(value = "/theme", method = RequestMethod.GET)
+    public ModelAndView ResolveThemeSettingPage() {
+        return new ModelAndView("Theme/theme");
+    }
+}

--- a/src/main/resources/config/theme/theme.properties
+++ b/src/main/resources/config/theme/theme.properties
@@ -1,8 +1,4 @@
 #设置是否使用黑白网页
 theme.grayscale=0
-#设置是否使用粉色主题
-theme.pink=0
-#设置是否使用蓝色主题
-theme.blue=0
 #设置是否使用Pride主题
 theme.pride=0

--- a/src/main/webapp/WEB-INF/view/About/index.jsp
+++ b/src/main/webapp/WEB-INF/view/About/index.jsp
@@ -27,16 +27,25 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/about/about.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/common/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link rel="stylesheet" type="text/css" href="/css/about/about.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="text/javascript" src="/js/common/bootstrap.min.js"></script>
     <script type="text/javascript" src="/js/common/swiper.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/about/about.js?time=" + Date.now() + "'><\/script>");</script>
 </head>
 <body>
@@ -285,7 +294,9 @@
         <p>All rights reserved</p>
         <div class="beian_area">
             <p class="beian_p"><a class="beian" href="http://www.beian.miit.gov.cn">粤ICP备17087427号-1</a></p>
-            <p class="beian_p"><a class="beian" href="http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=44010502001297">粤公网安备44010502001297号</a></p>
+            <p class="beian_p"><a class="beian"
+                                  href="http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=44010502001297">粤公网安备44010502001297号</a>
+            </p>
         </div>
     </div>
 

--- a/src/main/webapp/WEB-INF/view/Account/closeAccount.jsp
+++ b/src/main/webapp/WEB-INF/view/Account/closeAccount.jsp
@@ -11,13 +11,20 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/account/close.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Account/graduatedAccount.jsp
+++ b/src/main/webapp/WEB-INF/view/Account/graduatedAccount.jsp
@@ -11,13 +11,22 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <jsp:include page="/js/account/graduation.jsp"/>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Authenticate/authenticate.jsp
+++ b/src/main/webapp/WEB-INF/view/Authenticate/authenticate.jsp
@@ -11,13 +11,22 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <jsp:include page="/js/authenticate/authenticate.jsp"/>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Authenticate/tip.jsp
+++ b/src/main/webapp/WEB-INF/view/Authenticate/tip.jsp
@@ -2,9 +2,11 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <html>
 <head>
-    <title>未完成实名认证</title>
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
     <meta charset="UTF-8">
+    <title>未完成实名认证</title>
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="black" name="apple-mobile-web-app-status-bar-style">
@@ -18,6 +20,16 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
+    <script>
+
+        //消除iOS点击延迟
+        $(function () {
+            FastClick.attach(document.body);
+        });
+
+    </script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Authenticate/tip.jsp
+++ b/src/main/webapp/WEB-INF/view/Authenticate/tip.jsp
@@ -37,6 +37,10 @@
             <a onclick="window.location.href='/index'" href="javascript:"
                class="weui-btn weui-btn_default">已完成实名认证</a>
         </p>
+        <p class="weui-btn-area">
+            <a onclick="localStorage.clear();window.location.href='/logout'" href="javascript:"
+               class="weui-btn weui-btn_default">退出当前账号</a>
+        </p>
     </div>
 </div>
 

--- a/src/main/webapp/WEB-INF/view/Book/book.jsp
+++ b/src/main/webapp/WEB-INF/view/Book/book.jsp
@@ -18,14 +18,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
 
         let list = [];

--- a/src/main/webapp/WEB-INF/view/Book/collection.jsp
+++ b/src/main/webapp/WEB-INF/view/Book/collection.jsp
@@ -22,12 +22,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript" src="/js/book/collection.js"></script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Book/collectionDetail.jsp
+++ b/src/main/webapp/WEB-INF/view/Book/collectionDetail.jsp
@@ -21,10 +21,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
+
     <script>
         //消除iOS点击延迟
         $(function () {

--- a/src/main/webapp/WEB-INF/view/Card/card.jsp
+++ b/src/main/webapp/WEB-INF/view/Card/card.jsp
@@ -8,10 +8,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/logo.png">
     <link rel="shortcut icon" type="image/png" sizes="64x64" href="/img/favicon/logo.png">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
@@ -19,6 +27,7 @@
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/card/card.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Card/cardInfo.jsp
+++ b/src/main/webapp/WEB-INF/view/Card/cardInfo.jsp
@@ -8,10 +8,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/logo.png">
     <link rel="shortcut icon" type="image/png" sizes="64x64" href="/img/favicon/logo.png">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
@@ -19,6 +27,7 @@
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/card/cardInfo.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Card/cardLost.jsp
+++ b/src/main/webapp/WEB-INF/view/Card/cardLost.jsp
@@ -8,10 +8,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/logo.png">
     <link rel="shortcut icon" type="image/png" sizes="64x64" href="/img/favicon/logo.png">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
@@ -19,6 +27,7 @@
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/card/cardLost.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Cet/cet.jsp
+++ b/src/main/webapp/WEB-INF/view/Cet/cet.jsp
@@ -17,12 +17,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/cet/cet.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Cet/cetSave.jsp
+++ b/src/main/webapp/WEB-INF/view/Cet/cetSave.jsp
@@ -16,14 +16,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/cet/cetSave.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Data/electricityFees.jsp
+++ b/src/main/webapp/WEB-INF/view/Data/electricityFees.jsp
@@ -18,12 +18,22 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="application/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/data/electricityFees.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Data/index.jsp
+++ b/src/main/webapp/WEB-INF/view/Data/index.jsp
@@ -18,10 +18,21 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
+    <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
         //消除iOS点击延迟
         $(function () {

--- a/src/main/webapp/WEB-INF/view/Data/yellowPage.jsp
+++ b/src/main/webapp/WEB-INF/view/Data/yellowPage.jsp
@@ -18,14 +18,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="text/javascript" src="/js/common/yiban.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <jsp:include page="/js/data/yellowPage.jsp"/>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Dating/datingDetail.jsp
+++ b/src/main/webapp/WEB-INF/view/Dating/datingDetail.jsp
@@ -18,13 +18,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" href="/css/dating/global.css">
     <link rel="stylesheet" href="/css/dating/layout.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
 
         //消除iOS点击延迟

--- a/src/main/webapp/WEB-INF/view/Dating/datingIndex.jsp
+++ b/src/main/webapp/WEB-INF/view/Dating/datingIndex.jsp
@@ -18,13 +18,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" href="/css/dating/global.css">
     <link rel="stylesheet" href="/css/dating/layout.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
 
         var female_index = 0;

--- a/src/main/webapp/WEB-INF/view/Dating/datingMessage.jsp
+++ b/src/main/webapp/WEB-INF/view/Dating/datingMessage.jsp
@@ -18,13 +18,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" href="/css/dating/global.css">
     <link rel="stylesheet" href="/css/dating/layout.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
 
         var messageIndex = 0;

--- a/src/main/webapp/WEB-INF/view/Dating/datingPick.jsp
+++ b/src/main/webapp/WEB-INF/view/Dating/datingPick.jsp
@@ -18,13 +18,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" href="/css/dating/global.css">
     <link rel="stylesheet" href="/css/dating/layout.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
 
         //消除iOS点击延迟

--- a/src/main/webapp/WEB-INF/view/Dating/datingPublish.jsp
+++ b/src/main/webapp/WEB-INF/view/Dating/datingPublish.jsp
@@ -18,13 +18,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" href="/css/dating/global.css">
     <link rel="stylesheet" href="/css/dating/layout.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
 
         var imageBase64;

--- a/src/main/webapp/WEB-INF/view/Delivery/accept.jsp
+++ b/src/main/webapp/WEB-INF/view/Delivery/accept.jsp
@@ -17,14 +17,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/delivery/delivery.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
         $(function () {
             loadDeliveryOrder();

--- a/src/main/webapp/WEB-INF/view/Delivery/index.jsp
+++ b/src/main/webapp/WEB-INF/view/Delivery/index.jsp
@@ -17,15 +17,26 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/index/index${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/index/index.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/index/index_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/index/index_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/delivery/delivery.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <style>
         .avatar {
             width: 100%;

--- a/src/main/webapp/WEB-INF/view/Delivery/order.jsp
+++ b/src/main/webapp/WEB-INF/view/Delivery/order.jsp
@@ -17,14 +17,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/delivery/delivery.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <style>
         .weui_cells {
             margin-top: 0;

--- a/src/main/webapp/WEB-INF/view/Delivery/orderDetail.jsp
+++ b/src/main/webapp/WEB-INF/view/Delivery/orderDetail.jsp
@@ -18,14 +18,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/delivery/delivery.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Delivery/personal.jsp
+++ b/src/main/webapp/WEB-INF/view/Delivery/personal.jsp
@@ -18,15 +18,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
-    <script>document.write("<script type='text/javascript' src='/js/delivery/delivery.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
-
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
+    <script>document.write("<script type='text/javascript' src='/js/delivery/delivery.js?time=" + Date.now() + "'><\/script>");</script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Delivery/tradeDetail.jsp
+++ b/src/main/webapp/WEB-INF/view/Delivery/tradeDetail.jsp
@@ -18,14 +18,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/delivery/delivery.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Error/badRequestError.jsp
+++ b/src/main/webapp/WEB-INF/view/Error/badRequestError.jsp
@@ -3,8 +3,10 @@
 <html>
 <head>
     <title>400 Bad Request</title>
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
     <meta charset="UTF-8">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="black" name="apple-mobile-web-app-status-bar-style">
@@ -18,10 +20,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
+
+        //消除iOS点击延迟
+        $(function () {
+            FastClick.attach(document.body);
+        });
+
         function backToIndex() {
             window.location.href = "/index";
         }
+
     </script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Error/commonError.jsp
+++ b/src/main/webapp/WEB-INF/view/Error/commonError.jsp
@@ -2,9 +2,11 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <html>
 <head>
-    <title>${ErrorTitle}</title>
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
     <meta charset="UTF-8">
+    <title>${ErrorTitle}</title>
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="black" name="apple-mobile-web-app-status-bar-style">
@@ -18,6 +20,14 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
+    <script>
+        //消除iOS点击延迟
+        $(function () {
+            FastClick.attach(document.body);
+        });
+    </script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Error/methodNotAllowError.jsp
+++ b/src/main/webapp/WEB-INF/view/Error/methodNotAllowError.jsp
@@ -2,9 +2,11 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <html>
 <head>
-    <title>405 Method Not Allow</title>
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
     <meta charset="UTF-8">
+    <title>405 Method Not Allow</title>
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="black" name="apple-mobile-web-app-status-bar-style">
@@ -18,10 +20,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
+
+        //消除iOS点击延迟
+        $(function () {
+            FastClick.attach(document.body);
+        });
+
         function backToIndex() {
             window.location.href = "/index";
         }
+
     </script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Error/notFoundError.jsp
+++ b/src/main/webapp/WEB-INF/view/Error/notFoundError.jsp
@@ -3,7 +3,9 @@
 <html>
 <head>
     <title>404 Not Found</title>
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
@@ -18,7 +20,15 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
     <script>
+
+        //消除iOS点击延迟
+        $(function () {
+            FastClick.attach(document.body);
+        });
+
         function backToIndex() {
             window.location.href = "/index";
         }

--- a/src/main/webapp/WEB-INF/view/Error/serverError.jsp
+++ b/src/main/webapp/WEB-INF/view/Error/serverError.jsp
@@ -2,9 +2,11 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <html>
 <head>
-    <title>500 Internal Server Error</title>
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
     <meta charset="UTF-8">
+    <title>500 Internal Server Error</title>
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="black" name="apple-mobile-web-app-status-bar-style">
@@ -18,10 +20,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
+
+        //消除iOS点击延迟
+        $(function () {
+            FastClick.attach(document.body);
+        });
+
         function backToIndex() {
             window.location.href = "/index";
         }
+
     </script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Ershou/ershouEdit.jsp
+++ b/src/main/webapp/WEB-INF/view/Ershou/ershouEdit.jsp
@@ -13,13 +13,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/ershou/ershou-base.css">
     <title>广东第二师范学院二手交易</title>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟

--- a/src/main/webapp/WEB-INF/view/Ershou/ershouIndex.jsp
+++ b/src/main/webapp/WEB-INF/view/Ershou/ershouIndex.jsp
@@ -13,14 +13,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/ershou/ershou-base.css">
     <link rel="stylesheet" type="text/css" href="/css/ershou/ershou-nav.css">
     <title>广东第二师范学院二手交易</title>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
-    <script type="text/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟

--- a/src/main/webapp/WEB-INF/view/Ershou/ershouPersonal.jsp
+++ b/src/main/webapp/WEB-INF/view/Ershou/ershouPersonal.jsp
@@ -14,14 +14,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/ershou/ershou-base.css">
     <link rel="stylesheet" type="text/css" href="/css/ershou/ershou-nav.css">
     <title>广东第二师范学院二手交易</title>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟
@@ -89,8 +94,7 @@
                 success: function (result) {
                     if (result.success === true) {
                         $("#kickname").text(result.data.kickname);
-                    }
-                    else {
+                    } else {
                         showErrorTip(result.message);
                     }
                 },
@@ -105,12 +109,10 @@
                     if (result.success === true) {
                         if (result.data === '') {
                             $("#introduction").text('这个人很懒，什么都没写_(:3 」∠)_');
-                        }
-                        else {
+                        } else {
                             $("#introduction").text(result.data);
                         }
-                    }
-                    else {
+                    } else {
                         showErrorTip(result.message);
                     }
                 },
@@ -136,8 +138,7 @@
                 success: function (result) {
                     if (result.success === true) {
                         window.location.reload();
-                    }
-                    else {
+                    } else {
                         showErrorTip(result.message);
                     }
                 },
@@ -158,8 +159,7 @@
                 success: function (result) {
                     if (result.success === true) {
                         window.location.reload();
-                    }
-                    else {
+                    } else {
                         showErrorTip(result.message);
                     }
                 },
@@ -189,8 +189,7 @@
                             success: function (result) {
                                 if (result.success === true) {
                                     window.location.reload();
-                                }
-                                else {
+                                } else {
                                     showErrorTip(result.message);
                                 }
                             },
@@ -246,7 +245,8 @@
                             </i>
                             <h5 class="tit">${ErshouItem.name}</h5>
                             <em class="price">￥${ErshouItem.price}</em>
-                            <p class="tm"><fmt:formatDate value="${ErshouItem.publishTime}" pattern="yyyy-MM-dd HH:mm:ss"/></p>
+                            <p class="tm"><fmt:formatDate value="${ErshouItem.publishTime}"
+                                                          pattern="yyyy-MM-dd HH:mm:ss"/></p>
                         </div>
                         <p class="btns">
                             <a class="btn" href="/ershou/edit/id/${ErshouItem.id}"><b>编辑</b></a>
@@ -281,7 +281,8 @@
                             </i>
                             <h5 class="tit">${ErshouItem.name}</h5>
                             <em class="price">￥${ErshouItem.price}</em>
-                            <p class="tm"><fmt:formatDate value="${ErshouItem.publishTime}" pattern="yyyy-MM-dd HH:mm:ss"/></p>
+                            <p class="tm"><fmt:formatDate value="${ErshouItem.publishTime}"
+                                                          pattern="yyyy-MM-dd HH:mm:ss"/></p>
                         </div>
                         <p class="btns">
                             <a class="btn" href="/ershou/edit/id/${ErshouItem.id}"><b>编辑</b></a>
@@ -314,7 +315,8 @@
                             </i>
                             <h5 class="tit">${ErshouItem.name}</h5>
                             <em class="price">￥${ErshouItem.price}</em>
-                            <p class="tm"><fmt:formatDate value="${ErshouItem.publishTime}" pattern="yyyy-MM-dd HH:mm:ss"/></p>
+                            <p class="tm"><fmt:formatDate value="${ErshouItem.publishTime}"
+                                                          pattern="yyyy-MM-dd HH:mm:ss"/></p>
                         </div>
                     </div>
                     <script>

--- a/src/main/webapp/WEB-INF/view/Ershou/ershouPublish.jsp
+++ b/src/main/webapp/WEB-INF/view/Ershou/ershouPublish.jsp
@@ -12,13 +12,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/ershou/ershou-base.css">
     <title>广东第二师范学院二手交易</title>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟
@@ -100,26 +105,19 @@
                     //检查输入内容合法性
                     if ($("#name").val().length > 25) {
                         showErrorTip("商品名称长度不合法");
-                    }
-                    else if ($("#description").val().length > 100) {
+                    } else if ($("#description").val().length > 100) {
                         showErrorTip("商品描述长度不合法");
-                    }
-                    else if (parseFloat($("#price").val()) <= 0 || parseFloat($("#price").val() > 9999.99)) {
+                    } else if (parseFloat($("#price").val()) <= 0 || parseFloat($("#price").val() > 9999.99)) {
                         showErrorTip("交易金额价格范围不合法");
-                    }
-                    else if ($("#location").val().length > 30) {
+                    } else if ($("#location").val().length > 30) {
                         showErrorTip("交易地点长度不合法");
-                    }
-                    else if (parseInt($("#type").val()) < 0 || parseInt($("#type").val()) > 11) {
+                    } else if (parseInt($("#type").val()) < 0 || parseInt($("#type").val()) > 11) {
                         showErrorTip("不合法的商品分类")
-                    }
-                    else if ($("#qq").length > 20) {
+                    } else if ($("#qq").length > 20) {
                         showErrorTip("不合法的QQ号码");
-                    }
-                    else if ($("#phone").length > 11) {
+                    } else if ($("#phone").length > 11) {
                         showErrorTip("不合法的手机号码");
-                    }
-                    else {
+                    } else {
 
                         if (available) {
 
@@ -170,8 +168,7 @@
                                 success: function (result) {
                                     if (result.success === true) {
                                         window.location.href = '/ershou';
-                                    }
-                                    else {
+                                    } else {
                                         $(".submit").attr("disabled", false);
                                         loading.hide();
                                         showErrorTip(result.message);
@@ -247,8 +244,7 @@
 
                 if ($(".upimg").length >= 4) {
                     showErrorTip("最多只能选择四张图片！");
-                }
-                else {
+                } else {
 
                     reader.readAsDataURL(file);
 

--- a/src/main/webapp/WEB-INF/view/Evaluate/evaluate.jsp
+++ b/src/main/webapp/WEB-INF/view/Evaluate/evaluate.jsp
@@ -18,13 +18,20 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/evaluate/evaluate.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Function/function.jsp
+++ b/src/main/webapp/WEB-INF/view/Function/function.jsp
@@ -104,8 +104,4 @@
         <i style="background: url(/img/function/about.png) ; background-repeat: no-repeat; background-position: center; background-size: 85% auto"></i>
         <p>关于应用</p>
     </div>
-    <div id="exit" onclick="showLogoutConfirm()">
-        <i style="background: url(/img/function/exit.png) ; background-repeat: no-repeat; background-position: center; background-size: 85% auto"></i>
-        <p>安全退出</p>
-    </div>
 </div>

--- a/src/main/webapp/WEB-INF/view/Function/manage.jsp
+++ b/src/main/webapp/WEB-INF/view/Function/manage.jsp
@@ -10,13 +10,22 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <jsp:include page="/js/function/manage.jsp"/>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Grade/grade.jsp
+++ b/src/main/webapp/WEB-INF/view/Grade/grade.jsp
@@ -17,14 +17,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/grade/grade${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/grade/grade.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/grade/grade_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/grade/grade_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/grade/grade.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Index/index.jsp
+++ b/src/main/webapp/WEB-INF/view/Index/index.jsp
@@ -11,17 +11,28 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/index/index${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/index/index.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/index/index_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/index/index_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="text/javascript" src="/js/common/cropper.min.js"></script>
     <script type="text/javascript" src="/js/common/exif.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/KaoYan/kaoyan.jsp
+++ b/src/main/webapp/WEB-INF/view/KaoYan/kaoyan.jsp
@@ -17,12 +17,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/kaoyan/kaoyan.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Login/login.jsp
+++ b/src/main/webapp/WEB-INF/view/Login/login.jsp
@@ -20,11 +20,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟

--- a/src/main/webapp/WEB-INF/view/LostAndFound/edit.jsp
+++ b/src/main/webapp/WEB-INF/view/LostAndFound/edit.jsp
@@ -13,14 +13,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/ershou/ershou-base.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/publish.css">
     <title>广东第二师范学院失物招领</title>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟
@@ -82,32 +87,23 @@
                     //检查输入内容合法性
                     if (parseInt($("input[name='lostType']:checked").val()) < 0 || parseInt($("input[name='lostType']:checked").val()) > 1) {
                         showErrorTip("不合法的寻找类型");
-                    }
-                    else if ($("#name").val() == '' && $("#name").val().length > 25) {
+                    } else if ($("#name").val() == '' && $("#name").val().length > 25) {
                         showErrorTip("物品名称长度不合法");
-                    }
-                    else if ($("#description").val() == '' && $("#description").val().length > 100) {
+                    } else if ($("#description").val() == '' && $("#description").val().length > 100) {
                         showErrorTip("物品描述长度不合法");
-                    }
-                    else if ($("#location").val() == '' && $("#location").val().length > 30) {
+                    } else if ($("#location").val() == '' && $("#location").val().length > 30) {
                         showErrorTip("地点长度不合法");
-                    }
-                    else if (parseInt($("#itemType").val()) < 0 || parseInt($("#itemType").val()) > 11) {
+                    } else if (parseInt($("#itemType").val()) < 0 || parseInt($("#itemType").val()) > 11) {
                         showErrorTip("不合法的物品分类")
-                    }
-                    else if ($("#qq").val() == '' && $("#wechat").val() == '' && $("#phone").val() == '') {
+                    } else if ($("#qq").val() == '' && $("#wechat").val() == '' && $("#phone").val() == '') {
                         showErrorTip("联系方式至少需要填写一项");
-                    }
-                    else if ($("#qq").val().length > 20) {
+                    } else if ($("#qq").val().length > 20) {
                         showErrorTip("不合法的QQ号码");
-                    }
-                    else if ($("#wechat").val().length > 20) {
+                    } else if ($("#wechat").val().length > 20) {
                         showErrorTip("不合法的微信号");
-                    }
-                    else if ($("#phone").val().length > 11) {
+                    } else if ($("#phone").val().length > 11) {
                         showErrorTip("不合法的手机号码");
-                    }
-                    else {
+                    } else {
 
                         var formData = new FormData();
 
@@ -143,12 +139,10 @@
                                 if (result.success === true) {
                                     if (parseInt($("#lostType").val()) == 0) {
                                         window.location.href = '/lostandfound/lost';
-                                    }
-                                    else {
+                                    } else {
                                         window.location.href = '/lostandfound/found';
                                     }
-                                }
-                                else {
+                                } else {
                                     $(".submit").attr("disabled", false);
                                     loading.hide();
                                     showErrorTip(result.message);

--- a/src/main/webapp/WEB-INF/view/LostAndFound/foundIndex.jsp
+++ b/src/main/webapp/WEB-INF/view/LostAndFound/foundIndex.jsp
@@ -13,14 +13,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/base.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/nav.css">
     <title>广东第二师范学院失物招领</title>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
-    <script type="text/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript" src="/js/lostandfound/found.js"></script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/LostAndFound/lostIndex.jsp
+++ b/src/main/webapp/WEB-INF/view/LostAndFound/lostIndex.jsp
@@ -13,15 +13,20 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/base.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/nav.css">
     <title>广东第二师范学院失物招领</title>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
-    <script type="text/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript" src="/js/lostandfound/lost.js"></script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/LostAndFound/personal.jsp
+++ b/src/main/webapp/WEB-INF/view/LostAndFound/personal.jsp
@@ -13,14 +13,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/base.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/nav.css">
     <title>广东第二师范学院失物招领</title>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟
@@ -88,8 +93,7 @@
                 success: function (result) {
                     if (result.success === true) {
                         $("#kickname").text(result.data.kickname);
-                    }
-                    else {
+                    } else {
                         showErrorTip(result.message);
                     }
                 },
@@ -104,12 +108,10 @@
                     if (result.success === true) {
                         if (result.data === '') {
                             $("#introduction").text('这个人很懒，什么都没写_(:3 」∠)_');
-                        }
-                        else {
+                        } else {
                             $("#introduction").text(result.data);
                         }
-                    }
-                    else {
+                    } else {
                         showErrorTip(result.message);
                     }
                 },
@@ -154,8 +156,7 @@
                             success: function (result) {
                                 if (result.success === true) {
                                     window.location.reload();
-                                }
-                                else {
+                                } else {
                                     showErrorTip(result.message);
                                 }
                             },

--- a/src/main/webapp/WEB-INF/view/LostAndFound/publish.jsp
+++ b/src/main/webapp/WEB-INF/view/LostAndFound/publish.jsp
@@ -13,13 +13,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/publish.css">
     <title>广东第二师范学院失物招领</title>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript">
 
         //消除iOS点击延迟

--- a/src/main/webapp/WEB-INF/view/LostAndFound/search.jsp
+++ b/src/main/webapp/WEB-INF/view/LostAndFound/search.jsp
@@ -14,13 +14,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" type="text/css" href="/css/lostandfound/search.css">
     <script type="text/javascript" src="/js/lostandfound/search.js"></script>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/News/newDetail.jsp
+++ b/src/main/webapp/WEB-INF/view/News/newDetail.jsp
@@ -10,11 +10,21 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript" src="/js/common/yiban.js"></script>
     <jsp:include page="/js/news/newDetail.jsp"/>
 </head>

--- a/src/main/webapp/WEB-INF/view/News/news.jsp
+++ b/src/main/webapp/WEB-INF/view/News/news.jsp
@@ -10,11 +10,21 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript" src="/js/news/news.js"></script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Profile/introduction.jsp
+++ b/src/main/webapp/WEB-INF/view/Profile/introduction.jsp
@@ -11,14 +11,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript" src="/js/profile/introduction.js"></script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/Profile/privacy.jsp
+++ b/src/main/webapp/WEB-INF/view/Profile/privacy.jsp
@@ -10,15 +10,24 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/profile/privacy.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Profile/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/Profile/profile.jsp
@@ -142,6 +142,15 @@
             <span id="functionBadge" class="weui-badge" style="display:none;margin-left: 5px;">New</span>
         </div>
     </a>
+    <a class="weui-cell weui-cell_access" href="javascript:"
+       onclick="window.location.href = '/theme'">
+        <div class="weui-cell__bd">
+            <p>主题设置</p>
+        </div>
+        <div class="weui-cell__ft">
+            <span id="themeBadge" class="weui-badge" style="display:none;margin-left: 5px;">New</span>
+        </div>
+    </a>
 </div>
 
 <div class="weui-cells">
@@ -180,12 +189,20 @@
         <div class="weui-cell__ft">
         </div>
     </a>
-</div>
-
-<div class="weui-cells">
     <a class="weui-cell weui-cell_access" href="javascript:" onclick="exportUserData()">
         <div class="weui-cell__bd">
             <p>下载用户数据</p>
+        </div>
+        <div class="weui-cell__ft">
+        </div>
+    </a>
+</div>
+
+<div class="weui-cells">
+    <a class="weui-cell weui-cell_access" href="javascript:"
+       onclick="showLogoutConfirm()">
+        <div class="weui-cell__bd">
+            <p>退出账号</p>
         </div>
         <div class="weui-cell__ft">
         </div>

--- a/src/main/webapp/WEB-INF/view/Profile/publicProfile.jsp
+++ b/src/main/webapp/WEB-INF/view/Profile/publicProfile.jsp
@@ -13,11 +13,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
         //消除iOS点击延迟
         $(function () {

--- a/src/main/webapp/WEB-INF/view/Reading/reading.jsp
+++ b/src/main/webapp/WEB-INF/view/Reading/reading.jsp
@@ -10,15 +10,24 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/reading/reading.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Schedule/schedule.jsp
+++ b/src/main/webapp/WEB-INF/view/Schedule/schedule.jsp
@@ -14,19 +14,30 @@
     <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=0">
     <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/logo.png">
     <link rel="shortcut icon" type="image/png" sizes="64x64" href="/img/favicon/logo.png">
-    <script>document.write("<link rel='stylesheet' href='/css/schedule/schedule${themecolor}.css?time=" + Date.now() + "'><\/>");</script>
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/schedule/schedule.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/schedule/schedule_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/schedule/schedule_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/schedule/schedule.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Secret/secretDetail.jsp
+++ b/src/main/webapp/WEB-INF/view/Secret/secretDetail.jsp
@@ -12,9 +12,12 @@
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
     <link rel="stylesheet" href="/css/secret/secret-detail.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
 
         let audio = document.createElement("AUDIO");

--- a/src/main/webapp/WEB-INF/view/Secret/secretIndex.jsp
+++ b/src/main/webapp/WEB-INF/view/Secret/secretIndex.jsp
@@ -11,10 +11,13 @@
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
     <link rel="stylesheet" href="/css/secret/secret-index.css">
-    <link rel="stylesheet" type="text/css" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script>
         //消除iOS点击延迟
         $(function () {

--- a/src/main/webapp/WEB-INF/view/Secret/secretPublish.jsp
+++ b/src/main/webapp/WEB-INF/view/Secret/secretPublish.jsp
@@ -10,12 +10,17 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <link rel="stylesheet" href="/css/secret/secret-publish.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/weui.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="application/javascript" src="/js/common/recorder.mp3.min.js"></script>
     <script>
 

--- a/src/main/webapp/WEB-INF/view/Spare/spare.jsp
+++ b/src/main/webapp/WEB-INF/view/Spare/spare.jsp
@@ -11,14 +11,23 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/jquery-weui.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
     <script>document.write("<script type='text/javascript' src='/js/spare/spare.js?time=" + Date.now() + "'><\/script>");</script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/view/Theme/theme.jsp
+++ b/src/main/webapp/WEB-INF/view/Theme/theme.jsp
@@ -1,0 +1,73 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>主题设置</title>
+    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
+    <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/logo.png">
+    <link rel="shortcut icon" type="image/png" sizes="64x64" href="/img/favicon/logo.png">
+    <c:if test="${applicationScope.get('grayscale')}">
+        <link rel="stylesheet" href="/css/common/grayscale.css">
+    </c:if>
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
+    <link title="default" rel="stylesheet" href="/css/common/jquery-weui.min.css">
+    <link title="pink" rel="alternate stylesheet" href="/css/common/jquery-weui.min_pink.css">
+    <link title="blue" rel="alternate stylesheet" href="/css/common/jquery-weui.min_blue.css">
+    <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
+    <script type="text/javascript" src="/js/common/jquery-weui.min.js"></script>
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
+    <script>document.write("<script type='text/javascript' src='/js/theme/theme.js?time=" + Date.now() + "'><\/script>");</script>
+</head>
+<body>
+
+<div class="weui_cells_title" onclick="history.go(-1)">返回</div>
+
+<div class="hd">
+    <h1 class="page_title">主题配置</h1>
+</div>
+
+<div class="weui-cells__title">选择你的主题</div>
+<div class="weui-cells weui-cells_radio">
+    <label class="weui-cell weui-check__label" for="default">
+        <div class="weui-cell__bd">
+            <p>默认主题</p>
+        </div>
+        <div class="weui-cell__ft">
+            <input type="radio" class="weui-check" name="theme" id="default" checked="checked">
+            <span class="weui-icon-checked"></span>
+        </div>
+    </label>
+    <label class="weui-cell weui-check__label" for="pink">
+        <div class="weui-cell__bd">
+            <p>粉色主题</p>
+        </div>
+        <div class="weui-cell__ft">
+            <input type="radio" class="weui-check" name="theme" id="pink">
+            <span class="weui-icon-checked"></span>
+        </div>
+    </label>
+    <label class="weui-cell weui-check__label" for="blue">
+        <div class="weui-cell__bd">
+            <p>蓝色主题</p>
+        </div>
+        <div class="weui-cell__ft">
+            <input type="radio" class="weui-check" name="theme" id="blue">
+            <span class="weui-icon-checked"></span>
+        </div>
+    </label>
+</div>
+
+<br>
+
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/view/Wechat/wechatAttach.jsp
+++ b/src/main/webapp/WEB-INF/view/Wechat/wechatAttach.jsp
@@ -17,11 +17,18 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <script type="text/javascript" src="/js/wechat/attach.js"></script>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/YiBan/yibanAttach.jsp
+++ b/src/main/webapp/WEB-INF/view/YiBan/yibanAttach.jsp
@@ -18,12 +18,19 @@
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/common${themecolor}.css">
     <link rel="stylesheet" href="/css/login/login.css">
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <link rel="stylesheet" href="/css/common/weui-0.2.2.min${themecolor}.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/common.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/common_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/common_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-0.2.2.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-0.2.2.min_blue.css">
     <script type="text/javascript" src="/js/common/jquery-3.2.1.min.js"></script>
     <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
     <jsp:include page="/js/yiban/yibanAttach.jsp"/>
 </head>
 <body>

--- a/src/main/webapp/WEB-INF/view/YiBan/yibanError.jsp
+++ b/src/main/webapp/WEB-INF/view/YiBan/yibanError.jsp
@@ -3,14 +3,16 @@
 <%@ page isErrorPage="true" %>
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>登录失败</title>
     <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon/logo.png">
     <link rel="shortcut icon" type="image/png" sizes="64x64" href="/img/favicon/logo.png">
     <c:if test="${applicationScope.get('grayscale')}">
         <link rel="stylesheet" href="/css/common/grayscale.css">
     </c:if>
-    <link rel="stylesheet" href="/css/common/weui-1.1.1.min${themecolor}.css">
-    <meta charset="UTF-8">
+    <link title="default" type="text/css" rel="stylesheet" href="/css/common/weui-1.1.1.min.css">
+    <link title="pink" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_pink.css">
+    <link title="blue" type="text/css" rel="alternate stylesheet" href="/css/common/weui-1.1.1.min_blue.css">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="black" name="apple-mobile-web-app-status-bar-style">
@@ -19,6 +21,14 @@
     <!-- 如果使用双核浏览器，强制使用webkit来进行页面渲染 -->
     <meta name="renderer" content="webkit"/>
     <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=0">
+    <script type="application/javascript" src="/js/common/fastclick.js"></script>
+    <script type="application/javascript" src="/js/common/themeLoader.js"></script>
+    <script>
+        //消除iOS点击延迟
+        $(function () {
+            FastClick.attach(document.body);
+        });
+    </script>
 </head>
 <body>
 

--- a/src/main/webapp/css/about/about.css
+++ b/src/main/webapp/css/about/about.css
@@ -1,3 +1,7 @@
+body {
+    font-size: 0.65rem;
+}
+
 .download {
     width: 95%;
     max-width: 700px;

--- a/src/main/webapp/css/common/common.css
+++ b/src/main/webapp/css/common/common.css
@@ -1,3 +1,7 @@
+html {
+    visibility: hidden;
+}
+
 body, html {
     height: 100%;
     -webkit-tap-highlight-color: transparent

--- a/src/main/webapp/css/common/common_blue.css
+++ b/src/main/webapp/css/common/common_blue.css
@@ -1,3 +1,7 @@
+html {
+    visibility: hidden;
+}
+
 body, html {
     height: 100%;
     -webkit-tap-highlight-color: transparent

--- a/src/main/webapp/css/common/common_pink.css
+++ b/src/main/webapp/css/common/common_pink.css
@@ -1,3 +1,7 @@
+html {
+    visibility: hidden;
+}
+
 body, html {
     height: 100%;
     -webkit-tap-highlight-color: transparent

--- a/src/main/webapp/css/common/jquery-weui.min.css
+++ b/src/main/webapp/css/common/jquery-weui.min.css
@@ -3,6 +3,10 @@
 * By 言川
 * http://lihongxun945.github.io/jquery-weui/
  */
+html {
+    visibility: hidden;
+}
+
 .preloader {
     width: 20px;
     height: 20px;

--- a/src/main/webapp/css/common/jquery-weui.min_blue.css
+++ b/src/main/webapp/css/common/jquery-weui.min_blue.css
@@ -3,6 +3,10 @@
 * By 言川
 * http://lihongxun945.github.io/jquery-weui/
  */
+html {
+    visibility: hidden;
+}
+
 .preloader {
     width: 20px;
     height: 20px;

--- a/src/main/webapp/css/common/jquery-weui.min_pink.css
+++ b/src/main/webapp/css/common/jquery-weui.min_pink.css
@@ -3,6 +3,10 @@
 * By 言川
 * http://lihongxun945.github.io/jquery-weui/
  */
+html {
+    visibility: hidden;
+}
+
 .preloader {
     width: 20px;
     height: 20px;

--- a/src/main/webapp/css/common/weui-0.2.2.min.css
+++ b/src/main/webapp/css/common/weui-0.2.2.min.css
@@ -6,6 +6,7 @@
 html {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
+    visibility: hidden;
 }
 
 body {

--- a/src/main/webapp/css/common/weui-0.2.2.min_blue.css
+++ b/src/main/webapp/css/common/weui-0.2.2.min_blue.css
@@ -6,6 +6,7 @@
 html {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
+    visibility: hidden;
 }
 
 body {

--- a/src/main/webapp/css/common/weui-0.2.2.min_pink.css
+++ b/src/main/webapp/css/common/weui-0.2.2.min_pink.css
@@ -6,6 +6,7 @@
 html {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
+    visibility: hidden;
 }
 
 body {

--- a/src/main/webapp/css/common/weui-1.1.1.min.css
+++ b/src/main/webapp/css/common/weui-1.1.1.min.css
@@ -5,7 +5,8 @@
  */
 html {
     -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%
+    -webkit-text-size-adjust: 100%;
+    visibility: hidden;
 }
 
 body {

--- a/src/main/webapp/css/common/weui-1.1.1.min_blue.css
+++ b/src/main/webapp/css/common/weui-1.1.1.min_blue.css
@@ -5,7 +5,8 @@
  */
 html {
     -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%
+    -webkit-text-size-adjust: 100%;
+    visibility: hidden;
 }
 
 body {

--- a/src/main/webapp/css/common/weui-1.1.1.min_pink.css
+++ b/src/main/webapp/css/common/weui-1.1.1.min_pink.css
@@ -5,7 +5,8 @@
  */
 html {
     -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%
+    -webkit-text-size-adjust: 100%;
+    visibility: hidden;
 }
 
 body {

--- a/src/main/webapp/css/grade/grade.css
+++ b/src/main/webapp/css/grade/grade.css
@@ -7,6 +7,10 @@
     font-family: "SimHei" arial helvetica;
 }
 
+html {
+    visibility: hidden;
+}
+
 html:root {
     color: #222;
 }

--- a/src/main/webapp/css/grade/grade_blue.css
+++ b/src/main/webapp/css/grade/grade_blue.css
@@ -7,6 +7,10 @@
     font-family: "SimHei" arial helvetica;
 }
 
+html {
+    visibility: hidden;
+}
+
 html:root {
     color: #222;
 }

--- a/src/main/webapp/css/grade/grade_pink.css
+++ b/src/main/webapp/css/grade/grade_pink.css
@@ -7,6 +7,10 @@
     font-family: "SimHei" arial helvetica;
 }
 
+html {
+    visibility: hidden;
+}
+
 html:root {
     color: #222;
 }

--- a/src/main/webapp/css/index/index.css
+++ b/src/main/webapp/css/index/index.css
@@ -3,6 +3,10 @@
     padding: 0;
 }
 
+html {
+    visibility: hidden;
+}
+
 body {
     background: #FBF9FE;
     max-width: 480px;

--- a/src/main/webapp/css/index/index_blue.css
+++ b/src/main/webapp/css/index/index_blue.css
@@ -3,6 +3,10 @@
     padding: 0;
 }
 
+html {
+    visibility: hidden;
+}
+
 body {
     background: #FBF9FE;
     max-width: 480px;
@@ -29,7 +33,7 @@ body {
     color: #838383;
     text-align: center;
     margin: .5rem auto 1.5rem;
-    font-size: 1rem;
+    font-size: 0.7rem;
     font-weight: normal;
 }
 
@@ -91,7 +95,7 @@ body {
     color: #838383;
     text-align: center;
     margin: .5rem auto 1.5rem;
-    font-size: 1rem;
+    font-size: 0.7rem;
     font-weight: normal;
 }
 

--- a/src/main/webapp/css/index/index_pink.css
+++ b/src/main/webapp/css/index/index_pink.css
@@ -3,6 +3,10 @@
     padding: 0;
 }
 
+html {
+    visibility: hidden;
+}
+
 body {
     background: #FBF9FE;
     max-width: 480px;
@@ -29,7 +33,7 @@ body {
     color: #838383;
     text-align: center;
     margin: .5rem auto 1.5rem;
-    font-size: 1rem;
+    font-size: 0.7rem;
     font-weight: normal;
 }
 
@@ -91,7 +95,7 @@ body {
     color: #838383;
     text-align: center;
     margin: .5rem auto 1.5rem;
-    font-size: 1rem;
+    font-size: 0.7rem;
     font-weight: normal;
 }
 

--- a/src/main/webapp/css/schedule/schedule.css
+++ b/src/main/webapp/css/schedule/schedule.css
@@ -7,6 +7,10 @@
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+html {
+    visibility: hidden;
+}
+
 html:root {
     color: #222;
 }

--- a/src/main/webapp/css/schedule/schedule_blue.css
+++ b/src/main/webapp/css/schedule/schedule_blue.css
@@ -7,6 +7,10 @@
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+html {
+    visibility: hidden;
+}
+
 html:root {
     color: #979797;
 }

--- a/src/main/webapp/css/schedule/schedule_pink.css
+++ b/src/main/webapp/css/schedule/schedule_pink.css
@@ -7,6 +7,10 @@
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+html {
+    visibility: hidden;
+}
+
 html:root {
     color: #979797;
 }

--- a/src/main/webapp/js/account/close.js
+++ b/src/main/webapp/js/account/close.js
@@ -37,6 +37,8 @@ function postCloseRequest() {
                             type: 'primary',
                             onClick: function () {
                                 alert.hide();
+                                //清空本地缓存
+                                localStorage.clear();
                                 window.location.href = '/logout';
                             }
                         }]

--- a/src/main/webapp/js/common/themeLoader.js
+++ b/src/main/webapp/js/common/themeLoader.js
@@ -1,0 +1,18 @@
+$(function () {
+    let theme = localStorage.getItem("theme");
+    if (theme) {
+        let links = document.querySelectorAll('link[title]');
+        [].slice.call(links).forEach(function (link) {
+            link.disabled = false;
+        });
+        [].slice.call(links).forEach(function (link) {
+            link.disabled = true;
+        });
+        [].slice.call(links).forEach(function (link) {
+            if (link.getAttribute("title") == theme) {
+                link.disabled = false;
+            }
+        });
+    }
+    document.getElementsByTagName("html")[0].style.visibility = "visible";
+});

--- a/src/main/webapp/js/function/function.jsp
+++ b/src/main/webapp/js/function/function.jsp
@@ -153,23 +153,6 @@
         }
     }
 
-    //弹出退出确认框
-    function showLogoutConfirm() {
-        if (!yibanUser) {
-            $.confirm({
-                title: '退出当前账号',
-                text: '你确定退出当前账号并清除账号缓存吗？',
-                onOK: function () {
-                    //清空本地缓存
-                    localStorage.clear();
-                    window.location.href = '/logout';
-                }
-            });
-        } else {
-            $.alert("易班客户端不支持账号退出，你可以重新绑定易班账号", "错误提示");
-        }
-    }
-
     //切换TabPanel
     function switchTabPanel(index) {
         for (let i = 0; i < $(".weui-tabbar a").length; i++) {

--- a/src/main/webapp/js/profile/profile.jsp
+++ b/src/main/webapp/js/profile/profile.jsp
@@ -11,6 +11,9 @@
         if (!localStorage.getItem("functionBadge")) {
             $("#functionBadge").show();
         }
+        if (!localStorage.getItem("themeBadge")) {
+            $("#themeBadge").show();
+        }
     });
 
     // 压缩后的图片
@@ -772,6 +775,23 @@
                     }
                 }
             });
+        }
+    }
+
+    //弹出退出确认框
+    function showLogoutConfirm() {
+        if (!yibanUser) {
+            $.confirm({
+                title: '退出当前账号',
+                text: '你确定退出当前账号并清除账号缓存吗？',
+                onOK: function () {
+                    //清空本地缓存
+                    localStorage.clear();
+                    window.location.href = '/logout';
+                }
+            });
+        } else {
+            $.alert("易班客户端不支持账号退出，你可以重新绑定易班账号", "错误提示");
         }
     }
 

--- a/src/main/webapp/js/theme/theme.js
+++ b/src/main/webapp/js/theme/theme.js
@@ -1,0 +1,33 @@
+$(function () {
+    //消除iOS点击延迟
+    FastClick.attach(document.body);
+    //加载当前选中的主题
+    let theme = localStorage.getItem("theme");
+    if (theme) {
+        $("#" + theme).prop("checked", true);
+    }
+    //配置个人资料页功能管理小红点图标显示配置
+    if (!localStorage.getItem("themeBadge")) {
+        localStorage.setItem("themeBadge", 1);
+    }
+    //设置单选按钮点击事件
+    $(".weui-check").change(function () {
+        changeTheme($(this).attr("id"));
+    });
+});
+
+function changeTheme(theme) {
+    localStorage.setItem("theme", theme);
+    let links = document.querySelectorAll('link[title]');
+    [].slice.call(links).forEach(function (link) {
+        link.disabled = false;
+    });
+    [].slice.call(links).forEach(function (link) {
+        link.disabled = true;
+    });
+    [].slice.call(links).forEach(function (link) {
+        if (link.getAttribute("title") == theme) {
+            link.disabled = false;
+        }
+    });
+}


### PR DESCRIPTION
## 账号注销

- 注销账号成功后同时清空本地缓存

## 实名认证

- 实名认证提示页面添加退出当前账号的选项按钮

## 主题设置

- 添加用户主题颜色设置功能
- 通过利用link标签的rel="alternate stylesheet"属性和其DOM元素对象的disabled属性的机制，加载用户选中的主题的CSS文件
- 修改页面加载模式，等待CSS属性加载完成后再显示整个页面

## 个人中心

- 退出账号菜单选项移动到个人中心