### PR TITLE
fix: update backend web frontend to unified API routes

### DIFF
--- a/frontend/src/api/book.js
+++ b/frontend/src/api/book.js
@@ -1,38 +1,38 @@
 import request from '@/utils/request'
 
 /**
- * 馆藏检索。GET /api/book/search?keyword=xxx&page=1
+ * 馆藏检索。GET /api/library/search?keyword=xxx&page=1
  * @param {string} keyword
  * @param {number} [page=1]
  * @returns {Promise<{ success: boolean, data: { list: Array<Collection>, sumPage: number } }>} Collection: bookname, author, publishingHouse, detailURL
  */
 export function searchBooks(keyword, page = 1) {
-  return request.get('/book/search', { params: { keyword, page } })
+  return request.get('/library/search', { params: { keyword, page } })
 }
 
 /**
- * 馆藏详情。GET /api/book/detail?detailURL=xxx
+ * 馆藏详情。GET /api/library/detail?detailURL=xxx
  * @param {string} detailURL
  * @returns {Promise<{ success: boolean, data: CollectionDetail }>} 含 collectionDistributionList
  */
 export function getBookDetail(detailURL) {
-  return request.get('/book/detail', { params: { detailURL } })
+  return request.get('/library/detail', { params: { detailURL } })
 }
 
 /**
- * 我的借阅。GET /api/book/borrow
+ * 我的借阅。GET /api/library/borrow
  * @param {string} [password] 正常账号可传图书馆密码
  * @returns {Promise<{ success: boolean, data: Array<Book> }>} Book: name, author, borrowDate, returnDate, renewTime, id, sn, code
  */
 export function getBorrowedBooks(password) {
   const config = password ? { params: { password } } : {}
-  return request.get('/book/borrow', config)
+  return request.get('/library/borrow', config)
 }
 
 /**
- * 续借。POST /api/book/renew，body: { sn, code, password }，password 为图书馆密码（高危二次核验）
+ * 续借。POST /api/library/renew，body: { sn, code, password }，password 为图书馆密码（高危二次核验）
  * @param {object} payload - { sn, code, password }
  */
 export function renewBook(payload) {
-  return request.post('/book/renew', payload)
+  return request.post('/library/renew', payload)
 }

