### PR TITLE
fix: address news review follow-ups

### DIFF
--- a/frontend/src/views/news/NewsDetail.vue
+++ b/frontend/src/views/news/NewsDetail.vue
@@ -34,6 +34,62 @@ const displayDate = computed(() => detail.value?.publishDate || fallbackDate.val
 const displayContent = computed(() => detail.value?.content || '')
 const sourceUrl = computed(() => detail.value?.sourceUrl || '')
 
+function splitParagraphs(content) {
+  return content
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+}
+
+function parseAttachmentLine(line) {
+  const match = line.trim().match(/^(.*?)(https?:\/\/\S+)$/)
+  if (!match) {
+    return null
+  }
+  const url = match[2]
+  const title = match[1].trim().replace(/[：:]+$/, '') || '打开附件'
+  return { title, url }
+}
+
+const parsedContent = computed(() => {
+  const content = displayContent.value.trim()
+  if (!content) {
+    return { paragraphs: [], attachments: [] }
+  }
+
+  const markerMatch = content.match(/^([\s\S]*?)附件链接[：:]\s*([\s\S]*)$/)
+  if (!markerMatch) {
+    return {
+      paragraphs: splitParagraphs(content),
+      attachments: [],
+    }
+  }
+
+  const bodyText = markerMatch[1].trim()
+  const attachmentLines = markerMatch[2]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const attachments = attachmentLines
+    .map(parseAttachmentLine)
+    .filter(Boolean)
+
+  if (!attachments.length) {
+    return {
+      paragraphs: splitParagraphs(content),
+      attachments: [],
+    }
+  }
+
+  return {
+    paragraphs: splitParagraphs(bodyText),
+    attachments,
+  }
+})
+
+const contentParagraphs = computed(() => parsedContent.value.paragraphs)
+const attachmentItems = computed(() => parsedContent.value.attachments)
+
 async function loadDetail() {
   loading.value = true
   error.value = ''
@@ -89,8 +145,34 @@ onMounted(() => {
         >
           打开原文链接
         </a>
-        <p v-if="displayContent" class="news-detail-content">{{ displayContent }}</p>
-        <p v-else class="news-detail-empty">暂无详细内容</p>
+        <div v-if="contentParagraphs.length" class="news-detail-content">
+          <p
+            v-for="(paragraph, index) in contentParagraphs"
+            :key="`paragraph-${index}`"
+            class="news-detail-paragraph"
+          >
+            {{ paragraph }}
+          </p>
+        </div>
+        <div v-if="attachmentItems.length" class="news-detail-attachments">
+          <p class="news-detail-attachment-title">附件链接</p>
+          <a
+            v-for="(item, index) in attachmentItems"
+            :key="`attachment-${index}`"
+            :href="item.url"
+            class="news-detail-attachment-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ item.title }}
+          </a>
+        </div>
+        <p
+          v-if="!contentParagraphs.length && !attachmentItems.length"
+          class="news-detail-empty"
+        >
+          暂无详细内容
+        </p>
       </div>
     </div>
   </div>
@@ -190,10 +272,44 @@ onMounted(() => {
   color: #333;
   font-size: 15px;
   line-height: 1.9;
-  white-space: pre-wrap;
 }
 
 .news-detail-empty {
   color: #999;
+}
+
+.news-detail-paragraph {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.news-detail-paragraph + .news-detail-paragraph {
+  margin-top: 16px;
+}
+
+.news-detail-attachments {
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 14px;
+  background: #f4fbf8;
+}
+
+.news-detail-attachment-title {
+  margin: 0 0 10px;
+  color: #0f8f5f;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.news-detail-attachment-link {
+  display: block;
+  color: #0f8f5f;
+  text-decoration: none;
+  line-height: 1.7;
+  word-break: break-all;
+}
+
+.news-detail-attachment-link + .news-detail-attachment-link {
+  margin-top: 8px;
 }
 </style>

--- a/src/main/java/cn/gdeiassistant/core/information/service/schoolnews/SchoolNewsCornService.java
+++ b/src/main/java/cn/gdeiassistant/core/information/service/schoolnews/SchoolNewsCornService.java
@@ -114,7 +114,7 @@ public class SchoolNewsCornService {
                 }
 
                 try {
-                    NewInfo newInfo = buildNewsItem(type, item, linkElement, detailUrl, id);
+                    NewInfo newInfo = buildNewsItem(type, item, linkElement, detailUrl, id, existing);
                     if (newInfo != null && shouldSaveNews(existing, newInfo)) {
                         resultMap.put(id, newInfo);
                         pageChangedCount++;
@@ -133,15 +133,16 @@ public class SchoolNewsCornService {
         }
     }
 
-    private NewInfo buildNewsItem(int type, Element listItem, Element linkElement, String detailUrl, String id)
+    private NewInfo buildNewsItem(int type, Element listItem, Element linkElement, String detailUrl, String id,
+            NewInfo existing)
             throws Exception {
         String fallbackTitle = firstNonBlank(linkElement.attr("title"), linkElement.text(), "新闻通知");
-        Date publishDate = toDate(parsePublishDate(extractPublishDateText(listItem)));
         String content = "暂无详细内容";
         String title = fallbackTitle;
+        Document detailPage = null;
 
         if (isArticlePage(detailUrl)) {
-            Document detailPage = newsClient.fetchPage(detailUrl);
+            detailPage = newsClient.fetchPage(detailUrl);
             title = firstNonBlank(
                     extractText(detailPage.selectFirst(".arti_title")),
                     detailPage.title(),
@@ -151,6 +152,7 @@ public class SchoolNewsCornService {
         } else {
             content = buildAttachmentContent(detailUrl, fallbackTitle);
         }
+        Date publishDate = resolvePublishDate(extractPublishDateText(listItem), detailPage, existing);
 
         NewInfo newInfo = new NewInfo();
         newInfo.setId(id);
@@ -194,7 +196,32 @@ public class SchoolNewsCornService {
         return listItem.text();
     }
 
+    private String extractDetailPublishDateText(Document detailPage) {
+        return firstNonBlank(
+                extractText(detailPage.selectFirst(".arti_metas .arti_update")),
+                extractText(detailPage.selectFirst(".arti_update")),
+                extractText(detailPage.selectFirst(".arti_metas")),
+                extractText(detailPage.selectFirst(".article-info")),
+                extractText(detailPage.selectFirst(".article_info")),
+                extractText(detailPage.selectFirst(".meta"))
+        );
+    }
+
+    private Date resolvePublishDate(String listDateText, Document detailPage, NewInfo existing) {
+        LocalDate publishDate = parsePublishDate(listDateText);
+        if (publishDate == null && detailPage != null) {
+            publishDate = parsePublishDate(extractDetailPublishDateText(detailPage));
+        }
+        if (publishDate != null) {
+            return toDate(publishDate);
+        }
+        return existing == null ? null : existing.getPublishDate();
+    }
+
     private LocalDate parsePublishDate(String text) {
+        if (text == null || text.trim().isEmpty()) {
+            return null;
+        }
         Matcher matcher = DATE_PATTERN.matcher(text);
         if (matcher.find()) {
             try {
@@ -202,10 +229,13 @@ public class SchoolNewsCornService {
             } catch (DateTimeParseException ignored) {
             }
         }
-        return LocalDate.now();
+        return null;
     }
 
     private Date toDate(LocalDate localDate) {
+        if (localDate == null) {
+            return null;
+        }
         return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 


### PR DESCRIPTION
## Summary
- preserve the stored publish date when a list item date cannot be parsed instead of falling back to today
- render attachment-only news content as clickable links in the H5 detail page

## Verification
- ./gradlew compileJava
- npm run build