### PR TITLE
提供测试环境账号，设置默认使用IPV4，获取IP地址功能添加对本地环回IP的处理

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@
 
 本应用在中华人民共和国境内注册、发布和运营，目前仅面向广东第二师范学院在校师生开放注册使用。
 
+测试环境账号：（用户名 - 密码）
+
+- gdeiassistant - gdeiassistant
+
 ## 官网
 
 - [广东二师助手官网](https://gdeiassistant.cn)
@@ -349,10 +353,6 @@ System.setProperty("java.net.preferIPv4Addresses" , "true");
 [Anti 996 License](https://github.com/996icu/996.ICU/blob/master/LICENSE)
 
 Copyright (c) 2016 - 2023 GdeiAssistant
-
-## 文档
-
-- 广东第二师范学院校园助手系统说明文档请参考 [Wiki](https://github.com/GdeiAssistant/GdeiAssistant/wiki)
 
 ## 贡献
 

--- a/src/main/java/cn/gdeiassistant/Config/Application/GdeiAssistantAppInitializer.java
+++ b/src/main/java/cn/gdeiassistant/Config/Application/GdeiAssistantAppInitializer.java
@@ -50,6 +50,10 @@ public class GdeiAssistantAppInitializer implements WebApplicationInitializer {
         //设置WebRootKey
         servletContext.setInitParameter("webAppRootKey", "GdeiAssistant");
 
+        //配置使用IPV4
+        System.setProperty("java.net.preferIPv4Stack", "true");
+        System.setProperty("java.net.preferIPv4Addresses", "true");
+
         //配置DispatcherServlet
         AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
         applicationContext.register(ApplicationContextConfig.class);

--- a/src/main/java/cn/gdeiassistant/Tools/Utils/IPAddressUtils.java
+++ b/src/main/java/cn/gdeiassistant/Tools/Utils/IPAddressUtils.java
@@ -3,6 +3,8 @@ package cn.gdeiassistant.Tools.Utils;
 import org.apache.commons.lang.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 public class IPAddressUtils {
 
@@ -42,6 +44,16 @@ public class IPAddressUtils {
         }
         if (StringUtils.isBlank(XFor) || "unknown".equalsIgnoreCase(XFor)) {
             XFor = request.getRemoteAddr();
+        }
+        if ("127.0.0.1".equals(XFor) || "0:0:0:0:0:0:0:1".equals(XFor)) {
+            //如果是本地环回IP，则根据网卡取本机配置的IP
+            try {
+                InetAddress inetAddress = InetAddress.getLocalHost();
+                return inetAddress.getHostAddress();
+            } catch (UnknownHostException e) {
+                e.printStackTrace();
+                return XFor;
+            }
         }
         return XFor;
     }


### PR DESCRIPTION
## 测试环境

- 提供测试环境账号

## IP地址

- 设置默认使用IPV4
- 当获取的IP地址为本地环回地址时，通过网卡获取本机配置的IP地址