--- a/frontend/src/api/collection.js
+++ b/frontend/src/api/collection.js
@@ -2,29 +2,29 @@ import request from '@/utils/request'
 
 /**
  * 馆藏全局检索
- * GET /api/collection/search?keyword=xxx&page=1
+ * GET /api/library/search?keyword=xxx&page=1
  * @param {string} keyword - 搜索关键字
  * @param {number} [page=1] - 页码
  * @returns {Promise<{ success: boolean, data: { sumPage: number, collectionList: Array } }>}
  */
 export function searchBooks(keyword, page = 1) {
-  return request.get('/collection/search', {
+  return request.get('/library/search', {
     params: { keyword, page }
   })
 }
 
 /**
- * 馆藏详情。GET /api/collection/detail?detailURL=xxx
+ * 馆藏详情。GET /api/library/detail?detailURL=xxx
  * @param {string} detailURL
  * @returns {Promise<{ success: boolean, data: CollectionDetail }>} 含 collectionDistributionList
  */
 export function getCollectionDetail(detailURL) {
-  return request.get('/collection/detail', { params: { detailURL } })
+  return request.get('/library/detail', { params: { detailURL } })
 }
 
 /**
  * 查询我的借阅
- * GET /api/collection/borrow?password=xxx（测试账号可省略）
+ * GET /api/library/borrow?password=xxx（测试账号可省略）
  * @param {string} [password] - 图书馆密码，正常账号必填
  * @returns {Promise<{ success: boolean, data: Array<Book> }>} data 为借阅列表，字段 name, author, borrowDate, returnDate, renewTime, sn, code, id
  */
@@ -32,17 +32,14 @@ export function getBorrowedBooks(password) {
   const config = password != null && password !== ''
     ? { params: { password } }
     : {}
-  return request.get('/collection/borrow', config)
+  return request.get('/library/borrow', config)
 }
 
 /**
  * 图书续借
- * POST /api/collection/renew，参数 sn、code
- * @param {string} sn - 续借 SN
- * @param {string} code - 续借 Code
+ * POST /api/library/renew，body: { sn, code, password }
+ * @param {object} payload - { sn, code, password }
  */
-export function renewBook(sn, code) {
-  return request.post('/collection/renew', null, {
-    params: { sn, code }
-  })
+export function renewBook(payload) {
+  return request.post('/library/renew', payload)
 }

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -72,9 +72,9 @@ export function updateNickname(data) {
 
 /**
  * 获取地区字典树（后端代码，用于所在地/家乡选择器）
- * GET /api/locationList
+ * GET /api/profile/locations
  * @returns {Promise<{ success, data: Array<{ code, name, stateMap: Object }> }>}
  */
 export function getLocationList() {
-  return request.get('/locationList')
+  return request.get('/profile/locations')
 }

--- a/frontend/src/views/Info.vue
+++ b/frontend/src/views/Info.vue
@@ -195,7 +195,7 @@ function markInteractionItemRead(item) {
   }
   item.isRead = true
   interactionUnreadCount.value = Math.max(0, Number(interactionUnreadCount.value || 0) - 1)
-  request.post(`/message/id/${item.id}/read`).catch(() => {})
+  request.post(`/information/message/id/${item.id}/read`).catch(() => {})
 }
 
 function handleInteractionSelect(item) {
@@ -215,7 +215,7 @@ function handleMarkAllInteractionsRead() {
     ...item,
     isRead: true
   }))
-  request.post('/message/readall').catch(() => {
+  request.post('/information/message/readall').catch(() => {
     loadInfoPage()
   })
 }
@@ -227,10 +227,10 @@ async function loadInfoPage() {
   }
   try {
     const [announcementRes, informationRes, interactionRes, unreadRes] = await Promise.allSettled([
-      request.get('/announcement/start/0/size/5'),
-      request.get('/information/list'),
-      request.get('/message/interaction/start/0/size/20'),
-      request.get('/message/unread')
+      request.get('/information/announcement/start/0/size/5'),
+      request.get('/information/overview'),
+      request.get('/information/message/interaction/start/0/size/20'),
+      request.get('/information/message/unread')
     ])
 
     if (announcementRes.status === 'fulfilled' && announcementRes.value?.success) {

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -282,7 +282,7 @@ const updateMajorListByFaculty = () => {
 // 年份列表
 const yearList = ref([])
 
-// 所在地/家乡：使用后端 GET /api/locationList 返回的代码树（value=code，label=中文名）
+// 所在地/家乡：使用后端 GET /api/profile/locations 返回的代码树（value=code，label=中文名）
 const locationListTree = ref([])
 const locationFlatOptions = ref([])
 const locationFlatMap = ref({})

--- a/frontend/src/views/news/NewsDetail.vue
+++ b/frontend/src/views/news/NewsDetail.vue
@@ -94,7 +94,7 @@ async function loadDetail() {
   loading.value = true
   error.value = ''
   try {
-    const res = await request.get(`/news/id/${route.params.id}`)
+    const res = await request.get(`/information/news/id/${route.params.id}`)
     detail.value = res?.data ?? null
     if (!detail.value) {
       error.value = '未找到对应的新闻通知'

--- a/frontend/src/views/news/NewsList.vue
+++ b/frontend/src/views/news/NewsList.vue
@@ -100,7 +100,7 @@ function loadNews() {
   const start = (page.value - 1) * PAGE_SIZE
   const type = activeType.value
   request
-    .get(`/news/type/${type}/start/${start}/size/${PAGE_SIZE}`)
+    .get(`/information/news/type/${type}/start/${start}/size/${PAGE_SIZE}`)
     .then((res) => {
       const list = res?.data ?? []
       const mapped = list.map((item) => ({


### PR DESCRIPTION
## Background
PR #66 unified the backend contracts, but the web frontend inside this repository was still calling several old routes.

## Changes
- migrate library requests from the old `/api/book/*` and `/api/collection/*` routes to `/api/library/*`
- migrate info center requests to the unified `/api/information/*` routes
- migrate news list and detail requests to `/api/information/news/*`
- migrate profile location dictionary requests to `/api/profile/locations`
- keep this follow-up scoped to the web frontend in this repository without reintroducing compatibility aliases

## Files
- `frontend/src/api/book.js`
- `frontend/src/api/collection.js`
- `frontend/src/views/Info.vue`
- `frontend/src/views/news/NewsList.vue`
- `frontend/src/views/news/NewsDetail.vue`
- `frontend/src/api/user.js`
- `frontend/src/views/Profile.vue`

## Verification
- `./gradlew --console=plain --no-daemon test`
- `cd frontend && npm run build`