### PR TITLE
Implement unified notification center and align Info page notice and interaction flows

### DIFF
--- a/db-init/mysql/init.sql
+++ b/db-init/mysql/init.sql
@@ -196,6 +196,34 @@ BEGIN;
 COMMIT;
 
 -- ----------------------------
+-- Table structure for interaction_notification
+-- ----------------------------
+DROP TABLE IF EXISTS `interaction_notification`;
+CREATE TABLE `interaction_notification` (
+  `notification_id` bigint NOT NULL AUTO_INCREMENT COMMENT '统一互动通知ID',
+  `module` varchar(24) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT '模块',
+  `type` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT '通知类型',
+  `receiver_username` varchar(24) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT '接收者用户名',
+  `actor_username` varchar(24) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT '触发者用户名',
+  `target_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT '主目标ID',
+  `target_sub_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT '子目标ID',
+  `target_type` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT '目标类型',
+  `title` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '通知标题',
+  `content` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '通知内容',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `is_read` tinyint(1) NOT NULL DEFAULT 0 COMMENT '是否已读',
+  PRIMARY KEY (`notification_id`),
+  KEY `idx_interaction_notification_receiver_time` (`receiver_username`,`create_time`,`notification_id`),
+  KEY `idx_interaction_notification_receiver_read` (`receiver_username`,`is_read`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+-- ----------------------------
+-- Records of interaction_notification
+-- ----------------------------
+BEGIN;
+COMMIT;
+
+-- ----------------------------
 -- Table structure for ershou
 -- ----------------------------
 DROP TABLE IF EXISTS `ershou`;

--- a/frontend/src/components/info/NoticeBlock.vue
+++ b/frontend/src/components/info/NoticeBlock.vue
@@ -1,19 +1,25 @@
 <template>
-  <div v-if="notice" class="modern-card">
+  <div v-if="notices.length" class="modern-card">
     <div class="card-title">通知公告</div>
-    <div class="notice-content">
-      <div class="notice-title">{{ notice.title }}</div>
-      <div class="notice-date">时间：{{ notice.publishTime }}</div>
-      <div class="notice-body">{{ notice.content }}</div>
+    <div class="notice-list">
+      <div
+        v-for="notice in notices"
+        :key="notice.id || `${notice.title}-${notice.publishTime}`"
+        class="notice-content"
+      >
+        <div class="notice-title">{{ notice.title }}</div>
+        <div class="notice-date">时间：{{ notice.publishTime }}</div>
+        <div class="notice-body">{{ notice.content }}</div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
 defineProps({
-  notice: {
-    type: Object,
-    default: null
+  notices: {
+    type: Array,
+    default: () => []
   }
 })
 </script>
@@ -42,6 +48,15 @@ defineProps({
   background: #09bb07;
   border-radius: 2px;
   margin-right: 8px;
+}
+.notice-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.notice-content + .notice-content {
+  border-top: 1px solid #f2f2f2;
+  padding-top: 14px;
 }
 .notice-title {
   font-size: 16px;

--- a/frontend/src/views/Info.vue
+++ b/frontend/src/views/Info.vue
@@ -27,9 +27,9 @@
 
       <section class="info-section">
         <div class="section-title">系统通知 / 公告</div>
-        <NoticeBlock :notice="systemNotice" />
+        <NoticeBlock :notices="systemNoticeItems" />
         <HistoryBlock :festival="infoData.festival" :today-label="todayLabel" />
-        <div v-if="!systemNotice && !infoData.festival" class="modern-card empty-card">暂无系统通知</div>
+        <div v-if="!systemNoticeItems.length && !infoData.festival" class="modern-card empty-card">暂无系统通知</div>
       </section>
 
       <section class="info-section">
@@ -52,7 +52,7 @@ import InteractionBlock from '../components/info/InteractionBlock.vue'
 
 const router = useRouter()
 const infoData = ref({})
-const announcementData = ref(null)
+const announcementList = ref([])
 const interactionItems = ref([])
 const interactionUnreadCount = ref(0)
 
@@ -61,7 +61,18 @@ const todayLabel = computed(() => {
   return `${d.getMonth() + 1}月${d.getDate()}日`
 })
 
-const systemNotice = computed(() => announcementData.value || infoData.value.notice || null)
+const systemNoticeItems = computed(() => {
+  if (Array.isArray(announcementList.value) && announcementList.value.length > 0) {
+    return announcementList.value
+  }
+  if (Array.isArray(infoData.value?.notices) && infoData.value.notices.length > 0) {
+    return infoData.value.notices
+  }
+  if (infoData.value?.notice) {
+    return [infoData.value.notice]
+  }
+  return []
+})
 
 function handleViewAllAccounts() {
   router.push('/wechataccount')
@@ -89,20 +100,30 @@ function normalizeInteractionItems(rawList) {
   }))
 }
 
+function markInteractionItemRead(item) {
+  if (!item?.id || item?.isRead) {
+    return
+  }
+  item.isRead = true
+  interactionUnreadCount.value = Math.max(0, Number(interactionUnreadCount.value || 0) - 1)
+  request.post(`/message/id/${item.id}/read`).catch(() => {})
+}
+
 function handleInteractionSelect(item) {
+  markInteractionItemRead(item)
   if (item?.module === 'dating') {
     const query = {
       tab: item?.targetType === 'sent' ? 'sent' : 'received',
-      targetType: item?.targetType ?? ''
+      targetType: item?.targetType ?? '',
+      notificationId: item?.id ?? ''
     }
     if (item?.targetId) {
       query.focusedPickId = item.targetId
+      query.targetId = item.targetId
     }
     if (item?.targetSubId) {
       query.focusedProfileId = item.targetSubId
-    }
-    if (item?.id) {
-      query.messageId = item.id
+      query.targetSubId = item.targetSubId
     }
     router.push({
       path: '/dating/center',
@@ -158,14 +179,14 @@ async function loadInfoPage() {
   }
   try {
     const [announcementRes, informationRes, interactionRes, unreadRes] = await Promise.allSettled([
-      request.get('/announcement'),
+      request.get('/announcement/start/0/size/5'),
       request.get('/information/list'),
       request.get('/message/interaction/start/0/size/20'),
       request.get('/message/unread')
     ])
 
-    if (announcementRes.status === 'fulfilled' && announcementRes.value?.success && announcementRes.value?.data) {
-      announcementData.value = announcementRes.value.data
+    if (announcementRes.status === 'fulfilled' && announcementRes.value?.success) {
+      announcementList.value = Array.isArray(announcementRes.value?.data) ? announcementRes.value.data : []
     }
     if (informationRes.status === 'fulfilled' && informationRes.value?.success && informationRes.value?.data) {
       infoData.value = informationRes.value.data

--- a/frontend/src/views/dating/Center.vue
+++ b/frontend/src/views/dating/Center.vue
@@ -128,7 +128,7 @@ async function loadData() {
         id: normalizeId(p.profileId),
         name: p.nickname,
         image: p.pictureURL,
-        publishTime: p.createTime || ''
+        publishTime: p.createTime || '已发布'
       })) : []
     }
   } finally {

--- a/src/main/java/cn/gdeiassistant/common/config/DataSource/AppDataSourceConfig.java
+++ b/src/main/java/cn/gdeiassistant/common/config/DataSource/AppDataSourceConfig.java
@@ -24,6 +24,7 @@ import java.io.IOException;
         "cn.gdeiassistant.core.roommate.mapper",
         "cn.gdeiassistant.core.delivery.mapper",
         "cn.gdeiassistant.core.email.mapper",
+        "cn.gdeiassistant.core.message.mapper",
         "cn.gdeiassistant.core.secondhand.mapper",
         "cn.gdeiassistant.core.express.mapper",
         "cn.gdeiassistant.core.feedback.mapper",

--- a/src/main/java/cn/gdeiassistant/core/announcement/controller/AnnouncementController.java
+++ b/src/main/java/cn/gdeiassistant/core/announcement/controller/AnnouncementController.java
@@ -7,11 +7,13 @@ import cn.gdeiassistant.core.information.pojo.vo.AnnouncementVO;
 import cn.gdeiassistant.core.information.service.Announcement.AnnouncementService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @RestController
 public class AnnouncementController {
@@ -26,6 +28,17 @@ public class AnnouncementController {
     public DataJsonResult<AnnouncementVO> queryLatestAnnouncement() {
         AnnouncementVO announcement = announcementService.queryLatestAnnouncement();
         return new DataJsonResult<>(true, announcement);
+    }
+
+    @RequestMapping(value = "/api/announcement/start/{start}/size/{size}", method = RequestMethod.GET)
+    public DataJsonResult<List<AnnouncementVO>> queryAnnouncementPage(@PathVariable("start") Integer start,
+            @PathVariable("size") Integer size) {
+        return new DataJsonResult<>(true, announcementService.queryAnnouncementPage(start, size));
+    }
+
+    @RequestMapping(value = "/api/announcement/id/{id}", method = RequestMethod.GET)
+    public DataJsonResult<AnnouncementVO> queryAnnouncementDetail(@PathVariable("id") Integer id) {
+        return new DataJsonResult<>(true, announcementService.queryAnnouncementDetail(id));
     }
 
     /**

--- a/src/main/java/cn/gdeiassistant/core/announcement/mapper/AnnouncementMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/announcement/mapper/AnnouncementMapper.java
@@ -2,12 +2,15 @@ package cn.gdeiassistant.core.announcement.mapper;
 
 import cn.gdeiassistant.core.information.pojo.entity.AnnouncementEntity;
 import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.type.JdbcType;
 
 import java.util.Date;
+import java.util.List;
 
 public interface AnnouncementMapper {
 
@@ -19,6 +22,19 @@ public interface AnnouncementMapper {
     })
     @Select("select * from announcement order by publish_time desc limit 1")
     AnnouncementEntity queryLatestAnnouncement();
+
+    @Select("select * from announcement where id=#{id} limit 1")
+    @Results(id = "Announcement", value = {
+            @Result(property = "id", column = "id", id = true),
+            @Result(property = "title", column = "title"),
+            @Result(property = "content", column = "content"),
+            @Result(property = "publishTime", column = "publish_time", javaType = Date.class, jdbcType = JdbcType.TIMESTAMP)
+    })
+    AnnouncementEntity queryAnnouncementById(@Param("id") Integer id);
+
+    @Select("select * from announcement order by publish_time desc, id desc limit #{start},#{size}")
+    @ResultMap("Announcement")
+    List<AnnouncementEntity> queryAnnouncementPage(@Param("start") Integer start, @Param("size") Integer size);
 
     @Insert("insert into announcement (title,content,publish_time) values(#{title},#{content},#{publishTime})")
     void insertAnnouncement(AnnouncementEntity announcement);

--- a/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
+++ b/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
@@ -105,7 +105,7 @@ public class AccountDeletionService {
             } else if (deliveryOrder.getState().equals(1)) {
                 DeliveryTradeEntity deliveryTrade = deliveryMapper.selectDeliveryTradeByOrderId(deliveryOrder.getOrderId());
                 if (deliveryTrade != null && deliveryTrade.getState().equals(0)) {
-                    deliveryMapper.updateTradeState(deliveryTrade.getTradeId(), 2);
+                    deliveryMapper.updateTradeState(deliveryTrade.getTradeId(), 0, 2);
                 }
             }
         }

--- a/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
@@ -39,7 +39,7 @@ public class DeliveryController {
         Map<String, Object> data = new HashMap<>();
         data.put("order", order);
         data.put("detailType", detailType);
-        if (order.getState() != null && order.getState().equals(1)) {
+        if (order.getState() != null && !order.getState().equals(0)) {
             DeliveryTradeVO trade = deliveryService.queryDeliveryTradeByOrderId(order.getOrderId());
             data.put("trade", trade);
         }

--- a/src/main/java/cn/gdeiassistant/core/delivery/mapper/DeliveryMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/mapper/DeliveryMapper.java
@@ -113,8 +113,12 @@ public interface DeliveryMapper {
     @Update("update delivery_order set state=#{state} where order_id=#{id} and state=0")
     int updateOrderState(@Param("id") int id, @Param("state") int state);
 
-    @Update("update delivery_trade set state=#{state} where trade_id=#{tradeId}")
-    void updateTradeState(@Param("tradeId") Integer tradeId, @Param("state") Integer state);
+    @Update("update delivery_trade set state=#{state} where trade_id=#{tradeId} and state=#{expectedState}")
+    int updateTradeState(@Param("tradeId") Integer tradeId, @Param("expectedState") Integer expectedState,
+            @Param("state") Integer state);
+
+    @Update("update delivery_order set state=2 where order_id=#{orderId} and state=1")
+    int finishOrder(@Param("orderId") Integer orderId);
 
     @Update("update delivery_order set state=2 where order_id=#{orderId} and state!=1")
     int deleteOrder(Integer orderId);

--- a/src/main/java/cn/gdeiassistant/core/delivery/service/DeliveryService.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/service/DeliveryService.java
@@ -13,6 +13,7 @@ import cn.gdeiassistant.core.delivery.pojo.entity.DeliveryOrderEntity;
 import cn.gdeiassistant.core.delivery.pojo.entity.DeliveryTradeEntity;
 import cn.gdeiassistant.core.delivery.pojo.vo.DeliveryOrderVO;
 import cn.gdeiassistant.core.delivery.pojo.vo.DeliveryTradeVO;
+import cn.gdeiassistant.core.message.service.InteractionNotificationService;
 import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +36,9 @@ public class DeliveryService {
 
     @Autowired
     private UserCertificateService userCertificateService;
+
+    @Autowired
+    private InteractionNotificationService interactionNotificationService;
 
     /**
      * 分页查询订单信息
@@ -225,6 +229,19 @@ public class DeliveryService {
             trade.setUsername(username);
             trade.setOrderId(orderId);
             deliveryMapper.insertTradeRecord(trade);
+            DeliveryOrderEntity order = deliveryMapper.selectDeliveryOrderByOrderId(orderId);
+            String company = order != null && StringUtils.isNotBlank(order.getCompany()) ? order.getCompany() : "快递代收";
+            interactionNotificationService.createInteractionNotification(
+                    "delivery",
+                    "order_accepted",
+                    order != null ? order.getUsername() : null,
+                    username,
+                    orderId == null ? null : String.valueOf(orderId),
+                    trade.getTradeId() == null ? null : String.valueOf(trade.getTradeId()),
+                    "published",
+                    "订单已被接单",
+                    username + " 接取了你发布的 " + company + " 订单"
+            );
         } else {
             //抢单失败
             throw new DeliveryOrderTakenException("抢单失败");
@@ -298,6 +315,7 @@ public class DeliveryService {
      * @throws DataNotExistException
      * @throws NoAccessUpdatingException
      */
+    @Transactional("appTransactionManager")
     public void finishTrade(Integer tradeId, String sessionId) throws DataNotExistException, NoAccessUpdatingException {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         DeliveryTradeEntity deliveryTrade = deliveryMapper.selectDeliveryTradeByTradeId(tradeId);
@@ -306,7 +324,26 @@ public class DeliveryService {
                 DeliveryOrderEntity deliveryOrder = deliveryMapper.selectDeliveryOrderByOrderId(deliveryTrade.getOrderId());
                 if (deliveryOrder != null) {
                     if (deliveryOrder.getUsername().equals(user.getUsername())) {
-                        deliveryMapper.updateTradeState(tradeId, 1);
+                        int orderResult = deliveryMapper.finishOrder(deliveryTrade.getOrderId());
+                        if (orderResult <= 0) {
+                            return;
+                        }
+                        int tradeResult = deliveryMapper.updateTradeState(tradeId, 0, 1);
+                        if (tradeResult <= 0) {
+                            throw new IllegalStateException("快递代收交易状态更新失败");
+                        }
+                        String company = StringUtils.isNotBlank(deliveryOrder.getCompany()) ? deliveryOrder.getCompany() : "快递代收";
+                        interactionNotificationService.createInteractionNotification(
+                                "delivery",
+                                "order_finished",
+                                deliveryTrade.getUsername(),
+                                user.getUsername(),
+                                deliveryTrade.getOrderId() == null ? null : String.valueOf(deliveryTrade.getOrderId()),
+                                tradeId == null ? null : String.valueOf(tradeId),
+                                "accepted",
+                                "订单已完成",
+                                user.getUsername() + " 已确认你接取的 " + company + " 订单完成"
+                        );
                         return;
                     }
                     throw new NoAccessUpdatingException("你没有权限修改该订单状态");

--- a/src/main/java/cn/gdeiassistant/core/express/mapper/ExpressMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/express/mapper/ExpressMapper.java
@@ -143,7 +143,8 @@ public interface ExpressMapper {
     List<ExpressComment> selectExpressComment(@Param("expressId") int expressId);
 
     @Insert("insert into express_comment (username,express_id,comment,publish_time) values(#{username},#{expressId},#{comment},now())")
-    void insertExpressComment(@Param("expressId") int expressId, @Param("username") String username, @Param("comment") String comment);
+    @Options(useGeneratedKeys = true, keyProperty = "id", keyColumn = "id")
+    void insertExpressComment(ExpressComment expressComment);
 
     @Select("select ec.id,ec.username,p.nickname,ec.express_id,ec.comment,ec.publish_time from express_comment ec " +
             "left join profile p on p.username=ec.username inner join express e on ec.express_id=e.id " +

--- a/src/main/java/cn/gdeiassistant/core/express/service/ExpressService.java
+++ b/src/main/java/cn/gdeiassistant/core/express/service/ExpressService.java
@@ -11,10 +11,12 @@ import cn.gdeiassistant.core.express.mapper.ExpressMapper;
 import cn.gdeiassistant.core.express.pojo.dto.ExpressPublishDTO;
 import cn.gdeiassistant.core.express.pojo.entity.ExpressEntity;
 import cn.gdeiassistant.core.express.pojo.vo.ExpressVO;
+import cn.gdeiassistant.core.message.service.InteractionNotificationService;
 import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +32,9 @@ public class ExpressService {
 
     @Autowired
     private UserCertificateService userCertificateService;
+
+    @Autowired
+    private InteractionNotificationService interactionNotificationService;
 
     public List<ExpressVO> queryExpressPage(int start, int size, String sessionId) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
@@ -65,13 +70,29 @@ public class ExpressService {
         return list == null || list.isEmpty() ? new ArrayList<>() : list;
     }
 
+    @Transactional("appTransactionManager")
     public void addExpressComment(int expressId, String sessionId, String comment) throws DataNotExistException {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         ExpressEntity entity = expressMapper.selectExpressById(expressId, user.getUsername());
         if (entity == null) {
             throw new DataNotExistException("表白信息不存在");
         }
-        expressMapper.insertExpressComment(expressId, user.getUsername(), comment);
+        ExpressComment expressComment = new ExpressComment();
+        expressComment.setExpressId(expressId);
+        expressComment.setUsername(user.getUsername());
+        expressComment.setComment(comment);
+        expressMapper.insertExpressComment(expressComment);
+        interactionNotificationService.createInteractionNotification(
+                "express",
+                "comment",
+                entity.getUsername(),
+                user.getUsername(),
+                String.valueOf(expressId),
+                expressComment.getId() == null ? null : String.valueOf(expressComment.getId()),
+                "comment",
+                "表白墙收到新评论",
+                user.getUsername() + " 评论了你的表白：" + comment
+        );
     }
 
     public void addExpress(ExpressPublishDTO dto, String sessionId) {
@@ -87,6 +108,7 @@ public class ExpressService {
         expressMapper.insertExpress(entity);
     }
 
+    @Transactional("appTransactionManager")
     public void likeExpress(int expressId, String sessionId) throws DataNotExistException {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         ExpressEntity entity = expressMapper.selectExpressById(expressId, user.getUsername());
@@ -96,9 +118,21 @@ public class ExpressService {
         ExpressLike like = expressMapper.selectExpressLike(expressId, user.getUsername());
         if (like == null) {
             expressMapper.insertExpressLike(expressId, user.getUsername());
+            interactionNotificationService.createInteractionNotification(
+                    "express",
+                    "like",
+                    entity.getUsername(),
+                    user.getUsername(),
+                    String.valueOf(expressId),
+                    null,
+                    "like",
+                    "表白墙收到新点赞",
+                    user.getUsername() + " 点赞了你的表白"
+            );
         }
     }
 
+    @Transactional("appTransactionManager")
     public boolean guessExpress(int expressId, String sessionId, String name) throws NoRealNameException, DataNotExistException, CorrectRecordException {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         ExpressEntity entity = expressMapper.selectExpressById(expressId, user.getUsername());
@@ -113,11 +147,23 @@ public class ExpressService {
         if (StringUtils.isBlank(realname)) {
             throw new NoRealNameException("表白者未填写真实姓名");
         }
+        boolean correct = realname.equals(name);
         if (realname.equals(name)) {
             expressMapper.insertExpressGuess(expressId, user.getUsername(), 1);
-            return true;
+        } else {
+            expressMapper.insertExpressGuess(expressId, user.getUsername(), 0);
         }
-        expressMapper.insertExpressGuess(expressId, user.getUsername(), 0);
-        return false;
+        interactionNotificationService.createInteractionNotification(
+                "express",
+                "guess",
+                entity.getUsername(),
+                user.getUsername(),
+                String.valueOf(expressId),
+                null,
+                "guess",
+                correct ? "表白墙有人猜中了" : "表白墙有人参与猜名字",
+                correct ? user.getUsername() + " 猜中了你的表白对象" : user.getUsername() + " 参与了你的猜名字"
+        );
+        return correct;
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/information/controller/InformationController.java
+++ b/src/main/java/cn/gdeiassistant/core/information/controller/InformationController.java
@@ -34,12 +34,14 @@ public class InformationController {
     @RequestMapping(value = "/api/information/list", method = RequestMethod.GET)
     public DataJsonResult<InformationVO> loadInformation() {
         AnnouncementVO notice = announcementService.queryLatestAnnouncement();
+        List<AnnouncementVO> notices = announcementService.queryAnnouncementPage(0, 5);
         List<WechatAccount> accounts = WechatAccountUtils.getWechatAccountList();
         List<ReadingVO> topics = readingService.loadLatestReadingList();
         Festival festival = FestivalUtils.getFestivalInfo();
 
         InformationVO information = new InformationVO();
         information.setNotice(notice);
+        information.setNotices(notices);
         information.setAccounts(accounts);
         information.setTopics(topics);
         information.setFestival(festival);
@@ -47,4 +49,3 @@ public class InformationController {
         return new DataJsonResult<>(true, information);
     }
 }
-

--- a/src/main/java/cn/gdeiassistant/core/information/converter/AnnouncementConverter.java
+++ b/src/main/java/cn/gdeiassistant/core/information/converter/AnnouncementConverter.java
@@ -4,8 +4,12 @@ import cn.gdeiassistant.core.information.pojo.entity.AnnouncementEntity;
 import cn.gdeiassistant.core.information.pojo.vo.AnnouncementVO;
 import org.mapstruct.Mapper;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface AnnouncementConverter {
 
     AnnouncementVO toVO(AnnouncementEntity entity);
+
+    List<AnnouncementVO> toVOList(List<AnnouncementEntity> entityList);
 }

--- a/src/main/java/cn/gdeiassistant/core/information/pojo/vo/InformationVO.java
+++ b/src/main/java/cn/gdeiassistant/core/information/pojo/vo/InformationVO.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class InformationVO implements Serializable {
 
     private AnnouncementVO notice;
+    private List<AnnouncementVO> notices;
     private List<WechatAccount> accounts;
     private List<ReadingVO> topics;
     private Festival festival;
@@ -21,6 +22,14 @@ public class InformationVO implements Serializable {
 
     public void setNotice(AnnouncementVO notice) {
         this.notice = notice;
+    }
+
+    public List<AnnouncementVO> getNotices() {
+        return notices;
+    }
+
+    public void setNotices(List<AnnouncementVO> notices) {
+        this.notices = notices;
     }
 
     public List<WechatAccount> getAccounts() {

--- a/src/main/java/cn/gdeiassistant/core/information/service/announcement/AnnouncementService.java
+++ b/src/main/java/cn/gdeiassistant/core/information/service/announcement/AnnouncementService.java
@@ -8,7 +8,9 @@ import cn.gdeiassistant.core.information.pojo.vo.AnnouncementVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Service
 public class AnnouncementService {
@@ -35,5 +37,21 @@ public class AnnouncementService {
     public AnnouncementVO queryLatestAnnouncement() {
         AnnouncementEntity entity = announcementMapper.queryLatestAnnouncement();
         return entity == null ? null : announcementConverter.toVO(entity);
+    }
+
+    public AnnouncementVO queryAnnouncementDetail(Integer id) {
+        if (id == null) {
+            return null;
+        }
+        AnnouncementEntity entity = announcementMapper.queryAnnouncementById(id);
+        return entity == null ? null : announcementConverter.toVO(entity);
+    }
+
+    public List<AnnouncementVO> queryAnnouncementPage(Integer start, Integer size) {
+        if (start == null || start < 0 || size == null || size <= 0) {
+            return new ArrayList<>();
+        }
+        List<AnnouncementEntity> entityList = announcementMapper.queryAnnouncementPage(start, size);
+        return entityList == null ? new ArrayList<>() : announcementConverter.toVOList(entityList);
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/message/controller/MessageController.java
+++ b/src/main/java/cn/gdeiassistant/core/message/controller/MessageController.java
@@ -1,6 +1,7 @@
 package cn.gdeiassistant.core.message.controller;
 
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
+import cn.gdeiassistant.common.pojo.Result.JsonResult;
 import cn.gdeiassistant.core.message.pojo.vo.InteractionMessageVO;
 import cn.gdeiassistant.core.message.service.MessageService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,5 +30,19 @@ public class MessageController {
     public DataJsonResult<Integer> getInteractionUnreadCount(HttpServletRequest request) {
         String sessionId = (String) request.getAttribute("sessionId");
         return new DataJsonResult<>(true, messageService.queryInteractionUnreadCount(sessionId));
+    }
+
+    @RequestMapping(value = "/api/message/id/{id}/read", method = RequestMethod.POST)
+    public JsonResult readInteractionMessage(HttpServletRequest request, @PathVariable("id") String id) {
+        String sessionId = (String) request.getAttribute("sessionId");
+        messageService.markInteractionMessageRead(sessionId, id);
+        return new JsonResult(true);
+    }
+
+    @RequestMapping(value = "/api/message/readall", method = RequestMethod.POST)
+    public JsonResult readAllInteractionMessages(HttpServletRequest request) {
+        String sessionId = (String) request.getAttribute("sessionId");
+        messageService.markAllInteractionMessagesRead(sessionId);
+        return new JsonResult(true);
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/message/mapper/InteractionNotificationMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/message/mapper/InteractionNotificationMapper.java
@@ -1,0 +1,50 @@
+package cn.gdeiassistant.core.message.mapper;
+
+import cn.gdeiassistant.core.message.pojo.entity.InteractionNotificationEntity;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.List;
+
+public interface InteractionNotificationMapper {
+
+    @Insert("insert into interaction_notification " +
+            "(module,type,receiver_username,actor_username,target_id,target_sub_id,target_type,title,content,create_time,is_read) " +
+            "values (#{module},#{type},#{receiverUsername},#{actorUsername},#{targetId},#{targetSubId},#{targetType},#{title},#{content},now(),#{isRead})")
+    @Options(useGeneratedKeys = true, keyProperty = "notificationId", keyColumn = "notification_id")
+    void insertInteractionNotification(InteractionNotificationEntity entity);
+
+    @Select("select notification_id,module,type,receiver_username,actor_username,target_id,target_sub_id,target_type,title,content,create_time,is_read " +
+            "from interaction_notification where receiver_username=#{username} " +
+            "order by create_time desc, notification_id desc limit #{start},#{size}")
+    @Results(id = "InteractionNotification", value = {
+            @Result(property = "notificationId", column = "notification_id"),
+            @Result(property = "module", column = "module"),
+            @Result(property = "type", column = "type"),
+            @Result(property = "receiverUsername", column = "receiver_username"),
+            @Result(property = "actorUsername", column = "actor_username"),
+            @Result(property = "targetId", column = "target_id"),
+            @Result(property = "targetSubId", column = "target_sub_id"),
+            @Result(property = "targetType", column = "target_type"),
+            @Result(property = "title", column = "title"),
+            @Result(property = "content", column = "content"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "isRead", column = "is_read")
+    })
+    List<InteractionNotificationEntity> selectInteractionNotificationPage(@Param("username") String username,
+            @Param("start") Integer start, @Param("size") Integer size);
+
+    @Select("select count(notification_id) from interaction_notification where receiver_username=#{username} and is_read=0")
+    Integer selectUnreadInteractionNotificationCount(@Param("username") String username);
+
+    @Update("update interaction_notification set is_read=1 where receiver_username=#{username} and notification_id=#{notificationId}")
+    int updateInteractionNotificationRead(@Param("username") String username, @Param("notificationId") Long notificationId);
+
+    @Update("update interaction_notification set is_read=1 where receiver_username=#{username} and is_read=0")
+    int updateAllInteractionNotificationRead(@Param("username") String username);
+}

--- a/src/main/java/cn/gdeiassistant/core/message/pojo/entity/InteractionNotificationEntity.java
+++ b/src/main/java/cn/gdeiassistant/core/message/pojo/entity/InteractionNotificationEntity.java
@@ -1,0 +1,118 @@
+package cn.gdeiassistant.core.message.pojo.entity;
+
+import cn.gdeiassistant.common.pojo.Entity.Entity;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class InteractionNotificationEntity implements Serializable, Entity {
+
+    private Long notificationId;
+    private String module;
+    private String type;
+    private String receiverUsername;
+    private String actorUsername;
+    private String targetId;
+    private String targetSubId;
+    private String targetType;
+    private String title;
+    private String content;
+    private Date createTime;
+    private Integer isRead;
+
+    public Long getNotificationId() {
+        return notificationId;
+    }
+
+    public void setNotificationId(Long notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public void setModule(String module) {
+        this.module = module;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getReceiverUsername() {
+        return receiverUsername;
+    }
+
+    public void setReceiverUsername(String receiverUsername) {
+        this.receiverUsername = receiverUsername;
+    }
+
+    public String getActorUsername() {
+        return actorUsername;
+    }
+
+    public void setActorUsername(String actorUsername) {
+        this.actorUsername = actorUsername;
+    }
+
+    public String getTargetId() {
+        return targetId;
+    }
+
+    public void setTargetId(String targetId) {
+        this.targetId = targetId;
+    }
+
+    public String getTargetSubId() {
+        return targetSubId;
+    }
+
+    public void setTargetSubId(String targetSubId) {
+        this.targetSubId = targetSubId;
+    }
+
+    public String getTargetType() {
+        return targetType;
+    }
+
+    public void setTargetType(String targetType) {
+        this.targetType = targetType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public Integer getIsRead() {
+        return isRead;
+    }
+
+    public void setIsRead(Integer isRead) {
+        this.isRead = isRead;
+    }
+}

--- a/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
+++ b/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
@@ -1,0 +1,118 @@
+package cn.gdeiassistant.core.message.service;
+
+import cn.gdeiassistant.common.pojo.Entity.User;
+import cn.gdeiassistant.common.tools.Utils.StringUtils;
+import cn.gdeiassistant.core.message.mapper.InteractionNotificationMapper;
+import cn.gdeiassistant.core.message.pojo.entity.InteractionNotificationEntity;
+import cn.gdeiassistant.core.message.pojo.vo.InteractionMessageVO;
+import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.Resource;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class InteractionNotificationService {
+
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Shanghai");
+
+    @Autowired
+    private UserCertificateService userCertificateService;
+
+    @Resource(name = "interactionNotificationMapper")
+    private InteractionNotificationMapper interactionNotificationMapper;
+
+    public void createInteractionNotification(String module, String type, String receiverUsername, String actorUsername,
+            String targetId, String targetSubId, String targetType, String title, String content) {
+        if (StringUtils.isBlank(module) || StringUtils.isBlank(type) || StringUtils.isBlank(receiverUsername)) {
+            return;
+        }
+        if (StringUtils.isNotBlank(actorUsername) && receiverUsername.equals(actorUsername)) {
+            return;
+        }
+        InteractionNotificationEntity entity = new InteractionNotificationEntity();
+        entity.setModule(module);
+        entity.setType(type);
+        entity.setReceiverUsername(receiverUsername);
+        entity.setActorUsername(actorUsername);
+        entity.setTargetId(targetId);
+        entity.setTargetSubId(targetSubId);
+        entity.setTargetType(targetType);
+        entity.setTitle(StringUtils.isNotBlank(title) ? title : "互动消息");
+        entity.setContent(StringUtils.isNotBlank(content) ? content : "你有一条新的互动消息");
+        entity.setIsRead(0);
+        interactionNotificationMapper.insertInteractionNotification(entity);
+    }
+
+    public List<InteractionMessageVO> queryInteractionMessages(String sessionId, Integer start, Integer size) {
+        if (start == null || start < 0 || size == null || size <= 0) {
+            return new ArrayList<>();
+        }
+        User user = userCertificateService.getUserLoginCertificate(sessionId);
+        List<InteractionNotificationEntity> entityList = interactionNotificationMapper
+                .selectInteractionNotificationPage(user.getUsername(), start, size);
+        if (entityList == null || entityList.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<InteractionMessageVO> list = new ArrayList<>(entityList.size());
+        for (InteractionNotificationEntity entity : entityList) {
+            list.add(toInteractionMessageVO(entity));
+        }
+        return list;
+    }
+
+    public Integer queryInteractionUnreadCount(String sessionId) {
+        User user = userCertificateService.getUserLoginCertificate(sessionId);
+        Integer count = interactionNotificationMapper.selectUnreadInteractionNotificationCount(user.getUsername());
+        return count == null ? 0 : Math.max(count, 0);
+    }
+
+    public void markInteractionNotificationRead(String sessionId, String notificationId) {
+        Long parsedId = parseNotificationId(notificationId);
+        if (parsedId == null) {
+            return;
+        }
+        User user = userCertificateService.getUserLoginCertificate(sessionId);
+        interactionNotificationMapper.updateInteractionNotificationRead(user.getUsername(), parsedId);
+    }
+
+    public void markAllInteractionNotificationsRead(String sessionId) {
+        User user = userCertificateService.getUserLoginCertificate(sessionId);
+        interactionNotificationMapper.updateAllInteractionNotificationRead(user.getUsername());
+    }
+
+    private InteractionMessageVO toInteractionMessageVO(InteractionNotificationEntity entity) {
+        InteractionMessageVO vo = new InteractionMessageVO();
+        vo.setId(entity.getNotificationId() == null ? null : String.valueOf(entity.getNotificationId()));
+        vo.setModule(entity.getModule());
+        vo.setType(entity.getType());
+        vo.setTitle(entity.getTitle());
+        vo.setContent(entity.getContent());
+        vo.setCreatedAt(formatDate(entity.getCreateTime()));
+        vo.setIsRead(entity.getIsRead() != null && entity.getIsRead() != 0);
+        vo.setTargetType(entity.getTargetType());
+        vo.setTargetId(entity.getTargetId());
+        vo.setTargetSubId(entity.getTargetSubId());
+        return vo;
+    }
+
+    private String formatDate(java.util.Date value) {
+        return value == null ? "" : value.toInstant().atZone(ZONE_ID).toLocalDateTime().format(DATETIME_FORMATTER);
+    }
+
+    private Long parseNotificationId(String notificationId) {
+        if (StringUtils.isBlank(notificationId) || !StringUtils.isNumeric(notificationId)) {
+            return null;
+        }
+        try {
+            return Long.valueOf(notificationId);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/cn/gdeiassistant/core/message/service/MessageService.java
+++ b/src/main/java/cn/gdeiassistant/core/message/service/MessageService.java
@@ -1,61 +1,30 @@
 package cn.gdeiassistant.core.message.service;
 
-import cn.gdeiassistant.common.pojo.Entity.User;
 import cn.gdeiassistant.core.message.pojo.vo.InteractionMessageVO;
-import cn.gdeiassistant.core.message.service.provider.InteractionMessageProvider;
-import cn.gdeiassistant.core.message.service.provider.InteractionMessageRecord;
-import cn.gdeiassistant.core.roommate.mapper.RoommateMapper;
-import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
-import jakarta.annotation.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service
 public class MessageService {
 
     @Autowired
-    private UserCertificateService userCertificateService;
-
-    @Resource(name = "roommateMapper")
-    private RoommateMapper roommateMapper;
-
-    @Autowired(required = false)
-    private List<InteractionMessageProvider> interactionMessageProviderList = Collections.emptyList();
+    private InteractionNotificationService interactionNotificationService;
 
     public List<InteractionMessageVO> queryInteractionMessages(String sessionId, Integer start, Integer size) {
-        if (start == null || start < 0 || size == null || size <= 0) {
-            return new ArrayList<>();
-        }
-        User user = userCertificateService.getUserLoginCertificate(sessionId);
-        int fetchSize = start + size;
-        List<InteractionMessageRecord> records = new ArrayList<>();
-        for (InteractionMessageProvider provider : interactionMessageProviderList) {
-            List<InteractionMessageRecord> providerRecords = provider.queryMessages(user.getUsername(), fetchSize);
-            if (providerRecords != null && !providerRecords.isEmpty()) {
-                records.addAll(providerRecords);
-            }
-        }
-        if (records.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        records.sort(InteractionMessageRecord.DEFAULT_COMPARATOR);
-
-        List<InteractionMessageVO> voList = new ArrayList<>();
-        int end = Math.min(records.size(), start + size);
-        for (int i = start; i < end; i++) {
-            voList.add(records.get(i).getMessage());
-        }
-        return voList;
+        return interactionNotificationService.queryInteractionMessages(sessionId, start, size);
     }
 
     public Integer queryInteractionUnreadCount(String sessionId) {
-        User user = userCertificateService.getUserLoginCertificate(sessionId);
-        Integer datingUnreadCount = roommateMapper.selectUserUnReadRoommateMessageCount(user.getUsername());
-        return datingUnreadCount == null ? 0 : Math.max(datingUnreadCount, 0);
+        return interactionNotificationService.queryInteractionUnreadCount(sessionId);
+    }
+
+    public void markInteractionMessageRead(String sessionId, String id) {
+        interactionNotificationService.markInteractionNotificationRead(sessionId, id);
+    }
+
+    public void markAllInteractionMessagesRead(String sessionId) {
+        interactionNotificationService.markAllInteractionNotificationsRead(sessionId);
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/photograph/mapper/PhotographMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/mapper/PhotographMapper.java
@@ -89,6 +89,7 @@ public interface PhotographMapper {
     Integer selectPhotographCommentCount();
 
     @Insert("insert into photograph_comment (photo_id,comment,username,create_time) values(#{photoId},#{comment},#{username},now())")
+    @Options(useGeneratedKeys = true, keyProperty = "commentId", keyColumn = "comment_id")
     void insertPhotographComment(PhotographCommentEntity photographComment);
 
     @Select("select pc.comment_id,pc.photo_id,pc.comment,pc.username,p.nickname,pc.create_time from photograph_comment pc " +

--- a/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
@@ -2,6 +2,7 @@ package cn.gdeiassistant.core.photograph.service;
 
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import cn.gdeiassistant.common.pojo.Entity.User;
+import cn.gdeiassistant.core.message.service.InteractionNotificationService;
 import cn.gdeiassistant.core.photograph.converter.PhotographCommentConverter;
 import cn.gdeiassistant.core.photograph.converter.PhotographConverter;
 import cn.gdeiassistant.core.photograph.mapper.PhotographMapper;
@@ -16,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,6 +44,9 @@ public class PhotographService {
 
     @Autowired
     private R2StorageService r2StorageService;
+
+    @Autowired
+    private InteractionNotificationService interactionNotificationService;
 
     public int queryPhotoStatisticalData() {
         Integer n = photographMapper.selectPhotographImageCount();
@@ -121,6 +126,7 @@ public class PhotographService {
         return entity.getId();
     }
 
+    @Transactional("appTransactionManager")
     public void addPhotographComment(int id, String comment, String sessionId) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         PhotographCommentEntity entity = new PhotographCommentEntity();
@@ -128,6 +134,18 @@ public class PhotographService {
         entity.setComment(comment);
         entity.setUsername(user.getUsername());
         photographMapper.insertPhotographComment(entity);
+        PhotographEntity photograph = getNotificationTarget(id, user.getUsername());
+        interactionNotificationService.createInteractionNotification(
+                "photograph",
+                "comment",
+                photograph != null ? photograph.getUsername() : null,
+                user.getUsername(),
+                String.valueOf(id),
+                entity.getCommentId() == null ? null : String.valueOf(entity.getCommentId()),
+                "comment",
+                "作品收到新评论",
+                user.getUsername() + " 评论了你的作品：" + comment
+        );
     }
 
     public void uploadPhotographItemPicture(int id, int index, InputStream inputStream) {
@@ -149,11 +167,24 @@ public class PhotographService {
         return r2StorageService.generatePresignedUrl("gdeiassistant-userdata", "photograph/" + id + "_" + index + ".jpg", 30, TimeUnit.MINUTES);
     }
 
+    @Transactional("appTransactionManager")
     public void LikePhotograph(int id, String sessionId) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         Integer count = photographMapper.selectPhotographLikeCountByPhotoIdAndUsername(id, user.getUsername());
         if (count == null || count == 0) {
             photographMapper.insertPhotographLike(id, user.getUsername());
+            PhotographEntity photograph = getNotificationTarget(id, user.getUsername());
+            interactionNotificationService.createInteractionNotification(
+                    "photograph",
+                    "like",
+                    photograph != null ? photograph.getUsername() : null,
+                    user.getUsername(),
+                    String.valueOf(id),
+                    null,
+                    "like",
+                    "作品收到新点赞",
+                    user.getUsername() + " 点赞了你的作品"
+            );
         }
     }
 
@@ -165,5 +196,10 @@ public class PhotographService {
         e.setType(dto.getType());
         e.setUsername(username);
         return e;
+    }
+
+    private PhotographEntity getNotificationTarget(int id, String username) {
+        List<PhotographEntity> list = photographMapper.selectPhotographByIdAndUsername(id, username);
+        return list == null || list.isEmpty() ? null : list.get(0);
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/roommate/service/RoommateService.java
+++ b/src/main/java/cn/gdeiassistant/core/roommate/service/RoommateService.java
@@ -5,7 +5,9 @@ import cn.gdeiassistant.common.exception.DatabaseException.NoAccessException;
 import cn.gdeiassistant.common.exception.DatingException.RepeatPickException;
 import cn.gdeiassistant.common.exception.DatingException.SelfPickException;
 import cn.gdeiassistant.common.pojo.Entity.User;
+import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import cn.gdeiassistant.core.roommate.mapper.RoommateMapper;
+import cn.gdeiassistant.core.message.service.InteractionNotificationService;
 import cn.gdeiassistant.core.roommate.pojo.dto.RoommatePickSubmitDTO;
 import cn.gdeiassistant.core.roommate.pojo.dto.RoommatePublishDTO;
 import cn.gdeiassistant.core.roommate.pojo.entity.RoommateMessageEntity;
@@ -20,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.Resource;
 import java.io.IOException;
@@ -41,6 +44,9 @@ public class RoommateService {
 
     @Autowired
     private R2StorageService r2StorageService;
+
+    @Autowired
+    private InteractionNotificationService interactionNotificationService;
 
     public RoommateProfileVO queryRoommateProfile(Integer id) throws DataNotExistException {
         RoommateProfileEntity entity = roommateMapper.selectRoommateProfileById(id);
@@ -157,6 +163,7 @@ public class RoommateService {
         throw new NoAccessException("没有权限查看该撩一下信息");
     }
 
+    @Transactional("appTransactionManager")
     public void addRoommatePick(String sessionId, RoommatePickSubmitDTO dto) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         RoommatePickEntity pick = new RoommatePickEntity();
@@ -173,8 +180,22 @@ public class RoommateService {
         msg.setType(0);
         msg.setState(0);
         roommateMapper.insertRoommateMessage(msg);
+        interactionNotificationService.createInteractionNotification(
+                "dating",
+                "pick_received",
+                profile != null ? profile.getUsername() : null,
+                user.getUsername(),
+                toStringValue(pick.getPickId()),
+                toStringValue(profile != null ? profile.getProfileId() : null),
+                "received",
+                "收到新的撩一下",
+                StringUtils.isNotBlank(dto.getContent())
+                        ? user.getUsername() + " 向你发起了撩一下：" + dto.getContent()
+                        : user.getUsername() + " 向你发起了撩一下"
+        );
     }
 
+    @Transactional("appTransactionManager")
     public void updateRoommatePickState(Integer id, Integer state) throws DataNotExistException, NoAccessException {
         RoommatePickEntity entity = roommateMapper.selectRoommatePickById(id);
         if (entity == null) throw new DataNotExistException("该撩一下记录不存在");
@@ -186,6 +207,21 @@ public class RoommateService {
             msg.setRoommatePick(entity);
             msg.setState(0);
             roommateMapper.insertRoommateMessage(msg);
+            String nickname = entity.getRoommateProfile() != null && StringUtils.isNotBlank(entity.getRoommateProfile().getNickname())
+                    ? entity.getRoommateProfile().getNickname()
+                    : "对方";
+            boolean accepted = Integer.valueOf(1).equals(state);
+            interactionNotificationService.createInteractionNotification(
+                    "dating",
+                    accepted ? "pick_accepted" : "pick_rejected",
+                    entity.getUsername(),
+                    entity.getRoommateProfile() != null ? entity.getRoommateProfile().getUsername() : null,
+                    toStringValue(entity.getPickId()),
+                    toStringValue(entity.getRoommateProfile() != null ? entity.getRoommateProfile().getProfileId() : null),
+                    "sent",
+                    accepted ? "撩一下已通过" : "撩一下未通过",
+                    accepted ? nickname + " 通过了你的请求" : nickname + " 拒绝了你的请求"
+            );
             return;
         }
         throw new NoAccessException("该撩一下记录已处理，请勿重复提交");
@@ -270,5 +306,9 @@ public class RoommateService {
         vo.setCreateTime(e.getCreateTime());
         if (e.getRoommatePick() != null) vo.setRoommatePick(pickEntityToVO(e.getRoommatePick()));
         return vo;
+    }
+
+    private String toStringValue(Integer value) {
+        return value == null ? null : String.valueOf(value);
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
@@ -11,9 +11,9 @@ import java.util.List;
 
 public interface SecretMapper {
 
-    @Select("select sc.id,sc.content,sc.theme,sc.type,sc.timer,sc.state,sc.publish_time,count(scl.id) " +
+    @Select("select sc.id,sc.username,sc.content,sc.theme,sc.type,sc.timer,sc.state,sc.publish_time,count(scl.id) " +
             "as like_count from secret_content sc left outer join secret_like scl on sc.id=scl.content_id " +
-            "where sc.id=#{id} and state=0 group by sc.id,sc.content,sc.theme,sc.type,sc.timer,sc.state," +
+            "where sc.id=#{id} and state=0 group by sc.id,sc.username,sc.content,sc.theme,sc.type,sc.timer,sc.state," +
             "sc.publish_time,scl.id limit 1")
     @Results(id = "SecretContent", value = {
             @Result(property = "id", column = "id"),
@@ -89,6 +89,7 @@ public interface SecretMapper {
     void insertSecret(SecretContentEntity secretContent);
 
     @Insert("insert into secret_comment (content_id,username,comment,avatar_theme,publish_time) values(#{contentId},#{username},#{comment},#{avatarTheme},now())")
+    @Options(useGeneratedKeys = true, keyProperty = "id", keyColumn = "id")
     void insertSecretComment(SecretCommentEntity secretComment);
 
     @Insert("insert into secret_like (content_id,username,create_time) values(#{content_id},#{username},now())")

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -10,6 +10,7 @@ import cn.gdeiassistant.core.secret.pojo.entity.SecretCommentEntity;
 import cn.gdeiassistant.core.secret.pojo.entity.SecretContentEntity;
 import cn.gdeiassistant.core.secret.pojo.vo.SecretCommentVO;
 import cn.gdeiassistant.core.secret.pojo.vo.SecretVO;
+import cn.gdeiassistant.core.message.service.InteractionNotificationService;
 import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
 import cn.gdeiassistant.common.tools.SpringUtils.R2StorageService;
 import org.slf4j.Logger;
@@ -46,6 +47,9 @@ public class SecretService {
 
     @Autowired
     private R2StorageService r2StorageService;
+
+    @Autowired
+    private InteractionNotificationService interactionNotificationService;
 
     public List<SecretVO> getSecretInfo(int start, int size, String sessionId) throws Exception {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
@@ -149,6 +153,7 @@ public class SecretService {
         return entity.getId();
     }
 
+    @Transactional("appTransactionManager")
     public void addSecretComment(int id, String sessionId, String comment) throws Exception {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         SecretCommentEntity entity = new SecretCommentEntity();
@@ -157,12 +162,40 @@ public class SecretService {
         entity.setComment(comment);
         entity.setAvatarTheme((int) (Math.random() * 50));
         secretMapper.insertSecretComment(entity);
+        SecretContentEntity contentEntity = secretMapper.selectSecretByID(id);
+        interactionNotificationService.createInteractionNotification(
+                "secret",
+                "comment",
+                contentEntity != null ? contentEntity.getUsername() : null,
+                user.getUsername(),
+                String.valueOf(id),
+                entity.getId() == null ? null : String.valueOf(entity.getId()),
+                "comment",
+                "树洞收到新评论",
+                user.getUsername() + " 评论了你的树洞：" + comment
+        );
     }
 
+    @Transactional("appTransactionManager")
     public void changeUserLikeState(boolean like, int id, String sessionId) throws Exception {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         if (like) {
-            secretMapper.insertSecretLike(id, user.getUsername());
+            Integer existingLikeCount = secretMapper.selectSecretLike(id, user.getUsername());
+            if (existingLikeCount == null || existingLikeCount == 0) {
+                secretMapper.insertSecretLike(id, user.getUsername());
+                SecretContentEntity contentEntity = secretMapper.selectSecretByID(id);
+                interactionNotificationService.createInteractionNotification(
+                        "secret",
+                        "like",
+                        contentEntity != null ? contentEntity.getUsername() : null,
+                        user.getUsername(),
+                        String.valueOf(id),
+                        null,
+                        "like",
+                        "树洞收到新点赞",
+                        user.getUsername() + " 点赞了你的树洞"
+                );
+            }
         } else {
             secretMapper.deleteSecretLike(id, user.getUsername());
         }

--- a/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
@@ -2,6 +2,7 @@ package cn.gdeiassistant.core.topic.service;
 
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import cn.gdeiassistant.common.pojo.Entity.User;
+import cn.gdeiassistant.core.message.service.InteractionNotificationService;
 import cn.gdeiassistant.core.topic.converter.TopicConverter;
 import cn.gdeiassistant.core.topic.mapper.TopicMapper;
 import cn.gdeiassistant.core.topic.pojo.dto.TopicPublishDTO;
@@ -15,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +40,9 @@ public class TopicService {
 
     @Autowired
     private R2StorageService r2StorageService;
+
+    @Autowired
+    private InteractionNotificationService interactionNotificationService;
 
     public List<TopicVO> queryTopic(String sessionId, int start, int size) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
@@ -87,6 +92,7 @@ public class TopicService {
         return topicConverter.toVO(entity);
     }
 
+    @Transactional("appTransactionManager")
     public void likeTopic(int id, String sessionId) throws DataNotExistException {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         TopicEntity entity = topicMapper.selectTopicById(id, user.getUsername());
@@ -94,6 +100,17 @@ public class TopicService {
         TopicLikeEntity like = topicMapper.selectTopicLike(id, user.getUsername());
         if (like == null) {
             topicMapper.insertTopicLike(id, user.getUsername());
+            interactionNotificationService.createInteractionNotification(
+                    "topic",
+                    "like",
+                    entity.getUsername(),
+                    user.getUsername(),
+                    String.valueOf(id),
+                    null,
+                    "like",
+                    "话题收到新点赞",
+                    user.getUsername() + " 点赞了你的话题"
+            );
         }
     }
 


### PR DESCRIPTION
## Background

The previous unified interaction flow mainly relied on module-specific providers to scan historical tables and assemble messages on read. It did not have a real unified notification store or a usable global read/unread model.

At the same time, the Vue Info page did not have a stable list source for system notices/announcements, and the delivery completion flow had a mismatch between notification semantics and detail-page state.

## Goals

This PR focuses on the following:

- Introduce a real unified interaction notification model in the database
- Write notifications at the moment an interaction happens
- Switch the main unified interaction query path to the unified notification table
- Implement unified unread / read / readall
- Update the Vue Info page to consume real announcement and unified interaction data
- Fix a few low-cost contract gaps in related detail/user pages

## Unified Notification Model

This PR adds a new `interaction_notification` table with the following core fields:

- `notification_id`
- `module`
- `type`
- `receiver_username`
- `actor_username`
- `target_id`
- `target_sub_id`
- `target_type`
- `title`
- `content`
- `create_time`
- `is_read`

Backend changes:

- `GET /api/message/interaction/start/{start}/size/{size}` now reads directly from the unified notification table
- `GET /api/message/unread` returns the unified unread count
- `POST /api/message/id/{id}/read` marks one unified notification as read
- `POST /api/message/readall` marks all unified notifications for the current user as read

The response shape remains compatible with the current iOS interaction DTO:

- `id`
- `module`
- `type`
- `title`
- `content`
- `createdAt`
- `isRead`
- `targetType`
- `targetId`
- `targetSubId`

Notes:

- iOS already consumes the unified interaction list
- iOS has not been switched to unified unread/read/readall yet
- This PR does not backfill old business data into `interaction_notification`

## Integrated Social Modules

The following modules now write unified notifications directly at interaction time:

- `dating`
  - new pick request
  - accept / reject pick request
- `delivery`
  - order accepted
  - order finished
- `secret`
  - comment
  - like
- `express`
  - comment
  - like
  - guess
- `topic`
  - like
- `photograph`
  - comment
  - like

The following modules are still not part of unified interaction:

- `marketplace / ershou`
- `lostandfound`

Reason:

- there is no stable actor -> receiver interaction event source yet
- there is no reliable write point for a real notification event
- this PR does not force them into the unified model

## Vue Info Page

The Vue `Info.vue` page keeps the existing three-section structure:

- News / Reading
- System Notices / Announcements
- Interaction Messages

Changes:

- the interaction section now consumes the unified notification API
- clicking an interaction item attempts to mark it as read
- routing continues to pass `module / targetType / targetId / targetSubId / notificationId`
- the system notice section now uses the real announcement list endpoint: `/api/announcement/start/0/size/5`
- if the list is empty, it can still fall back to `information.list.notice`

Notes:

- Vue now uses the announcement list endpoint
- iOS still uses `/api/announcement` for the latest announcement plus `/api/information/list` for festival/reading aggregation
- iOS has not been switched to the announcement list/detail endpoints

## Delivery Order Completion Notification

This PR completes the delivery completion notification flow:

- a unified notification is written after `finishTrade(tradeId, sessionId)` succeeds
- `receiver`: the runner who accepted the order
- `actor`: the publisher who confirms completion
- `targetId`: `order_id`
- `targetSubId`: `trade_id`
- `targetType`: `accepted`
- `type`: `order_finished`

This PR also fixes the related detail-page semantics:

- finishing a trade now updates `delivery_order.state` to completed
- the completed order detail still returns `trade`
- opening an `order_finished` notification now lands on a consistent delivery detail state

## Announcement List / Detail Endpoints

This PR adds announcement list support without mixing announcements into `interaction_notification`.

Endpoints:

- `GET /api/announcement`
  - latest announcement
- `GET /api/announcement/start/{start}/size/{size}`
  - announcement list
- `GET /api/announcement/id/{id}`
  - announcement detail
- `GET /api/information/list`
  - keeps the existing aggregate response and now also includes `notices`

Notes:

- Vue currently uses the announcement list endpoint
- iOS has not switched to the announcement list/detail endpoints yet

## User-Page Gap Fixes

This PR also includes a few low-cost fixes:

- delivery detail stays consistent after order completion
- Vue `dating/center` now shows a fallback label when the backend does not provide a real publish time for "My Posts", instead of rendering an empty time field

## Build Results

Backend:

- Command: `./gradlew build`
- Result: passed

Frontend:

- Command: `cd frontend && npm run build`
- Result: passed

Notes:

- the frontend build still shows existing runtime asset warnings and large chunk warnings
- they do not block this PR

## Known Limitations

- iOS has not been switched to the announcement list endpoint yet
- iOS has not been switched to unified unread/read/readall yet
- `marketplace / ershou` and `lostandfound` are still not part of unified interaction
- this PR does not backfill historical interaction data into `interaction_notification`
- `topic` only writes like notifications for now; there is still no complete topic comment model in the current repository