### PR TITLE
feat: unify community UI with shared design system

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,9 +1,46 @@
 <script setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const COMMUNITY_PREFIXES = ['/ershou', '/lostandfound', '/secret', '/express', '/topic', '/delivery', '/dating', '/photograph']
+
+const transitionName = computed(() => {
+  const p = route.path
+  return COMMUNITY_PREFIXES.some(prefix => p === prefix || p.startsWith(prefix + '/'))
+    ? 'community-fade'
+    : ''
+})
 </script>
 
 <template>
-  <router-view></router-view>
+  <router-view v-slot="{ Component }">
+    <transition :name="transitionName" mode="out-in">
+      <component :is="Component" />
+    </transition>
+  </router-view>
 </template>
 
 <style scoped>
+.community-fade-enter-active {
+  animation: community-page-in 0.25s ease;
+}
+.community-fade-leave-active {
+  animation: community-page-out 0.15s ease;
+}
+@keyframes community-page-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes community-page-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
 </style>

--- a/frontend/src/components/community/CommunityHeader.vue
+++ b/frontend/src/components/community/CommunityHeader.vue
@@ -1,0 +1,103 @@
+<script setup>
+import { useRouter } from 'vue-router'
+
+const props = defineProps({
+  /** 页面标题 */
+  title: { type: String, default: '' },
+  /** 模块主色 */
+  moduleColor: { type: String, default: '#6366f1' },
+  /** 返回目标路径，默认 / */
+  backTo: { type: String, default: '/' },
+  /** 是否显示返回按钮 */
+  showBack: { type: Boolean, default: true }
+})
+
+const emit = defineEmits(['back'])
+const router = useRouter()
+
+function handleBack() {
+  emit('back')
+  if (props.backTo) {
+    router.push(props.backTo)
+  }
+}
+</script>
+
+<template>
+  <div class="community-header" :style="{ '--module-color': moduleColor }">
+    <div class="community-header__accent"></div>
+    <div class="community-header__content">
+      <span
+        v-if="showBack"
+        class="community-header__back"
+        @click="handleBack"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="15 18 9 12 15 6"/>
+        </svg>
+      </span>
+      <h1 class="community-header__title">{{ title }}</h1>
+      <span class="community-header__right">
+        <slot name="right" />
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.community-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: #fff;
+}
+
+.community-header__accent {
+  height: 3px;
+  background: linear-gradient(90deg, var(--module-color), var(--module-color));
+  background: linear-gradient(90deg, var(--module-color), color-mix(in srgb, var(--module-color) 60%, white));
+}
+
+.community-header__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 48px;
+  padding: 0 var(--space-md, 12px);
+  border-bottom: 1px solid var(--c-border, #f3f4f6);
+}
+
+.community-header__back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--c-text-1, #1f2937);
+  transition: background 0.2s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.community-header__back:active {
+  background: var(--c-bg, #f9fafb);
+}
+
+.community-header__title {
+  flex: 1;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--c-text-1, #1f2937);
+  letter-spacing: 0.5px;
+}
+
+.community-header__right {
+  min-width: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+</style>

--- a/frontend/src/components/community/CommunityTabbar.vue
+++ b/frontend/src/components/community/CommunityTabbar.vue
@@ -1,0 +1,111 @@
+<script setup>
+import { computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+const props = defineProps({
+  /** 模块基础路径，如 '/ershou' */
+  basePath: { type: String, required: true },
+  /** 模块主色，如 '#10b981' */
+  moduleColor: { type: String, default: '#6366f1' },
+  /** Tab 配置列表 [{key, label, path, icon}] */
+  tabs: { type: Array, required: true }
+})
+
+const router = useRouter()
+const route = useRoute()
+
+const activeTab = computed(() => {
+  const p = route.path
+  for (const tab of props.tabs) {
+    if (p.includes(tab.path)) return tab.key
+  }
+  return props.tabs[0]?.key || ''
+})
+
+function goTo(path) {
+  router.push(path)
+}
+</script>
+
+<template>
+  <div class="community-tabbar" :style="{ '--module-color': moduleColor }">
+    <a
+      v-for="tab in tabs"
+      :key="tab.key"
+      href="javascript:;"
+      class="community-tabbar__item"
+      :class="{ active: activeTab === tab.key }"
+      @click.prevent="goTo(tab.path)"
+    >
+      <i class="community-tabbar__icon" v-html="tab.icon"></i>
+      <p class="community-tabbar__label">{{ tab.label }}</p>
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.community-tabbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 56px;
+  background: #fff;
+  border-top: 1px solid #f3f4f6;
+  display: flex;
+  z-index: 500;
+  box-shadow: 0 -1px 8px rgba(0, 0, 0, 0.04);
+}
+
+.community-tabbar__item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #9ca3af;
+  text-decoration: none;
+  font-size: 12px;
+  padding: 6px 0;
+  transition: color 0.25s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.community-tabbar__item.active {
+  color: var(--module-color, #6366f1);
+}
+
+.community-tabbar__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin-bottom: 3px;
+  transition: transform 0.25s ease, color 0.25s ease;
+}
+
+.community-tabbar__item.active .community-tabbar__icon {
+  transform: scale(1.1);
+  color: var(--module-color, #6366f1);
+}
+
+.community-tabbar__icon :deep(svg) {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+}
+
+.community-tabbar__label {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1;
+  color: inherit;
+  font-weight: 400;
+}
+
+.community-tabbar__item.active .community-tabbar__label {
+  font-weight: 500;
+}
+</style>

--- a/frontend/src/constants/features.js
+++ b/frontend/src/constants/features.js
@@ -10,8 +10,10 @@ export const ALL_FEATURES = [
   { id: 'spare', name: '教室查询', icon: 'icon-spare', path: '/spare', defaultVisible: true },
   { id: 'collection', name: '图书馆', icon: 'icon-collection', path: '/library', defaultVisible: true },
   { id: 'card', name: '校园卡', icon: 'icon-card', path: '/card', defaultVisible: true },
+  { id: 'pe', name: '体测查询', icon: 'icon-pe', path: '/pe', defaultVisible: true },
   { id: 'data', name: '数据查询', icon: 'icon-data', path: '/data', defaultVisible: true },
   { id: 'evaluate', name: '教学评价', icon: 'icon-evaluate', path: '/evaluate', defaultVisible: true },
+  { id: 'about', name: '关于应用', icon: 'icon-about', path: '/about', defaultVisible: true },
   { id: 'ershou', name: '二手交易', icon: 'icon-ershou', path: '/ershou', defaultVisible: true },
   { id: 'delivery', name: '全民快递', icon: 'icon-delivery', path: '/delivery', defaultVisible: true },
   { id: 'lostandfound', name: '失物招领', icon: 'icon-lostandfound', path: '/lostandfound', defaultVisible: true },
@@ -41,4 +43,6 @@ export const FEATURE_ICON_SRC = {
   dating: '/img/function/dating.png',
   topic: '/img/function/topic.png',
   delivery: '/img/function/delivery.png',
+  pe: '/img/function/pe.png',
+  about: '/img/function/about.png',
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,7 @@
 import 'weui'
 import { createApp } from 'vue'
 import './style.css'
+import './styles/community-theme.css'
 import App from './App.vue'
 import router from './router'
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -132,6 +132,12 @@ const routes = [
     name: 'CetSave',
     component: CetSave
   },
+  // 旧路由兼容重定向：/collection/* → /library/*, /book → /library/borrow
+  { path: '/collection', redirect: '/library' },
+  { path: '/collection/search', redirect: '/library/search' },
+  { path: '/collection/list', redirect: '/library/list' },
+  { path: '/collection/detail', redirect: '/library/detail' },
+  { path: '/book', redirect: '/library/borrow' },
   {
     path: '/library',
     name: 'Collection',

--- a/frontend/src/styles/community-theme.css
+++ b/frontend/src/styles/community-theme.css
@@ -1,0 +1,407 @@
+/* ============================================================
+   社区功能统一设计令牌 (Community Design Tokens)
+   仅作用于社区模块，不影响教务系统/主系统的 WeUI 样式
+   ============================================================ */
+
+:root {
+  /* 模块专属色 */
+  --c-ershou: #10b981;
+  --c-lostandfound: #3b82f6;
+  --c-secret: #8b5cf6;
+  --c-express: #f43f5e;
+  --c-topic: #6366f1;
+  --c-delivery: #f59e0b;
+  --c-dating: #ec4899;
+  --c-photograph: #06b6d4;
+
+  /* 中性色 */
+  --c-text-1: #1f2937;
+  --c-text-2: #4b5563;
+  --c-text-3: #9ca3af;
+  --c-bg: #f9fafb;
+  --c-card: #ffffff;
+  --c-border: #f3f4f6;
+  --c-divider: #e5e7eb;
+
+  /* 圆角 */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-full: 9999px;
+
+  /* 阴影 */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.02);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
+
+  /* 间距 */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+
+  /* 字号 */
+  --font-xs: 11px;
+  --font-sm: 12px;
+  --font-base: 14px;
+  --font-md: 15px;
+  --font-lg: 16px;
+  --font-xl: 18px;
+  --font-2xl: 20px;
+}
+
+/* ============================================================
+   社区页面基础样式
+   ============================================================ */
+
+.community-page {
+  min-height: 100vh;
+  background-color: var(--c-bg);
+}
+
+.community-page *,
+.community-page *::before,
+.community-page *::after {
+  box-sizing: border-box;
+}
+
+/* ============================================================
+   社区卡片
+   ============================================================ */
+
+.community-card {
+  background: var(--c-card);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.community-card:active {
+  transform: scale(0.985);
+  box-shadow: var(--shadow-md);
+}
+
+/* ============================================================
+   图片网格
+   ============================================================ */
+
+.community-image-grid {
+  display: grid;
+  gap: 4px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.community-image-grid[data-count="1"] {
+  grid-template-columns: 1fr;
+  max-width: 70%;
+}
+
+.community-image-grid[data-count="2"] {
+  grid-template-columns: 1fr 1fr;
+}
+
+.community-image-grid[data-count="3"],
+.community-image-grid[data-count="4"],
+.community-image-grid[data-count="5"],
+.community-image-grid[data-count="6"],
+.community-image-grid[data-count="7"],
+.community-image-grid[data-count="8"],
+.community-image-grid[data-count="9"] {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.community-image-grid .grid-image-item {
+  position: relative;
+  aspect-ratio: 1;
+  overflow: hidden;
+  background: #f0f0f0;
+  cursor: pointer;
+}
+
+.community-image-grid[data-count="1"] .grid-image-item {
+  aspect-ratio: auto;
+}
+
+.community-image-grid .grid-image-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: opacity 0.3s ease;
+}
+
+.community-image-grid[data-count="1"] .grid-image-item img {
+  height: auto;
+  max-height: 400px;
+  object-fit: contain;
+}
+
+/* ============================================================
+   加载状态
+   ============================================================ */
+
+.community-loading-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--c-border);
+  border-top-color: var(--module-color, var(--c-topic));
+  border-radius: 50%;
+  animation: community-spin 0.8s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+@keyframes community-spin {
+  to { transform: rotate(360deg); }
+}
+
+.community-loadmore {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  gap: var(--space-sm);
+  color: var(--c-text-3);
+  font-size: var(--font-base);
+}
+
+/* ============================================================
+   下拉刷新
+   ============================================================ */
+
+.community-pull-refresh {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  transition: height 0.3s ease;
+}
+
+.community-pull-refresh__text {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--font-base);
+  color: var(--c-text-3);
+}
+
+/* ============================================================
+   空状态
+   ============================================================ */
+
+.community-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px var(--space-xl);
+  color: var(--c-text-3);
+}
+
+.community-empty__icon {
+  font-size: 48px;
+  margin-bottom: var(--space-lg);
+  opacity: 0.5;
+}
+
+.community-empty__text {
+  font-size: var(--font-md);
+  margin-bottom: var(--space-xl);
+}
+
+.community-empty__action {
+  padding: 8px 24px;
+  border-radius: var(--radius-full);
+  border: none;
+  font-size: var(--font-base);
+  font-weight: 500;
+  color: #fff;
+  background: var(--module-color, var(--c-topic));
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.community-empty__action:active {
+  opacity: 0.85;
+}
+
+/* ============================================================
+   对话框 (覆盖 WeUI Dialog 以匹配社区风格)
+   ============================================================ */
+
+.community-dialog-mask {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 1000;
+  animation: community-fade-in 0.2s ease;
+}
+
+.community-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 85%;
+  max-width: 320px;
+  background: var(--c-card);
+  border-radius: var(--radius-lg);
+  z-index: 1001;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+  animation: community-scale-in 0.2s ease;
+}
+
+.community-dialog__title {
+  padding: 20px 20px 8px;
+  text-align: center;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--c-text-1);
+}
+
+.community-dialog__body {
+  padding: 8px 20px 20px;
+  text-align: center;
+  font-size: var(--font-md);
+  color: var(--c-text-2);
+  line-height: 1.5;
+}
+
+.community-dialog__footer {
+  display: flex;
+  border-top: 1px solid var(--c-border);
+}
+
+.community-dialog__btn {
+  flex: 1;
+  padding: 14px 0;
+  text-align: center;
+  font-size: var(--font-lg);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s;
+  border: none;
+  background: none;
+}
+
+.community-dialog__btn:active {
+  background: var(--c-bg);
+}
+
+.community-dialog__btn--cancel {
+  color: var(--c-text-2);
+  border-right: 1px solid var(--c-border);
+}
+
+.community-dialog__btn--confirm {
+  color: var(--module-color, var(--c-topic));
+  font-weight: 500;
+}
+
+/* ============================================================
+   图片预览
+   ============================================================ */
+
+.community-lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.92);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  animation: community-fade-in 0.2s ease;
+}
+
+.community-lightbox img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+/* ============================================================
+   动画
+   ============================================================ */
+
+@keyframes community-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes community-scale-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@keyframes community-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes community-like-bounce {
+  0%, 100% { transform: scale(1.2); }
+  50% { transform: scale(1.5); }
+}
+
+/* ============================================================
+   骨架屏 (Skeleton Loading)
+   ============================================================ */
+
+.community-skeleton {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: community-shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+.community-skeleton--circle {
+  border-radius: 50%;
+}
+
+.community-skeleton--text {
+  height: 14px;
+  margin-bottom: 8px;
+}
+
+.community-skeleton--text:last-child {
+  width: 60%;
+}
+
+.community-skeleton--image {
+  aspect-ratio: 1;
+  border-radius: var(--radius-sm);
+}
+
+@keyframes community-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* ============================================================
+   图片懒加载淡入
+   ============================================================ */
+
+.community-img-lazy {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.community-img-lazy.loaded {
+  opacity: 1;
+}

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -4,15 +4,50 @@ import { onMounted, onActivated, ref, computed } from 'vue'
 import { ALL_FEATURES, FEATURE_ICON_SRC } from '@/constants/features'
 
 const STORAGE_KEY = 'user_features_config'
+const MIGRATION_KEY = 'user_features_migrated_v2'
 
 const router = useRouter()
+
+/**
+ * 迁移旧版 feature toggle 配置：
+ * - 旧版 id `book` / `cardInfo` 已合并到 `collection`（图书馆）/ `card`（校园卡），
+ *   如果用户曾隐藏 book 或 collection 之一，合并后的入口不应被意外隐藏，重置为可见。
+ * - 移除已废弃的旧 id 键，避免残留数据干扰。
+ */
+function migrateFeatureConfig(config) {
+  if (!config || typeof config !== 'object') return config
+  if (localStorage.getItem(MIGRATION_KEY)) return config
+
+  const oldLibraryIds = ['book', 'collection']
+  const oldCardIds = ['cardInfo', 'card']
+  const hasOldLibrary = oldLibraryIds.some((k) => k in config)
+  const hasOldCard = oldCardIds.some((k) => k in config)
+
+  if (hasOldLibrary) {
+    // 只要任一旧入口曾可见，合并后保持可见
+    const anyVisible = oldLibraryIds.some((k) => config[k] !== false)
+    config['collection'] = anyVisible
+    delete config['book']
+  }
+  if (hasOldCard) {
+    const anyVisible = oldCardIds.some((k) => config[k] !== false)
+    config['card'] = anyVisible
+    delete config['cardInfo']
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
+  localStorage.setItem(MIGRATION_KEY, '1')
+  return config
+}
 
 // 从 localStorage 实时读取功能开关；无配置时按 defaultVisible 兜底显示
 const featuresConfig = ref(null)
 function loadFeaturesConfig() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    featuresConfig.value = raw ? JSON.parse(raw) : {}
+    let config = raw ? JSON.parse(raw) : {}
+    config = migrateFeatureConfig(config)
+    featuresConfig.value = config
   } catch (_) {
     featuresConfig.value = {}
   }
@@ -36,7 +71,7 @@ const visibleMenuList = computed(() => {
   }))
 })
 
-const SERVICE_FEATURE_IDS = new Set(['grade', 'schedule', 'cet', 'kaoyan', 'spare', 'collection', 'card', 'data', 'evaluate'])
+const SERVICE_FEATURE_IDS = new Set(['grade', 'schedule', 'cet', 'kaoyan', 'spare', 'collection', 'card', 'pe', 'data', 'evaluate', 'about'])
 const LIFE_FEATURE_IDS = new Set(['ershou', 'delivery', 'lostandfound', 'secret', 'dating', 'express', 'topic', 'photograph'])
 
 const featureSections = computed(() => {

--- a/frontend/src/views/dating/Center.vue
+++ b/frontend/src/views/dating/Center.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -182,12 +183,8 @@ watch(() => route.fullPath, () => {
 </script>
 
 <template>
-  <div class="dating-center">
-    <div class="dating-header unified-header">
-      <span class="dating-header__back" @click="router.back()">返回</span>
-      <h1 class="dating-header__title">互动中心</h1>
-      <span class="dating-header__placeholder"></span>
-    </div>
+  <div class="community-page dating-center">
+    <CommunityHeader title="互动中心" moduleColor="#ec4899" backTo="/dating/home" />
 
     <!-- 顶部 Tabs -->
     <div class="dating-tabs">
@@ -213,13 +210,17 @@ watch(() => route.fullPath, () => {
 
     <!-- Tab 1: 收到的撩 -->
     <div v-if="activeTab === 0" class="dating-content">
-      <div v-if="loading" class="dating-loading">加载中...</div>
-      <div v-else-if="receivedList.length === 0" class="dating-empty">暂无收到的请求</div>
+      <div v-if="loading" class="community-loadmore"><i class="community-loading-spinner" style="--module-color: #ec4899"></i> 加载中</div>
+      <div v-else-if="receivedList.length === 0" class="community-empty">
+        <div class="community-empty__icon">💕</div>
+        <div class="community-empty__text">暂无收到的请求</div>
+      </div>
       <div v-else class="dating-list">
         <div
-          v-for="item in receivedList"
+          v-for="(item, index) in receivedList"
           :key="item.id"
-          class="dating-card"
+          class="community-card dating-card"
+          :style="{ animationDelay: (index % 10) * 0.05 + 's' }"
         >
           <div class="dating-card__header">
             <img :src="item.avatar || '/img/dating/default-avatar.png'" class="dating-card__avatar" />
@@ -245,13 +246,17 @@ watch(() => route.fullPath, () => {
 
     <!-- Tab 2: 我发出的 -->
     <div v-if="activeTab === 1" class="dating-content">
-      <div v-if="loading" class="dating-loading">加载中...</div>
-      <div v-else-if="sentList.length === 0" class="dating-empty">暂无发出的请求</div>
+      <div v-if="loading" class="community-loadmore"><i class="community-loading-spinner" style="--module-color: #ec4899"></i> 加载中</div>
+      <div v-else-if="sentList.length === 0" class="community-empty">
+        <div class="community-empty__icon">💕</div>
+        <div class="community-empty__text">暂无发出的请求</div>
+      </div>
       <div v-else class="dating-list">
         <div
-          v-for="item in sentList"
+          v-for="(item, index) in sentList"
           :key="item.id"
-          class="dating-card"
+          class="community-card dating-card"
+          :style="{ animationDelay: (index % 10) * 0.05 + 's' }"
         >
           <div class="dating-card__header">
             <img :src="item.targetAvatar || item.targetImage || '/img/dating/default-avatar.png'" class="dating-card__avatar" />
@@ -276,13 +281,17 @@ watch(() => route.fullPath, () => {
 
     <!-- Tab 3: 我的发布 -->
     <div v-if="activeTab === 2" class="dating-content">
-      <div v-if="loading" class="dating-loading">加载中...</div>
-      <div v-else-if="postsList.length === 0" class="dating-empty">暂无发布</div>
+      <div v-if="loading" class="community-loadmore"><i class="community-loading-spinner" style="--module-color: #ec4899"></i> 加载中</div>
+      <div v-else-if="postsList.length === 0" class="community-empty">
+        <div class="community-empty__icon">💕</div>
+        <div class="community-empty__text">暂无发布</div>
+      </div>
       <div v-else class="dating-list">
         <div
-          v-for="item in postsList"
+          v-for="(item, index) in postsList"
           :key="item.id"
-          :class="['dating-card', 'dating-card--post']"
+          class="community-card dating-card dating-card--post"
+          :style="{ animationDelay: (index % 10) * 0.05 + 's' }"
         >
           <img :src="(item.images && item.images[0]) || item.image || '/img/dating/default-avatar.png'" class="dating-card__thumb" />
           <div class="dating-card__body">
@@ -295,23 +304,23 @@ watch(() => route.fullPath, () => {
     </div>
 
     <!-- 提示对话框 -->
-    <div v-if="dialogVisible" class="weui-mask" @click="dialogVisible = false"></div>
-    <div v-if="dialogVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div v-if="dialogVisible" class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div v-if="dialogVisible" class="community-dialog" style="--module-color: #ec4899">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
 
     <!-- 隐藏确认对话框 -->
-    <div v-if="deleteDialogVisible" class="weui-mask" @click="deleteDialogVisible = false"></div>
-    <div v-if="deleteDialogVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">确认隐藏</strong></div>
-      <div class="weui-dialog__bd">确定要隐藏这条发布吗？隐藏后他人将无法在卖室友大厅看到此内容。</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_default" @click="deleteDialogVisible = false">取消</a>
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="confirmDelete">确定</a>
+    <div v-if="deleteDialogVisible" class="community-dialog-mask" @click="deleteDialogVisible = false"></div>
+    <div v-if="deleteDialogVisible" class="community-dialog" style="--module-color: #ec4899">
+      <div class="community-dialog__title">确认隐藏</div>
+      <div class="community-dialog__body">确定要隐藏这条发布吗？隐藏后他人将无法在卖室友大厅看到此内容。</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--cancel" @click="deleteDialogVisible = false">取消</a>
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="confirmDelete">确定</a>
       </div>
     </div>
   </div>
@@ -319,41 +328,28 @@ watch(() => route.fullPath, () => {
 
 <style scoped>
 .dating-center {
-  background: #eee;
+  background: var(--c-bg);
   min-height: 100vh;
-  padding-bottom: 20px;
+  padding-bottom: var(--space-lg);
 }
-
-.dating-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: linear-gradient(180deg, #78e2d1 0%, #6dcbbd 100%);
-  color: #fff;
-}
-.dating-header__back { color: #fff; cursor: pointer; min-width: 48px; font-size: 14px; }
-.dating-header__title { flex: 1; text-align: center; font-size: 16px; margin: 0; }
-.dating-header__placeholder { min-width: 48px; }
 
 .dating-tabs {
   display: flex;
-  background: #fff;
-  border-bottom: 1px solid #e0e0e0;
+  background: var(--c-card);
+  border-bottom: 1px solid var(--c-border);
 }
 .dating-tab {
   flex: 1;
   text-align: center;
-  padding: 12px 0;
-  font-size: 15px;
-  color: #666;
+  padding: var(--space-sm) 0;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   cursor: pointer;
   position: relative;
   transition: all 0.3s;
 }
 .dating-tab.active {
-  color: #6dcbbd;
+  color: var(--c-dating);
   font-weight: bold;
 }
 .dating-tab.active::after {
@@ -363,64 +359,54 @@ watch(() => route.fullPath, () => {
   left: 0;
   right: 0;
   height: 3px;
-  background: #78e2d1;
+  background: var(--c-dating);
 }
 
 .dating-content {
-  padding: 15px;
-}
-
-.dating-loading,
-.dating-empty {
-  text-align: center;
-  padding: 40px 20px;
-  color: #999;
-  font-size: 14px;
+  padding: var(--space-md);
 }
 
 .dating-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-sm);
 }
 
 .dating-card {
-  background: #fff;
-  border-radius: 8px;
-  padding: 15px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: var(--space-md);
+  animation: community-slide-up 0.4s ease both;
 }
 
 .dating-card__header {
   display: flex;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-sm);
   position: relative;
 }
 .dating-card__avatar {
   width: 48px;
   height: 48px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   object-fit: cover;
-  margin-right: 12px;
+  margin-right: var(--space-sm);
 }
 .dating-card__info {
   flex: 1;
 }
 .dating-card__name {
-  font-size: 16px;
+  font-size: var(--font-md);
   font-weight: 500;
-  color: #333;
+  color: var(--c-text-1);
   margin-bottom: 4px;
 }
 .dating-card__time {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-xs);
+  color: var(--c-text-3);
 }
 .dating-badge {
-  padding: 4px 10px;
-  border-radius: 12px;
-  font-size: 12px;
+  padding: 4px var(--space-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--font-xs);
   font-weight: 500;
 }
 .dating-badge.status-pending {
@@ -437,26 +423,26 @@ watch(() => route.fullPath, () => {
 }
 
 .dating-card__message {
-  padding: 12px;
-  background: #f5f5f5;
-  border-radius: 6px;
-  font-size: 14px;
-  color: #666;
+  padding: var(--space-sm);
+  background: var(--c-bg);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
+  color: var(--c-text-2);
   line-height: 1.6;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-sm);
 }
 
 .dating-card__actions {
   display: flex;
-  gap: 10px;
-  margin-top: 12px;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
 }
 .dating-btn {
   flex: 1;
-  padding: 10px 0;
+  padding: var(--space-sm) 0;
   border: none;
-  border-radius: 6px;
-  font-size: 14px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
   cursor: pointer;
   transition: opacity 0.3s;
 }
@@ -464,70 +450,70 @@ watch(() => route.fullPath, () => {
   opacity: 0.7;
 }
 .dating-btn--accept {
-  background: #6dcbbd;
+  background: var(--c-dating);
   color: #fff;
 }
 .dating-btn--reject {
-  background: #e0e0e0;
-  color: #666;
+  background: var(--c-border);
+  color: var(--c-text-2);
 }
 .dating-btn--hide {
   width: 100%;
-  padding: 10px 0;
-  background-color: #f8f8f8;
-  color: #666666;
-  border: 1px solid #e5e5e5;
-  border-radius: 6px;
-  font-size: 14px;
-  margin-top: 10px;
+  padding: var(--space-sm) 0;
+  background-color: var(--c-bg);
+  color: var(--c-text-2);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
+  margin-top: var(--space-sm);
 }
 .dating-btn--hide:active {
-  background-color: #eeeeee;
+  background-color: var(--c-border);
 }
 
 .dating-card__status {
-  margin-top: 12px;
+  margin-top: var(--space-sm);
   text-align: center;
 }
 .status-text {
-  font-size: 14px;
+  font-size: var(--font-sm);
   font-weight: 500;
 }
 .status-text.status-accepted {
-  color: #6dcbbd;
+  color: var(--c-dating);
 }
 .status-text.status-rejected {
-  color: #999;
+  color: var(--c-text-3);
 }
 
 .dating-card__contact {
-  margin-top: 12px;
-  padding: 12px;
-  background: #e8f5e9;
-  border-radius: 6px;
-  border-left: 3px solid #6dcbbd;
+  margin-top: var(--space-sm);
+  padding: var(--space-sm);
+  background: #fdf2f8;
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--c-dating);
 }
 .contact-label {
-  font-size: 13px;
-  color: #666;
+  font-size: var(--font-xs);
+  color: var(--c-text-2);
   margin-bottom: 6px;
 }
 .contact-info {
-  font-size: 14px;
-  color: #6dcbbd;
+  font-size: var(--font-sm);
+  color: var(--c-dating);
   font-weight: 500;
   line-height: 1.8;
 }
 
 .dating-card--post {
   display: flex;
-  gap: 12px;
+  gap: var(--space-sm);
   align-items: center;
 }
 .dating-card__thumb {
   width: 80px;
   height: 80px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   object-fit: cover;
   flex-shrink: 0;
 }
@@ -539,57 +525,5 @@ watch(() => route.fullPath, () => {
 }
 .dating-card__body .dating-card__name {
   margin-bottom: 0;
-}
-
-.weui-mask {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 16px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-  line-height: 1.5;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #eee;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 14px;
-  text-align: center;
-  color: #6dcbbd;
-  text-decoration: none;
-}
-.weui-dialog__btn_default {
-  color: #999;
-}
-.weui-dialog__btn_primary {
-  font-weight: 500;
-  color: #6dcbbd;
 }
 </style>

--- a/frontend/src/views/dating/Detail.vue
+++ b/frontend/src/views/dating/Detail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -76,14 +77,10 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="dating-detail">
-    <div class="dating-header unified-header">
-      <span class="dating-header__back" @click="router.back()">返回</span>
-      <h1 class="dating-header__title">卖室友</h1>
-      <span class="dating-header__placeholder"></span>
-    </div>
+  <div class="community-page dating-detail">
+    <CommunityHeader title="卖室友" moduleColor="#ec4899" backTo="/dating/home" />
 
-    <div v-if="item" class="dating-detail__box">
+    <div v-if="item" class="community-card dating-detail__box" style="--module-color: #ec4899; animation: community-slide-up 0.4s ease both;">
       <div class="dating-detail__name">{{ item.name }}</div>
       <div class="dating-detail__photo">
         <img :src="(item.images && item.images[0]) || item.image || '/img/dating/default-avatar.png'" :alt="item.name" />
@@ -102,55 +99,102 @@ onMounted(async () => {
       </div>
     </div>
 
-    <div v-if="pickSuccessVisible" class="weui-mask_transparent"></div>
-    <div v-if="pickSuccessVisible" class="weui-toast weui-toast_text">
-      <p class="weui-toast__content">发送成功，请耐心等待对方回复</p>
+    <div v-if="pickSuccessVisible" class="community-dialog-mask" style="background: transparent;"></div>
+    <div v-if="pickSuccessVisible" class="dating-toast">
+      <p class="dating-toast__content">发送成功，请耐心等待对方回复</p>
     </div>
 
-    <div v-if="dialogVisible" class="weui-mask" @click="dialogVisible = false"></div>
-    <div v-if="dialogVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div v-if="dialogVisible" class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div v-if="dialogVisible" class="community-dialog" style="--module-color: #ec4899">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.dating-detail { background: #eee; min-height: 100vh; padding-bottom: 40px; }
-.dating-header.unified-header {
-  display: flex; align-items: center; justify-content: space-between;
-  height: 44px; padding: 0 12px;
-  background: linear-gradient(180deg, #78e2d1 0%, #6dcbbd 100%);
-  color: #fff;
-}
-.dating-header__back { color: #fff; cursor: pointer; min-width: 48px; font-size: 14px; }
-.dating-header__title { flex: 1; text-align: center; font-size: 16px; margin: 0; }
-.dating-header__placeholder { min-width: 48px; }
+.dating-detail { padding-bottom: 40px; }
 
-.dating-detail__box { width: 90%; margin: 10px auto; background: #fff; overflow: hidden; padding: 15px; border-radius: 8px; }
-.dating-detail__name { font-size: 22px; color: #6dcbbd; font-weight: bold; margin-bottom: 12px; }
-.dating-detail__photo { width: 100%; border-radius: 8px; overflow: hidden; background: #eee; margin-bottom: 12px; }
+.dating-detail__box {
+  width: 90%;
+  margin: var(--space-md) auto;
+  padding: var(--space-lg);
+  overflow: hidden;
+}
+.dating-detail__name {
+  font-size: 22px;
+  color: var(--c-dating);
+  font-weight: bold;
+  margin-bottom: var(--space-md);
+}
+.dating-detail__photo {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--c-bg);
+  margin-bottom: var(--space-md);
+}
 .dating-detail__photo img { width: 100%; height: auto; max-height: 360px; object-fit: cover; }
-.dating-detail__bio { padding: 12px 0; line-height: 1.6; color: #333; font-size: 15px; }
+.dating-detail__bio {
+  padding: var(--space-md) 0;
+  line-height: 1.6;
+  color: var(--c-text-1);
+  font-size: var(--font-md);
+}
 .dating-detail__info { list-style: none; margin: 0; padding: 0; width: 90%; margin: 0 auto; }
-.dating-detail__info li { height: 44px; line-height: 44px; border-bottom: 1px dashed #ccc; font-size: 14px; color: #333; }
-.dating-detail__info li span { font-weight: bold; margin-right: 8px; color: #000; }
-.dating-detail__pick { border-top: 2px dashed #eee; padding-top: 15px; margin-top: 15px; text-align: center; }
-.dating-textarea { width: 100%; padding: 12px; border: 1px solid #ddd; border-radius: 8px; font-size: 14px; min-height: 80px; box-sizing: border-box; margin-bottom: 12px; }
-.circle-btn { padding: 10px 28px; background: #2ee9d0; color: #fff; border: none; border-radius: 24px; font-size: 16px; cursor: pointer; }
+.dating-detail__info li {
+  height: 44px;
+  line-height: 44px;
+  border-bottom: 1px dashed var(--c-divider);
+  font-size: var(--font-base);
+  color: var(--c-text-1);
+}
+.dating-detail__info li span { font-weight: bold; margin-right: var(--space-sm); color: var(--c-text-1); }
+.dating-detail__pick {
+  border-top: 2px dashed var(--c-divider);
+  padding-top: var(--space-lg);
+  margin-top: var(--space-lg);
+  text-align: center;
+}
+.dating-textarea {
+  width: 100%;
+  padding: var(--space-md);
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-base);
+  min-height: 80px;
+  box-sizing: border-box;
+  margin-bottom: var(--space-md);
+  color: var(--c-text-1);
+}
+.dating-textarea::placeholder { color: var(--c-text-3); }
+.circle-btn {
+  padding: 10px 28px;
+  background: var(--c-dating);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-full);
+  font-size: var(--font-lg);
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.circle-btn:active { opacity: 0.85; }
 .circle-btn:disabled { opacity: 0.6; }
 
-.weui-mask { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 1000; }
-.weui-dialog { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 85%; max-width: 300px; background: #fff; border-radius: 8px; z-index: 1001; overflow: hidden; }
-.weui-dialog__hd { padding: 16px; text-align: center; }
-.weui-dialog__title { font-size: 17px; color: #333; }
-.weui-dialog__bd { padding: 10px 20px; text-align: center; font-size: 15px; color: #666; }
-.weui-dialog__ft { display: flex; border-top: 1px solid #eee; }
-.weui-dialog__btn { flex: 1; padding: 14px; text-align: center; color: #6dcbbd; text-decoration: none; }
-.weui-mask_transparent { position: fixed; inset: 0; z-index: 1002; }
-.weui-toast { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: rgba(0,0,0,0.7); color: #fff; padding: 16px 24px; border-radius: 8px; z-index: 1003; }
-.weui-toast__content { margin: 0; font-size: 14px; }
+.dating-toast {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  padding: var(--space-lg) var(--space-xl);
+  border-radius: var(--radius-sm);
+  z-index: 1003;
+  animation: community-fade-in 0.2s ease;
+}
+.dating-toast__content { margin: 0; font-size: var(--font-base); }
 </style>

--- a/frontend/src/views/dating/Home.vue
+++ b/frontend/src/views/dating/Home.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const activeArea = ref(0) // 0 小姐姐 1 小哥哥
@@ -61,21 +62,21 @@ onUnmounted(() => {
 
 <template>
   <div
-    class="dating-home"
+    class="community-page dating-home"
     @touchstart="handleTouchStart"
     @touchmove="handleTouchMove($event, scrollContainer)"
     @touchend="handleTouchEnd"
   >
-    <div class="dating-header unified-header">
-      <span class="dating-header__back" @click="router.push('/')">返回</span>
-      <h1 class="dating-header__title">卖室友</h1>
-      <div class="dating-header__right" @click="router.push('/dating/center')">我的</div>
-    </div>
+    <CommunityHeader title="卖室友" moduleColor="#ec4899" backTo="/">
+      <template #right>
+        <span class="dating-header-right" @click="router.push('/dating/center')">我的</span>
+      </template>
+    </CommunityHeader>
 
-    <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-      <span v-if="refreshing" class="pull-refresh-text"><i class="weui-loading"></i> 正在刷新...</span>
-      <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-      <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+    <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+      <span v-if="refreshing" class="community-pull-refresh__text"><i class="community-loading-spinner" style="--module-color: #ec4899"></i> 正在刷新...</span>
+      <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+      <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
     </div>
 
     <!-- 性别 Tab：小姐姐 / 小哥哥（原版 JSP sexTab） -->
@@ -92,9 +93,10 @@ onUnmounted(() => {
 
     <div class="dating-list">
       <div
-        v-for="item in list"
+        v-for="(item, index) in list"
         :key="item.id"
-        class="dating-card"
+        class="community-card dating-card"
+        :style="{ animationDelay: (index % 10) * 0.05 + 's' }"
         @click="goDetail(item.id)"
       >
         <div class="dating-card__img">
@@ -103,17 +105,16 @@ onUnmounted(() => {
         <h2 class="dating-card__title">{{ item.name }}</h2>
         <div class="dating-card__info">{{ item.faculty }} {{ getGradeText(item.grade) }}学生</div>
         <div class="dating-card__info">来自{{ item.hometown || '未知' }}</div>
-        <div class="dating-card__actions">
-          <button type="button" class="dating-action-btn" :class="{ 'is-liked': item.isLiked }" @click.stop="handleLike(item)">
-            {{ item.isLiked ? '♥' : '♡' }} {{ item.likeCount || 0 }}
-          </button>
-        </div>
+        <p class="dating-card__desc">{{ item.content }}</p>
       </div>
     </div>
 
-    <div v-if="!loading && !refreshing && list.length === 0" class="dating-empty">暂无内容</div>
-    <div v-if="loading && !refreshing" class="dating-loadmore"><i class="weui-loading"></i> 正在加载</div>
-    <div v-if="finished && list.length > 0" class="dating-loadmore">已经到底了</div>
+    <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+      <div class="community-empty__icon">💕</div>
+      <div class="community-empty__text">暂无内容</div>
+    </div>
+    <div v-if="loading && !refreshing" class="community-loadmore"><i class="community-loading-spinner" style="--module-color: #ec4899"></i> 正在加载</div>
+    <div v-if="finished && list.length > 0" class="community-loadmore">已经到底了</div>
 
     <!-- 右下角发布悬浮按钮（原版 JSP skypub） -->
     <div class="dating-fab" @click="router.push('/dating/publish')">
@@ -124,35 +125,18 @@ onUnmounted(() => {
 
 <style scoped>
 .dating-home {
-  background: #eee;
-  min-height: 100vh;
   padding-bottom: 80px;
 }
 
-.dating-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: linear-gradient(180deg, #78e2d1 0%, #6dcbbd 100%);
-  color: #fff;
+.dating-header-right {
+  color: var(--c-text-2);
+  cursor: pointer;
+  font-size: var(--font-base);
 }
-.dating-header__back { color: #fff; cursor: pointer; min-width: 48px; font-size: 14px; }
-.dating-header__title { flex: 1; text-align: center; font-size: 16px; font-weight: 500; margin: 0; }
-.dating-header__right { color: #fff; cursor: pointer; min-width: 48px; font-size: 14px; text-align: right; }
-
-.pull-refresh-indicator { display: flex; align-items: center; justify-content: center; overflow: hidden; transition: height 0.3s; }
-.pull-refresh-text { font-size: 14px; color: #999; }
-.pull-refresh-text .weui-loading {
-  width: 16px; height: 16px; border: 2px solid #e5e5e5; border-top-color: #6dcbbd; border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin { to { transform: rotate(360deg); } }
 
 .dating-sex-tab {
-  background: #fff;
-  margin-top: 10px;
+  background: var(--c-card);
+  margin-top: var(--space-sm);
   height: 44px;
 }
 .dating-sex-tab ul { display: flex; list-style: none; margin: 0; padding: 0; }
@@ -160,61 +144,52 @@ onUnmounted(() => {
   flex: 1;
   text-align: center;
   line-height: 44px;
-  font-size: 18px;
+  font-size: var(--font-xl);
+  transition: background 0.3s, color 0.3s;
 }
-.dating-sex-tab .tab-item a { color: #333; text-decoration: none; }
-.dating-sex-tab .tab-item.selected { background: #78e2d1; }
+.dating-sex-tab .tab-item a { color: var(--c-text-2); text-decoration: none; }
+.dating-sex-tab .tab-item.selected { background: var(--c-dating); }
 .dating-sex-tab .tab-item.selected a { color: #fff; }
 
-.dating-list { padding: 10px; }
+.dating-list { padding: var(--space-md); }
 .dating-card {
-  background: #fff;
-  margin-bottom: 10px;
-  padding: 10px;
-  border-radius: 8px;
+  margin-bottom: var(--space-md);
+  padding: var(--space-md);
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
   cursor: pointer;
+  animation: community-slide-up 0.4s ease both;
 }
 .dating-card__img {
   width: 100%;
   aspect-ratio: 1;
-  background: #ccc;
-  border-radius: 6px;
+  background: var(--c-border);
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-sm);
 }
 .dating-card__img img { width: 100%; height: 100%; object-fit: cover; }
 .dating-card__title {
   margin: 0 0 6px;
-  font-size: 18px;
+  font-size: var(--font-xl);
   font-weight: bold;
-  color: #6dcbbd;
+  color: var(--c-dating);
   line-height: 1.3;
 }
 .dating-card__info {
-  color: #666;
-  font-size: 14px;
+  color: var(--c-text-2);
+  font-size: var(--font-base);
   margin-top: 2px;
   line-height: 1.5;
 }
-.dating-card__actions { margin-top: 10px; padding-top: 8px; border-top: 1px solid #f0f0f0; }
+.dating-card__actions { margin-top: var(--space-md); padding-top: var(--space-sm); border-top: 1px solid var(--c-border); }
 .dating-action-btn {
   background: none;
   border: none;
-  font-size: 14px;
-  color: #666;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   cursor: pointer;
 }
-.dating-action-btn.is-liked { color: #ff5252; font-weight: bold; }
-
-.dating-empty { text-align: center; padding: 40px 20px; color: #999; font-size: 14px; }
-.dating-loadmore { text-align: center; padding: 16px; color: #999; font-size: 14px; }
-.dating-loadmore .weui-loading {
-  width: 16px; height: 16px; border: 2px solid #e5e5e5; border-top-color: #6dcbbd; border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  display: inline-block; vertical-align: middle; margin-right: 6px;
-}
+.dating-action-btn.is-liked { color: var(--c-dating); font-weight: bold; }
 
 .dating-fab {
   position: fixed;
@@ -222,14 +197,18 @@ onUnmounted(() => {
   bottom: 24px;
   width: 48px;
   height: 48px;
-  border-radius: 50%;
-  background: #2ee9d0;
-  box-shadow: 0 4px 12px rgba(46, 233, 208, 0.5);
+  border-radius: var(--radius-full);
+  background: var(--c-dating);
+  box-shadow: 0 4px 12px rgba(236, 72, 153, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 100;
   cursor: pointer;
+  transition: transform 0.2s;
+}
+.dating-fab:active {
+  transform: scale(0.92);
 }
 .dating-fab__icon {
   font-size: 28px;

--- a/frontend/src/views/dating/Publish.vue
+++ b/frontend/src/views/dating/Publish.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { uploadFileByPresignedUrl } from '../../utils/presignedUpload'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const formData = ref({
@@ -159,14 +160,10 @@ async function submit() {
 </script>
 
 <template>
-  <div class="dating-publish">
-    <div class="dating-header unified-header">
-      <span class="dating-header__back" @click="router.push('/dating/home')">返回</span>
-      <h1 class="dating-header__title">发布资料</h1>
-      <span class="dating-header__placeholder"></span>
-    </div>
+  <div class="community-page dating-publish">
+    <CommunityHeader title="发布资料" moduleColor="#ec4899" backTo="/dating/home" />
 
-    <div class="dating-publish__box">
+    <div class="community-card dating-publish__box" style="--module-color: #ec4899">
       <div class="dating-publish__title">发布资料</div>
 
       <div class="dating-photo" @click="$refs.fileInput.click()">
@@ -200,66 +197,77 @@ async function submit() {
       </div>
     </div>
 
-    <div v-if="dialogVisible" class="weui-mask" @click="dialogVisible = false"></div>
-    <div v-if="dialogVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div v-if="dialogVisible" class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div v-if="dialogVisible" class="community-dialog" style="--module-color: #ec4899">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.dating-publish { background: #eee; min-height: 100vh; padding-bottom: 40px; }
-.dating-header.unified-header {
-  display: flex; align-items: center; justify-content: space-between;
-  height: 44px; padding: 0 12px;
-  background: linear-gradient(180deg, #78e2d1 0%, #6dcbbd 100%);
-  color: #fff;
-}
-.dating-header__back { color: #fff; cursor: pointer; min-width: 48px; font-size: 14px; }
-.dating-header__title { flex: 1; text-align: center; font-size: 16px; margin: 0; }
-.dating-header__placeholder { min-width: 48px; }
+.dating-publish { padding-bottom: 40px; }
 
-.dating-publish__box { width: 90%; margin: 0 auto; background: #fff; overflow: hidden; padding: 15px; margin-top: 10px; border-radius: 8px; }
-.dating-publish__title { font-size: 22px; color: #6dcbbd; font-weight: bold; margin-bottom: 15px; padding-left: 8px; }
+.dating-publish__box {
+  width: 90%;
+  margin: var(--space-md) auto 0;
+  padding: var(--space-lg);
+  overflow: hidden;
+  animation: community-slide-up 0.4s ease both;
+}
+.dating-publish__title {
+  font-size: 22px;
+  color: var(--c-dating);
+  font-weight: bold;
+  margin-bottom: var(--space-lg);
+  padding-left: var(--space-sm);
+}
 
 .dating-photo {
-  width: 100%; min-height: 200px; background: #eee; border-radius: 8px; margin-bottom: 15px;
+  width: 100%; min-height: 200px; background: var(--c-bg); border-radius: var(--radius-sm); margin-bottom: var(--space-lg);
   display: flex; align-items: center; justify-content: center; overflow: hidden; position: relative;
 }
 .dating-photo__img { width: 100%; height: auto; max-height: 320px; object-fit: cover; }
 .dating-photo__placeholder { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; }
 .dating-photo__input { opacity: 0; position: absolute; inset: 0; width: 100%; height: 100%; cursor: pointer; }
-.dating-photo__btn { padding: 10px 24px; background: #2ee9d0; color: #fff; border-radius: 20px; }
-.dating-photo-hint { text-align: center; margin-bottom: 15px; }
-.circle-btn { padding: 10px 28px; background: #2ee9d0; color: #fff; border: none; border-radius: 24px; font-size: 16px; cursor: pointer; }
+.dating-photo__btn {
+  padding: 10px 24px;
+  background: var(--c-dating);
+  color: #fff;
+  border-radius: var(--radius-full);
+}
+.dating-photo-hint { text-align: center; margin-bottom: var(--space-lg); }
+.circle-btn {
+  padding: 10px 28px;
+  background: var(--c-dating);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-full);
+  font-size: var(--font-lg);
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.circle-btn:active { opacity: 0.85; }
 .circle-btn:disabled { opacity: 0.6; }
-.circle-btn--submit { width: 80px; height: 80px; border-radius: 50%; font-size: 18px; margin-top: 15px; }
+.circle-btn--submit { width: 80px; height: 80px; border-radius: 50%; font-size: var(--font-xl); margin-top: var(--space-lg); }
 
-.dating-form { margin: 15px 0; }
+.dating-form { margin: var(--space-lg) 0; }
 .input-box {
-  width: 100%; max-width: 320px; margin: 8px auto; display: block;
-  height: 44px; padding: 0 12px; border: none; border-bottom: 2px solid #2ee8d0; background: #fff; font-size: 14px;
+  width: 100%; max-width: 320px; margin: var(--space-sm) auto; display: block;
+  height: 44px; padding: 0 var(--space-md); border: none; border-bottom: 2px solid var(--c-dating); background: var(--c-card); font-size: var(--font-base);
+  color: var(--c-text-1);
 }
-.dating-hint { text-align: center; margin: 10px 15px; font-size: 12px; color: #666; }
+.input-box::placeholder { color: var(--c-text-3); }
+.dating-hint { text-align: center; margin: var(--space-md) var(--space-lg); font-size: var(--font-sm); color: var(--c-text-2); }
 .dating-hint__warn { color: #e53935; }
-.dating-textarea-wrap { border-top: 2px dashed #eee; padding-top: 15px; text-align: center; }
+.dating-textarea-wrap { border-top: 2px dashed var(--c-divider); padding-top: var(--space-lg); text-align: center; }
 .dating-textarea {
-  width: 100%; max-width: 320px; margin: 0 auto 15px; padding: 12px; border: 1px solid #ddd; border-radius: 8px;
-  font-size: 14px; min-height: 100px; display: block; box-sizing: border-box;
+  width: 100%; max-width: 320px; margin: 0 auto var(--space-lg); padding: var(--space-md); border: 1px solid var(--c-divider); border-radius: var(--radius-sm);
+  font-size: var(--font-base); min-height: 100px; display: block; box-sizing: border-box;
+  color: var(--c-text-1);
 }
-
-.weui-mask { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 1000; }
-.weui-dialog {
-  position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
-  width: 85%; max-width: 300px; background: #fff; border-radius: 8px; z-index: 1001; overflow: hidden;
-}
-.weui-dialog__hd { padding: 16px; text-align: center; }
-.weui-dialog__title { font-size: 17px; color: #333; }
-.weui-dialog__bd { padding: 10px 20px; text-align: center; font-size: 15px; color: #666; }
-.weui-dialog__ft { display: flex; border-top: 1px solid #eee; }
-.weui-dialog__btn { flex: 1; padding: 14px; text-align: center; color: #6dcbbd; text-decoration: none; }
+.dating-textarea::placeholder { color: var(--c-text-3); }
 </style>

--- a/frontend/src/views/delivery/Detail.vue
+++ b/frontend/src/views/delivery/Detail.vue
@@ -116,7 +116,7 @@ onMounted(async () => {
 
 <template>
   <div class="delivery-detail" style="--module-color: #f59e0b">
-    <CommunityHeader title="任务详情" moduleColor="#f59e0b" />
+    <CommunityHeader title="任务详情" moduleColor="#f59e0b" @back="router.back()" backTo="" />
 
     <div v-if="item" class="delivery-detail__content">
       <!-- 任务卡片 -->

--- a/frontend/src/views/delivery/Detail.vue
+++ b/frontend/src/views/delivery/Detail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -114,20 +115,16 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="delivery-detail">
-    <div class="delivery-header unified-header">
-      <span class="delivery-header__back" @click="router.back()">返回</span>
-      <h1 class="delivery-header__title">任务详情</h1>
-      <span class="delivery-header__placeholder"></span>
-    </div>
+  <div class="delivery-detail" style="--module-color: #f59e0b">
+    <CommunityHeader title="任务详情" moduleColor="#f59e0b" />
 
     <div v-if="item" class="delivery-detail__content">
       <!-- 任务卡片 -->
-      <div class="detail-card">
+      <div class="detail-card community-card">
         <div class="detail-card__header">
           <div class="detail-card__type">{{ getTypeText(item.type) }}</div>
           <div class="detail-card__reward">
-            <span class="reward-symbol">￥</span>
+            <span class="reward-symbol">&#xffe5;</span>
             <span class="reward-amount">{{ item.reward.toFixed(2) }}</span>
           </div>
         </div>
@@ -216,23 +213,23 @@ onMounted(async () => {
     </div>
 
     <!-- 提示对话框 -->
-    <div v-if="dialogVisible" class="weui-mask" @click="dialogVisible = false"></div>
-    <div v-if="dialogVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div v-if="dialogVisible" class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div v-if="dialogVisible" class="community-dialog">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
 
     <!-- 确认完成对话框 -->
-    <div v-if="confirmCompleteVisible" class="weui-mask" @click="confirmCompleteVisible = false"></div>
-    <div v-if="confirmCompleteVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">确认完成</strong></div>
-      <div class="weui-dialog__bd">确定要完成这个订单吗？完成后将无法撤销。</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn" @click="confirmCompleteVisible = false">取消</a>
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="handleComplete">确定</a>
+    <div v-if="confirmCompleteVisible" class="community-dialog-mask" @click="confirmCompleteVisible = false"></div>
+    <div v-if="confirmCompleteVisible" class="community-dialog">
+      <div class="community-dialog__title">确认完成</div>
+      <div class="community-dialog__body">确定要完成这个订单吗？完成后将无法撤销。</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--cancel" @click="confirmCompleteVisible = false">取消</a>
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="handleComplete">确定</a>
       </div>
     </div>
   </div>
@@ -240,55 +237,39 @@ onMounted(async () => {
 
 <style scoped>
 .delivery-detail {
-  background: #f5f5f5;
+  background: var(--c-bg);
   min-height: 100vh;
-  padding-bottom: 60px;
 }
-
-.delivery-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-.delivery-header__back { color: #333; cursor: pointer; min-width: 48px; font-size: 14px; }
-.delivery-header__title { flex: 1; text-align: center; font-size: 16px; font-weight: 500; margin: 0; color: #333; }
-.delivery-header__placeholder { min-width: 48px; }
 
 .delivery-detail__content {
-  padding: 15px;
+  padding: var(--space-lg);
+  animation: community-slide-up 0.4s ease both;
 }
 
 .detail-card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 20px;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.03);
+  padding: var(--space-xl);
 }
 
 .detail-card__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
-  padding-bottom: 15px;
-  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--c-border);
 }
 .detail-card__type {
-  font-size: 18px;
+  font-size: var(--font-xl);
   font-weight: 600;
-  color: #333;
+  color: var(--c-text-1);
 }
 .detail-card__reward {
   display: flex;
   align-items: baseline;
-  color: #ff5252;
+  color: #ef4444;
 }
 .reward-symbol {
-  font-size: 18px;
+  font-size: var(--font-xl);
   font-weight: bold;
   margin-right: 2px;
 }
@@ -298,15 +279,15 @@ onMounted(async () => {
 }
 
 .detail-card__route {
-  margin-bottom: 20px;
-  padding: 15px;
-  background: #f8f9fa;
-  border-radius: 8px;
+  margin-bottom: var(--space-xl);
+  padding: var(--space-lg);
+  background: var(--c-bg);
+  border-radius: var(--radius-sm);
 }
 .route-item {
   display: flex;
   align-items: flex-start;
-  margin-bottom: 15px;
+  margin-bottom: var(--space-lg);
 }
 .route-item:last-child {
   margin-bottom: 0;
@@ -314,45 +295,45 @@ onMounted(async () => {
 .route-icon {
   width: 28px;
   height: 28px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 13px;
   font-weight: bold;
   color: #fff;
-  margin-right: 12px;
+  margin-right: var(--space-md);
   flex-shrink: 0;
   margin-top: 2px;
 }
 .route-icon--pickup {
-  background: #4a90e2;
+  background: #3b82f6;
 }
 .route-icon--delivery {
-  background: #fa8231;
+  background: var(--c-delivery);
 }
 .route-content {
   flex: 1;
 }
 .route-text {
-  font-size: 16px;
-  color: #333;
+  font-size: var(--font-lg);
+  color: var(--c-text-1);
   line-height: 1.5;
   margin-bottom: 6px;
   font-weight: 500;
 }
 .route-code,
 .route-phone {
-  font-size: 14px;
-  color: #666;
-  margin-top: 4px;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
+  margin-top: var(--space-xs);
 }
 
 .detail-card__image {
-  margin-bottom: 20px;
-  border-radius: 8px;
+  margin-bottom: var(--space-xl);
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  background: #f0f0f0;
+  background: var(--c-border);
 }
 .detail-card__image img {
   width: 100%;
@@ -362,89 +343,89 @@ onMounted(async () => {
 }
 
 .detail-card__info {
-  padding-top: 15px;
-  border-top: 1px solid #f0f0f0;
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--c-border);
 }
 .info-row {
   display: flex;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-md);
 }
 .info-row:last-child {
   margin-bottom: 0;
 }
 .info-label {
-  font-size: 14px;
-  color: #666;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   min-width: 80px;
 }
 .info-value {
   flex: 1;
-  font-size: 14px;
-  color: #333;
+  font-size: var(--font-base);
+  color: var(--c-text-1);
 }
 .info-row--role {
-  margin-bottom: 15px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid var(--c-border);
 }
 .role-badge {
   padding: 6px 14px;
-  border-radius: 16px;
+  border-radius: var(--radius-full);
   font-size: 13px;
   font-weight: 500;
 }
 .role-publisher {
-  background: #e3f2fd;
-  color: #1976d2;
+  background: #dbeafe;
+  color: #1e40af;
 }
 .role-runner {
-  background: #fff3e0;
-  color: #f57c00;
+  background: #fef3c7;
+  color: #92400e;
 }
 .delivery-badge {
-  padding: 4px 12px;
-  border-radius: 12px;
-  font-size: 12px;
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-full);
+  font-size: var(--font-sm);
   font-weight: 500;
 }
 .delivery-badge.status-pending {
-  background: #fff3cd;
-  color: #856404;
+  background: #fef3c7;
+  color: #92400e;
 }
 .delivery-badge.status-delivering {
-  background: #d1ecf1;
-  color: #0c5460;
+  background: #dbeafe;
+  color: #1e40af;
 }
 .delivery-badge.status-completed {
-  background: #d4edda;
-  color: #155724;
+  background: #d1fae5;
+  color: #065f46;
 }
 
 .detail-card__actions {
-  margin-top: 20px;
-  padding-top: 20px;
-  border-top: 1px solid #f0f0f0;
+  margin-top: var(--space-xl);
+  padding-top: var(--space-xl);
+  border-top: 1px solid var(--c-border);
   display: flex;
-  gap: 12px;
+  gap: var(--space-md);
 }
 .action-btn {
   flex: 1;
   height: 44px;
   border: none;
-  border-radius: 8px;
-  font-size: 16px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-lg);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.3s;
 }
 .action-btn--accept {
-  background: linear-gradient(135deg, #fa8231 0%, #ff6b35 100%);
+  background: linear-gradient(135deg, var(--c-delivery) 0%, #d97706 100%);
   color: #fff;
-  box-shadow: 0 2px 8px rgba(250, 130, 49, 0.25);
+  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.25);
 }
 .action-btn--accept:hover {
-  box-shadow: 0 4px 12px rgba(250, 130, 49, 0.35);
+  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.35);
 }
 .action-btn--accept:disabled {
   opacity: 0.6;
@@ -461,50 +442,5 @@ onMounted(async () => {
 .action-btn--complete:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-}
-
-.weui-mask {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 16px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #eee;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 14px;
-  text-align: center;
-  color: #fa8231;
-  text-decoration: none;
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/delivery/Home.vue
+++ b/frontend/src/views/delivery/Home.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const activeStatus = ref('all') // all, pending, delivering, completed
@@ -78,16 +79,12 @@ onUnmounted(() => {
     @touchmove="handleTouchMove($event, scrollContainer)"
     @touchend="handleTouchEnd"
   >
-    <div class="delivery-header unified-header">
-      <span class="delivery-header__back" @click="router.push('/')">返回</span>
-      <h1 class="delivery-header__title">全民快递</h1>
-      <span class="delivery-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="全民快递" moduleColor="#f59e0b" backTo="/" />
 
-    <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-      <span v-if="refreshing" class="pull-refresh-text"><i class="weui-loading"></i> 正在刷新...</span>
-      <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-      <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+    <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+      <span v-if="refreshing" class="community-pull-refresh__text"><i class="community-loading-spinner"></i> 正在刷新...</span>
+      <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+      <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
     </div>
 
     <!-- 状态筛选 Tab -->
@@ -121,16 +118,17 @@ onUnmounted(() => {
     <!-- 任务卡片列表 -->
     <div class="delivery-list">
       <div
-        v-for="item in list"
+        v-for="(item, index) in list"
         :key="item.id"
-        class="delivery-card"
+        class="delivery-card community-card"
+        :style="{ animationDelay: (index * 0.05) + 's' }"
         @click="goDetail(item.id)"
       >
         <!-- 卡片头部 -->
         <div class="delivery-card__header">
           <div class="delivery-card__type">{{ getTypeText(item.type) }}</div>
           <div class="delivery-card__reward">
-            <span class="reward-symbol">￥</span>
+            <span class="reward-symbol">&#xffe5;</span>
             <span class="reward-amount">{{ item.reward.toFixed(2) }}</span>
           </div>
         </div>
@@ -160,58 +158,39 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <div v-if="!loading && !refreshing && list.length === 0" class="delivery-empty">暂无任务</div>
-    <div v-if="loading && !refreshing" class="delivery-loadmore"><i class="weui-loading"></i> 正在加载</div>
-    <div v-if="finished && list.length > 0" class="delivery-loadmore">没有更多了</div>
+    <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+      <div class="community-empty__text">暂无任务</div>
+    </div>
+    <div v-if="loading && !refreshing" class="community-loadmore"><i class="community-loading-spinner"></i> 正在加载</div>
+    <div v-if="finished && list.length > 0" class="community-loadmore">没有更多了</div>
   </div>
 </template>
 
 <style scoped>
 .delivery-home {
-  background: #f5f5f5;
+  background: var(--c-bg);
   min-height: 100vh;
-  padding-bottom: 60px;
+  --module-color: #f59e0b;
 }
-
-.delivery-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-.delivery-header__back { color: #333; cursor: pointer; min-width: 48px; font-size: 14px; }
-.delivery-header__title { flex: 1; text-align: center; font-size: 16px; font-weight: 500; margin: 0; color: #333; }
-.delivery-header__placeholder { min-width: 48px; }
-
-.pull-refresh-indicator { display: flex; align-items: center; justify-content: center; overflow: hidden; transition: height 0.3s; }
-.pull-refresh-text { font-size: 14px; color: #999; }
-.pull-refresh-text .weui-loading {
-  width: 16px; height: 16px; border: 2px solid #e5e5e5; border-top-color: #fa8231; border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin { to { transform: rotate(360deg); } }
 
 .delivery-status-tabs {
   display: flex;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-  padding: 0 15px;
+  background: var(--c-card);
+  border-bottom: 1px solid var(--c-divider);
+  padding: 0 var(--space-lg);
 }
 .status-tab {
   flex: 1;
   text-align: center;
-  padding: 12px 0;
-  font-size: 15px;
-  color: #666;
+  padding: var(--space-md) 0;
+  font-size: var(--font-md);
+  color: var(--c-text-2);
   cursor: pointer;
   position: relative;
   transition: all 0.3s;
 }
 .status-tab.active {
-  color: #fa8231;
+  color: var(--c-delivery);
   font-weight: 500;
 }
 .status-tab.active::after {
@@ -221,59 +200,54 @@ onUnmounted(() => {
   left: 0;
   right: 0;
   height: 3px;
-  background: #fa8231;
+  background: var(--c-delivery);
+  border-radius: 3px 3px 0 0;
 }
 
 .delivery-list {
-  padding: 15px;
+  padding: var(--space-lg);
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: var(--space-lg);
 }
 
 .delivery-card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 15px;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.03);
+  padding: var(--space-lg);
   cursor: pointer;
-  transition: box-shadow 0.3s;
-}
-.delivery-card:active {
-  box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+  animation: community-slide-up 0.4s ease both;
 }
 
 .delivery-card__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 15px;
+  margin-bottom: var(--space-lg);
 }
 .delivery-card__type {
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: 600;
-  color: #333;
+  color: var(--c-text-1);
 }
 .delivery-card__reward {
   display: flex;
   align-items: baseline;
-  color: #ff5252;
+  color: #ef4444;
 }
 .reward-symbol {
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: bold;
   margin-right: 2px;
 }
 .reward-amount {
-  font-size: 24px;
+  font-size: var(--font-2xl);
   font-weight: bold;
 }
 
 .delivery-card__route {
-  margin-bottom: 15px;
-  padding: 12px;
-  background: #f8f9fa;
-  border-radius: 8px;
+  margin-bottom: var(--space-lg);
+  padding: var(--space-md);
+  background: var(--c-bg);
+  border-radius: var(--radius-sm);
 }
 .route-item {
   display: flex;
@@ -286,26 +260,26 @@ onUnmounted(() => {
 .route-icon {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: var(--font-sm);
   font-weight: bold;
   color: #fff;
   margin-right: 10px;
   flex-shrink: 0;
 }
 .route-icon--pickup {
-  background: #4a90e2;
+  background: #3b82f6;
 }
 .route-icon--delivery {
-  background: #fa8231;
+  background: var(--c-delivery);
 }
 .route-text {
   flex: 1;
-  font-size: 15px;
-  color: #333;
+  font-size: var(--font-md);
+  color: var(--c-text-1);
   line-height: 1.5;
 }
 
@@ -313,48 +287,35 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 12px;
-  border-top: 1px solid #f0f0f0;
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--c-border);
 }
 .delivery-card__meta {
   display: flex;
-  gap: 12px;
-  font-size: 13px;
-  color: #999;
+  gap: var(--space-md);
+  font-size: var(--font-base);
+  color: var(--c-text-3);
 }
 .meta-time,
 .meta-size {
   display: inline-block;
 }
 .delivery-badge {
-  padding: 4px 12px;
-  border-radius: 12px;
-  font-size: 12px;
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-full);
+  font-size: var(--font-sm);
   font-weight: 500;
 }
 .delivery-badge.status-pending {
-  background: #fff3cd;
-  color: #856404;
+  background: #fef3c7;
+  color: #92400e;
 }
 .delivery-badge.status-delivering {
-  background: #d1ecf1;
-  color: #0c5460;
+  background: #dbeafe;
+  color: #1e40af;
 }
 .delivery-badge.status-completed {
-  background: #d4edda;
-  color: #155724;
-}
-
-.delivery-empty,
-.delivery-loadmore {
-  text-align: center;
-  padding: 40px 20px;
-  color: #999;
-  font-size: 14px;
-}
-.delivery-loadmore .weui-loading {
-  width: 16px; height: 16px; border: 2px solid #e5e5e5; border-top-color: #fa8231; border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  display: inline-block; vertical-align: middle; margin-right: 6px;
+  background: #d1fae5;
+  color: #065f46;
 }
 </style>

--- a/frontend/src/views/delivery/Index.vue
+++ b/frontend/src/views/delivery/Index.vue
@@ -1,134 +1,29 @@
 <script setup>
-import { computed } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
+import CommunityTabbar from '../../components/community/CommunityTabbar.vue'
 
-const router = useRouter()
-const route = useRoute()
-
-const activeTab = computed(() => {
-  const p = route.path
-  if (p.includes('/delivery/publish')) return 'publish'
-  if (p.includes('/delivery/mine')) return 'mine'
-  return 'home'
-})
-
-function goTo(path) {
-  router.push(path)
-}
+const tabs = [
+  { key: 'home', label: '大厅', path: '/delivery/home', icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>' },
+  { key: 'publish', label: '发布', path: '/delivery/publish', icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>' },
+  { key: 'mine', label: '我的', path: '/delivery/mine', icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>' }
+]
 </script>
 
 <template>
-  <div class="delivery-page">
+  <div class="community-page" style="--module-color: #f59e0b">
     <div class="delivery-container">
       <router-view />
     </div>
-    <!-- 专属底部 Tabbar：跑腿橙主题 -->
-    <div class="delivery-tabbar">
-      <a
-        href="javascript:;"
-        class="delivery-tabbar__item"
-        :class="{ active: activeTab === 'home' }"
-        @click.prevent="goTo('/delivery/home')"
-      >
-        <i class="delivery-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-          </svg>
-        </i>
-        <p class="delivery-tabbar__label">大厅</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="delivery-tabbar__item"
-        :class="{ active: activeTab === 'publish' }"
-        @click.prevent="goTo('/delivery/publish')"
-      >
-        <i class="delivery-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-          </svg>
-        </i>
-        <p class="delivery-tabbar__label">发布</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="delivery-tabbar__item"
-        :class="{ active: activeTab === 'mine' }"
-        @click.prevent="goTo('/delivery/mine')"
-      >
-        <i class="delivery-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
-          </svg>
-        </i>
-        <p class="delivery-tabbar__label">我的</p>
-      </a>
-    </div>
+    <CommunityTabbar
+      basePath="/delivery"
+      moduleColor="#f59e0b"
+      :tabs="tabs"
+    />
   </div>
 </template>
 
 <style scoped>
-.delivery-page {
-  min-height: 100vh;
-  background-color: #f5f5f5;
-}
 .delivery-container {
-  padding-bottom: 60px;
+  padding-bottom: 56px;
   box-sizing: border-box;
-}
-
-.delivery-tabbar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 60px;
-  background: #fff;
-  border-top: 1px solid #e5e5e5;
-  display: flex;
-  z-index: 500;
-  box-shadow: 0 -2px 8px rgba(0,0,0,0.04);
-}
-
-.delivery-tabbar__item {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: #999;
-  text-decoration: none;
-  font-size: 12px;
-  padding: 6px 0;
-  transition: all 0.3s ease;
-}
-
-.delivery-tabbar__item.active {
-  color: #fa8231;
-  font-weight: 500;
-}
-
-.delivery-tabbar__item.active .delivery-tabbar__icon {
-  color: #fa8231;
-  transform: scale(1.1);
-}
-
-.delivery-tabbar__icon {
-  display: block;
-  margin-bottom: 4px;
-  color: #999;
-  transition: all 0.3s ease;
-}
-
-.delivery-tabbar__item.active .delivery-tabbar__icon svg {
-  fill: #fa8231;
-}
-
-.delivery-tabbar__label {
-  margin: 0;
-  font-size: 12px;
-  line-height: 1;
-  color: inherit;
 }
 </style>

--- a/frontend/src/views/delivery/Mine.vue
+++ b/frontend/src/views/delivery/Mine.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -109,12 +110,8 @@ watch(() => route.fullPath, () => {
 </script>
 
 <template>
-  <div class="delivery-mine">
-    <div class="delivery-header unified-header">
-      <span class="delivery-header__back" @click="router.push('/')">返回</span>
-      <h1 class="delivery-header__title">我的跑腿</h1>
-      <span class="delivery-header__placeholder"></span>
-    </div>
+  <div class="delivery-mine" style="--module-color: #f59e0b">
+    <CommunityHeader title="我的跑腿" moduleColor="#f59e0b" backTo="/" />
 
     <!-- Tab切换 -->
     <div class="delivery-mine__tabs">
@@ -134,19 +131,22 @@ watch(() => route.fullPath, () => {
 
     <!-- 我发布的 -->
     <div v-if="activeTab === 'published'" class="delivery-mine__content">
-      <div v-if="loading" class="delivery-loading">加载中...</div>
-      <div v-else-if="publishedList.length === 0" class="delivery-empty">暂无发布的任务</div>
+      <div v-if="loading" class="community-loadmore"><i class="community-loading-spinner"></i> 加载中</div>
+      <div v-else-if="publishedList.length === 0" class="community-empty">
+        <div class="community-empty__text">暂无发布的任务</div>
+      </div>
       <div v-else class="delivery-list">
         <div
-          v-for="item in publishedList"
+          v-for="(item, index) in publishedList"
           :key="item.id"
-          class="delivery-card"
+          class="delivery-card community-card"
+          :style="{ animationDelay: (index * 0.05) + 's' }"
           @click="goDetail(item.id)"
         >
           <div class="delivery-card__header">
             <div class="delivery-card__type">{{ getTypeText(item.type) }}</div>
             <div class="delivery-card__reward">
-              <span class="reward-symbol">￥</span>
+              <span class="reward-symbol">&#xffe5;</span>
               <span class="reward-amount">{{ item.reward.toFixed(2) }}</span>
             </div>
           </div>
@@ -174,19 +174,22 @@ watch(() => route.fullPath, () => {
 
     <!-- 我接的单 -->
     <div v-if="activeTab === 'accepted'" class="delivery-mine__content">
-      <div v-if="loading" class="delivery-loading">加载中...</div>
-      <div v-else-if="acceptedList.length === 0" class="delivery-empty">暂无接单的任务</div>
+      <div v-if="loading" class="community-loadmore"><i class="community-loading-spinner"></i> 加载中</div>
+      <div v-else-if="acceptedList.length === 0" class="community-empty">
+        <div class="community-empty__text">暂无接单的任务</div>
+      </div>
       <div v-else class="delivery-list">
         <div
-          v-for="item in acceptedList"
+          v-for="(item, index) in acceptedList"
           :key="item.id"
-          class="delivery-card"
+          class="delivery-card community-card"
+          :style="{ animationDelay: (index * 0.05) + 's' }"
           @click="goDetail(item.id)"
         >
           <div class="delivery-card__header">
             <div class="delivery-card__type">{{ getTypeText(item.type) }}</div>
             <div class="delivery-card__reward">
-              <span class="reward-symbol">￥</span>
+              <span class="reward-symbol">&#xffe5;</span>
               <span class="reward-amount">{{ item.reward.toFixed(2) }}</span>
             </div>
           </div>
@@ -216,41 +219,29 @@ watch(() => route.fullPath, () => {
 
 <style scoped>
 .delivery-mine {
-  background: #f5f5f5;
+  background: var(--c-bg);
   min-height: 100vh;
   padding-bottom: 60px;
 }
 
-.delivery-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-.delivery-header__back { color: #333; cursor: pointer; min-width: 48px; font-size: 14px; }
-.delivery-header__title { flex: 1; text-align: center; font-size: 16px; font-weight: 500; margin: 0; color: #333; }
-.delivery-header__placeholder { min-width: 48px; }
-
 .delivery-mine__tabs {
   display: flex;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
+  background: var(--c-card);
+  border-bottom: 1px solid var(--c-divider);
+  padding: 0 var(--space-lg);
 }
 .mine-tab {
   flex: 1;
   text-align: center;
-  padding: 12px 0;
-  font-size: 15px;
-  color: #666;
+  padding: var(--space-md) 0;
+  font-size: var(--font-md);
+  color: var(--c-text-2);
   cursor: pointer;
   position: relative;
   transition: all 0.3s;
 }
 .mine-tab.active {
-  color: #fa8231;
+  color: var(--c-delivery);
   font-weight: 500;
 }
 .mine-tab.active::after {
@@ -260,70 +251,58 @@ watch(() => route.fullPath, () => {
   left: 0;
   right: 0;
   height: 3px;
-  background: #fa8231;
+  background: var(--c-delivery);
+  border-radius: 3px 3px 0 0;
 }
 
 .delivery-mine__content {
-  padding: 15px;
-}
-
-.delivery-loading,
-.delivery-empty {
-  text-align: center;
-  padding: 40px 20px;
-  color: #999;
-  font-size: 14px;
+  padding: var(--space-lg);
+  animation: community-fade-in 0.3s ease both;
 }
 
 .delivery-list {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: var(--space-lg);
 }
 
 .delivery-card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 15px;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.03);
+  padding: var(--space-lg);
   cursor: pointer;
-  transition: box-shadow 0.3s;
-}
-.delivery-card:active {
-  box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+  animation: community-slide-up 0.4s ease both;
 }
 
 .delivery-card__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 15px;
+  margin-bottom: var(--space-lg);
 }
 .delivery-card__type {
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: 600;
-  color: #333;
+  color: var(--c-text-1);
 }
 .delivery-card__reward {
   display: flex;
   align-items: baseline;
-  color: #ff5252;
+  color: #ef4444;
 }
 .reward-symbol {
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: bold;
   margin-right: 2px;
 }
 .reward-amount {
-  font-size: 24px;
+  font-size: var(--font-2xl);
   font-weight: bold;
 }
 
 .delivery-card__route {
-  margin-bottom: 15px;
-  padding: 12px;
-  background: #f8f9fa;
-  border-radius: 8px;
+  margin-bottom: var(--space-lg);
+  padding: var(--space-md);
+  background: var(--c-bg);
+  border-radius: var(--radius-sm);
 }
 .route-item {
   display: flex;
@@ -336,26 +315,26 @@ watch(() => route.fullPath, () => {
 .route-icon {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: var(--font-sm);
   font-weight: bold;
   color: #fff;
   margin-right: 10px;
   flex-shrink: 0;
 }
 .route-icon--pickup {
-  background: #4a90e2;
+  background: #3b82f6;
 }
 .route-icon--delivery {
-  background: #fa8231;
+  background: var(--c-delivery);
 }
 .route-text {
   flex: 1;
-  font-size: 15px;
-  color: #333;
+  font-size: var(--font-md);
+  color: var(--c-text-1);
   line-height: 1.5;
 }
 
@@ -363,35 +342,34 @@ watch(() => route.fullPath, () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 12px;
-  border-top: 1px solid #f0f0f0;
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--c-border);
 }
-
 .delivery-card__meta {
   display: flex;
-  gap: 12px;
-  font-size: 13px;
-  color: #999;
+  gap: var(--space-md);
+  font-size: var(--font-base);
+  color: var(--c-text-3);
 }
 .meta-time {
   display: inline-block;
 }
 .delivery-badge {
-  padding: 4px 12px;
-  border-radius: 12px;
-  font-size: 12px;
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-full);
+  font-size: var(--font-sm);
   font-weight: 500;
 }
 .delivery-badge.status-pending {
-  background: #fff3cd;
-  color: #856404;
+  background: #fef3c7;
+  color: #92400e;
 }
 .delivery-badge.status-delivering {
-  background: #d1ecf1;
-  color: #0c5460;
+  background: #dbeafe;
+  color: #1e40af;
 }
 .delivery-badge.status-completed {
-  background: #d4edda;
-  color: #155724;
+  background: #d1fae5;
+  color: #065f46;
 }
 </style>

--- a/frontend/src/views/delivery/Publish.vue
+++ b/frontend/src/views/delivery/Publish.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const formData = ref({
@@ -96,18 +97,18 @@ function submit() {
 </script>
 
 <template>
-  <div class="delivery-publish">
-    <div class="delivery-publish__header">
-      <span class="delivery-publish__cancel" @click="router.back()">取消</span>
-      <h1 class="delivery-publish__title">发布任务</h1>
-      <button type="button" class="delivery-publish__submit" :disabled="submitting" @click="submit">
-        {{ submitting ? '提交中...' : '确认发布' }}
-      </button>
-    </div>
+  <div class="delivery-publish" style="--module-color: #f59e0b">
+    <CommunityHeader title="发布任务" moduleColor="#f59e0b" :showBack="false">
+      <template #right>
+        <button type="button" class="delivery-publish__submit" :disabled="submitting" @click="submit">
+          {{ submitting ? '提交中...' : '确认发布' }}
+        </button>
+      </template>
+    </CommunityHeader>
 
     <div class="delivery-publish__content">
       <!-- 取件信息区 -->
-      <div class="form-block">
+      <div class="form-block community-card">
         <div class="form-block__title">取件信息</div>
         <div class="form-item">
           <label class="form-label">取件地点</label>
@@ -131,7 +132,7 @@ function submit() {
           <label class="form-label">取件凭证图片（可选）</label>
           <div v-if="pickupImagePreview" class="image-preview">
             <img :src="pickupImagePreview" />
-            <button type="button" class="image-remove" @click="removePickupImage">×</button>
+            <button type="button" class="image-remove" @click="removePickupImage">x</button>
           </div>
           <div v-else class="image-upload-btn" @click="$refs.pickupImageInput.click()">
             <input
@@ -148,7 +149,7 @@ function submit() {
       </div>
 
       <!-- 送达信息区 -->
-      <div class="form-block">
+      <div class="form-block community-card">
         <div class="form-block__title">送达信息</div>
         <div class="form-item">
           <label class="form-label">送达地址</label>
@@ -172,7 +173,7 @@ function submit() {
       </div>
 
       <!-- 物品描述区 -->
-      <div class="form-block">
+      <div class="form-block community-card">
         <div class="form-block__title">物品描述</div>
         <div class="form-item">
           <label class="form-label">重量/体积</label>
@@ -206,7 +207,7 @@ function submit() {
     <div class="delivery-publish__footer">
       <div class="footer-reward">
         <span class="reward-label">跑腿费：</span>
-        <span class="reward-symbol">￥</span>
+        <span class="reward-symbol">&#xffe5;</span>
         <input
           type="number"
           class="reward-input"
@@ -223,12 +224,12 @@ function submit() {
     </div>
 
     <!-- 提示对话框 -->
-    <div v-if="dialogVisible" class="weui-mask" @click="dialogVisible = false"></div>
-    <div v-if="dialogVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div v-if="dialogVisible" class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div v-if="dialogVisible" class="community-dialog">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
   </div>
@@ -236,40 +237,18 @@ function submit() {
 
 <style scoped>
 .delivery-publish {
-  background: #f5f5f5;
+  background: var(--c-bg);
   min-height: 100vh;
   padding-bottom: 80px;
 }
 
-.delivery-publish__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 15px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-.delivery-publish__cancel {
-  color: #666;
-  font-size: 14px;
-  cursor: pointer;
-}
-.delivery-publish__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
 .delivery-publish__submit {
   padding: 6px 20px;
-  background: #fa8231;
+  background: var(--c-delivery);
   color: #fff;
   border: none;
-  border-radius: 20px;
-  font-size: 14px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-base);
   cursor: pointer;
   transition: opacity 0.3s;
 }
@@ -279,49 +258,49 @@ function submit() {
 }
 
 .delivery-publish__content {
-  padding: 15px;
+  padding: var(--space-lg);
+  animation: community-slide-up 0.4s ease both;
 }
 
 .form-block {
-  background: #fff;
-  border-radius: 12px;
-  padding: 15px;
-  margin-bottom: 15px;
+  padding: var(--space-lg);
+  margin-bottom: var(--space-lg);
 }
 .form-block__title {
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: 600;
-  color: #333;
-  margin-bottom: 15px;
+  color: var(--c-text-1);
+  margin-bottom: var(--space-lg);
   padding-bottom: 10px;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--c-border);
 }
 .form-item {
-  margin-bottom: 15px;
+  margin-bottom: var(--space-lg);
 }
 .form-item:last-child {
   margin-bottom: 0;
 }
 .form-label {
   display: block;
-  font-size: 14px;
-  color: #666;
-  margin-bottom: 8px;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
+  margin-bottom: var(--space-sm);
 }
 .form-input,
 .form-textarea {
   width: 100%;
-  padding: 12px;
-  border: 1px solid #e5e5e5;
-  border-radius: 8px;
-  font-size: 15px;
-  color: #333;
+  padding: var(--space-md);
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-md);
+  color: var(--c-text-1);
   outline: none;
   box-sizing: border-box;
+  transition: border-color 0.2s;
 }
 .form-input:focus,
 .form-textarea:focus {
-  border-color: #fa8231;
+  border-color: var(--c-delivery);
 }
 .form-textarea {
   resize: none;
@@ -332,9 +311,9 @@ function submit() {
   position: relative;
   width: 100px;
   height: 100px;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  background: #f0f0f0;
+  background: var(--c-border);
 }
 .image-preview img {
   width: 100%;
@@ -350,8 +329,8 @@ function submit() {
   background: rgba(0,0,0,0.6);
   color: #fff;
   border: none;
-  border-radius: 50%;
-  font-size: 18px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-xl);
   line-height: 1;
   cursor: pointer;
   display: flex;
@@ -361,23 +340,27 @@ function submit() {
 .image-upload-btn {
   width: 100px;
   height: 100px;
-  border: 2px dashed #ddd;
-  border-radius: 8px;
+  border: 2px dashed var(--c-divider);
+  border-radius: var(--radius-sm);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  background: #fafafa;
+  background: var(--c-bg);
+  transition: border-color 0.2s;
+}
+.image-upload-btn:active {
+  border-color: var(--c-delivery);
 }
 .upload-icon {
   font-size: 32px;
-  color: #999;
-  margin-bottom: 4px;
+  color: var(--c-text-3);
+  margin-bottom: var(--space-xs);
 }
 .upload-text {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
 }
 
 .size-tags {
@@ -386,71 +369,72 @@ function submit() {
   flex-wrap: wrap;
 }
 .size-tag {
-  padding: 8px 16px;
-  border: 1px solid #e5e5e5;
-  border-radius: 20px;
-  background: #fff;
-  color: #666;
-  font-size: 14px;
+  padding: var(--space-sm) var(--space-lg);
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-full);
+  background: var(--c-card);
+  color: var(--c-text-2);
+  font-size: var(--font-base);
   cursor: pointer;
   transition: all 0.3s;
 }
 .size-tag.active {
-  background: #fa8231;
+  background: var(--c-delivery);
   color: #fff;
-  border-color: #fa8231;
+  border-color: var(--c-delivery);
 }
 
 .delivery-publish__footer {
   position: fixed;
-  bottom: 60px;
+  bottom: 56px;
   left: 0;
   right: 0;
   display: flex;
   align-items: center;
-  padding: 12px 15px;
-  background: #fff;
-  border-top: 1px solid #e5e5e5;
+  padding: var(--space-md) var(--space-lg);
+  background: var(--c-card);
+  border-top: 1px solid var(--c-border);
   z-index: 100;
   box-shadow: 0 -2px 8px rgba(0,0,0,0.04);
 }
 .footer-reward {
   display: flex;
   align-items: center;
-  margin-right: 15px;
+  margin-right: var(--space-lg);
 }
 .reward-label {
-  font-size: 14px;
-  color: #666;
-  margin-right: 4px;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
+  margin-right: var(--space-xs);
 }
 .reward-symbol {
-  font-size: 16px;
-  color: #ff5252;
+  font-size: var(--font-lg);
+  color: #ef4444;
   font-weight: bold;
 }
 .reward-input {
   width: 80px;
-  padding: 6px 8px;
-  border: 1px solid #e5e5e5;
-  border-radius: 4px;
-  font-size: 16px;
-  color: #ff5252;
+  padding: 6px var(--space-sm);
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-lg);
+  color: #ef4444;
   font-weight: bold;
   outline: none;
-  margin-left: 4px;
+  margin-left: var(--space-xs);
+  transition: border-color 0.2s;
 }
 .reward-input:focus {
-  border-color: #fa8231;
+  border-color: var(--c-delivery);
 }
 .footer-submit {
   flex: 1;
   height: 44px;
-  background: #fa8231;
+  background: var(--c-delivery);
   color: #fff;
   border: none;
-  border-radius: 8px;
-  font-size: 16px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-lg);
   font-weight: 500;
   cursor: pointer;
   transition: opacity 0.3s;
@@ -458,50 +442,5 @@ function submit() {
 .footer-submit:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-}
-
-.weui-mask {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 16px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #eee;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 14px;
-  text-align: center;
-  color: #fa8231;
-  text-decoration: none;
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/ershou/Detail.vue
+++ b/frontend/src/views/ershou/Detail.vue
@@ -10,6 +10,7 @@ const id = route.params.id
 
 const loading = ref(true)
 const detail = ref(null)
+const errorMessage = ref('')
 const tipVisible = ref(false)
 const tipText = ref('')
 
@@ -86,9 +87,11 @@ onMounted(async () => {
       detail.value = mapErshouDetail(info)
     } else {
       detail.value = null
+      errorMessage.value = res?.message || '商品不存在'
     }
   } catch (e) {
     detail.value = null
+    errorMessage.value = '加载失败，请稍后重试'
   } finally {
     loading.value = false
   }
@@ -164,7 +167,7 @@ onMounted(async () => {
     </template>
 
     <div v-else class="community-empty">
-      <p class="community-empty__text">加载失败或商品不存在</p>
+      <p class="community-empty__text">{{ errorMessage || '加载失败或商品不存在' }}</p>
     </div>
 
     <!-- 底部悬浮操作栏 -->

--- a/frontend/src/views/ershou/Detail.vue
+++ b/frontend/src/views/ershou/Detail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -97,22 +98,18 @@ onMounted(async () => {
 <template>
   <div class="ershou-detail-page">
     <!-- 统一顶部导航栏 -->
-    <div class="unified-header">
-      <span class="unified-header__back" @click="router.back()">返回</span>
-      <h1 class="unified-header__title">商品详情</h1>
-      <span class="unified-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="商品详情" moduleColor="#10b981" :showBack="true" @back="router.back()" backTo="" />
 
     <!-- 加载中 -->
     <div v-if="loading" class="detail-loading">
-      <div class="weui-loading"></div>
+      <div class="community-loading-spinner" style="width: 24px; height: 24px;"></div>
       <p>加载中</p>
     </div>
 
     <template v-else-if="detail">
-      <!-- 主体：复刻 ershouDetail.jsp 的 section.detail + section.userinfo -->
+      <!-- 主体 -->
       <section class="detail">
-        <!-- 多图：原版为轮播，此处上下堆叠展示 -->
+        <!-- 多图 -->
         <div class="detail-images">
           <img
             v-for="(img, idx) in detail.images"
@@ -123,7 +120,7 @@ onMounted(async () => {
           />
         </div>
 
-        <!-- 商品基本信息：价格（圆形）、标题、发布时间 -->
+        <!-- 商品基本信息 -->
         <div class="info">
           <em class="price"><b>￥</b>{{ detail.price }}</em>
           <h5 class="tit">{{ detail.title }}</h5>
@@ -149,7 +146,7 @@ onMounted(async () => {
           <p class="w">商品描述：{{ detail.desc || '—' }}</p>
         </div>
 
-        <!-- 联系方式：QQ、手机（打电话/发短信） -->
+        <!-- 联系方式 -->
         <div class="contact">
           <i class="i icontact"></i>
           <p class="qq">qq：<b>{{ detail.contact?.qq || '—' }}</b></p>
@@ -166,55 +163,30 @@ onMounted(async () => {
       </section>
     </template>
 
-    <div v-else class="detail-empty">
-      <p>加载失败或商品不存在</p>
+    <div v-else class="community-empty">
+      <p class="community-empty__text">加载失败或商品不存在</p>
     </div>
 
-    <!-- 底部悬浮操作栏：复制QQ、拨打电话 -->
+    <!-- 底部悬浮操作栏 -->
     <div v-if="detail && !loading" class="detail-action-bar">
       <button type="button" class="action-btn" @click="copyQQ">复制QQ</button>
       <button v-if="detail.contact?.phone" type="button" class="action-btn primary" @click="callPhone">拨打电话</button>
     </div>
 
-    <!-- 底部栏占位，避免内容被遮挡 -->
+    <!-- 底部栏占位 -->
     <div v-if="detail && !loading" class="detail-action-bar-placeholder"></div>
 
-    <!-- WEUI TopTips -->
-    <div v-show="tipVisible" class="weui-toptips weui-toptips_warn">{{ tipText }}</div>
+    <!-- TopTips -->
+    <div v-show="tipVisible" class="toptips">{{ tipText }}</div>
   </div>
 </template>
 
 <style scoped>
 .ershou-detail-page {
   min-height: 100vh;
-  background: #e3eeec;
+  background: var(--c-bg);
   padding-bottom: 20px;
 }
-
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__placeholder { min-width: 48px; }
 
 .detail-loading {
   display: flex;
@@ -222,45 +194,28 @@ onMounted(async () => {
   align-items: center;
   justify-content: center;
   padding: 60px 20px;
-  color: #999;
+  color: var(--c-text-3);
 }
-.weui-loading {
-  width: 24px;
-  height: 24px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-.detail-loading p { margin: 12px 0 0; font-size: 14px; }
-
-.detail-empty {
-  text-align: center;
-  padding: 40px 20px;
-  color: #999;
-}
+.detail-loading p { margin: 12px 0 0; font-size: var(--font-base); }
 
 /* 复刻 ershou-base.css .detail */
 .detail { margin: 0 10px 10px; }
 .detail-images {
-  background: #fff;
-  border-radius: 8px;
+  background: var(--c-card);
+  border-radius: var(--radius-md);
   overflow: hidden;
-  box-shadow: 0 0 2px #d6e0de;
+  box-shadow: var(--shadow-sm);
 }
 .detail-img {
   width: 100%;
   display: block;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   margin-top: 10px;
 }
 .detail-img:first-child { margin-top: 0; }
 
 .detail .info {
-  background: #44c1a5;
+  background: #10b981;
   padding: 10px 70px 10px 12px;
   position: relative;
 }
@@ -270,7 +225,7 @@ onMounted(async () => {
   margin: 0 0 4px;
 }
 .detail .info .tm {
-  font-size: 14px;
+  font-size: var(--font-base);
   color: #fff;
   margin: 0;
 }
@@ -293,7 +248,7 @@ onMounted(async () => {
 .detail .info .price b {
   position: absolute;
   top: 4px;
-  font-size: 12px;
+  font-size: var(--font-sm);
   line-height: 12px;
   left: 50%;
   margin-left: -5px;
@@ -301,11 +256,11 @@ onMounted(async () => {
 }
 
 .detail .site {
-  background: #fff;
+  background: var(--c-card);
   padding: 8px 10px 8px 98px;
-  color: #45c1a6;
+  color: var(--c-ershou);
   line-height: 20px;
-  font-size: 14px;
+  font-size: var(--font-base);
   position: relative;
   margin: 0;
 }
@@ -330,9 +285,9 @@ onMounted(async () => {
 .userinfo .info,
 .userinfo .contact {
   margin: 10px 0 0;
-  background: #fff;
-  box-shadow: 0 0 2px #d6e0de;
-  border-radius: 4px;
+  background: var(--c-card);
+  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 .userinfo .user {
@@ -357,16 +312,16 @@ onMounted(async () => {
 }
 .userinfo .user .nm {
   line-height: 30px;
-  font-size: 16px;
-  color: #565656;
+  font-size: var(--font-lg);
+  color: var(--c-text-2);
 }
 
 .userinfo .info,
 .userinfo .contact {
   position: relative;
   padding: 15px 15px 15px 60px;
-  font-size: 14px;
-  color: #666;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
 }
 .userinfo .info p,
 .userinfo .contact p { line-height: 20px; margin: 0 0 2px; }
@@ -382,15 +337,15 @@ onMounted(async () => {
 }
 .userinfo .contact .icontact { background-position: 0 -30px; }
 .userinfo .contact .cont a { margin-left: 5px; }
-.userinfo .contact .phone a { color: #565656; }
+.userinfo .contact .phone a { color: var(--c-text-2); }
 
 .footer {
   text-align: center;
   line-height: 38px;
   height: 38px;
   margin-top: 20px;
-  color: #999;
-  font-size: 12px;
+  color: var(--c-text-3);
+  font-size: var(--font-sm);
 }
 
 /* 底部悬浮操作栏 */
@@ -404,7 +359,7 @@ onMounted(async () => {
   align-items: center;
   gap: 12px;
   padding: 10px 12px;
-  background: #fff;
+  background: var(--c-card);
   box-shadow: 0 -2px 10px rgba(0,0,0,0.08);
   z-index: 400;
 }
@@ -412,10 +367,10 @@ onMounted(async () => {
   flex: 1;
   height: 44px;
   border: none;
-  border-radius: 6px;
-  font-size: 16px;
-  background: #f0f0f0;
-  color: #333;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-lg);
+  background: var(--c-bg);
+  color: var(--c-text-1);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -424,26 +379,24 @@ onMounted(async () => {
   line-height: 1;
 }
 .action-btn.primary {
-  background: #3cb395;
+  background: #10b981;
   color: #fff;
 }
 .detail-action-bar-placeholder {
   height: 70px;
 }
 
-/* WEUI TopTips */
-.weui-toptips {
+/* TopTips */
+.toptips {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   padding: 10px;
   text-align: center;
-  font-size: 14px;
+  font-size: var(--font-base);
   z-index: 6000;
   transition: opacity 0.3s;
-}
-.weui-toptips_warn {
   background: rgba(0,0,0,0.7);
   color: #fff;
 }

--- a/frontend/src/views/ershou/Home.vue
+++ b/frontend/src/views/ershou/Home.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const keyword = ref('')
@@ -80,23 +81,19 @@ onMounted(() => {
 
 <template>
   <div class="ershou-home">
-    <!-- 统一顶部导航栏：左侧返回到应用首页，标题「二手交易」，无右侧菜单 -->
-    <div class="ershou-header unified-header">
-      <span class="ershou-header__back" @click="router.push('/')">返回</span>
-      <h1 class="ershou-header__title">二手交易</h1>
-      <span class="ershou-header__placeholder"></span>
-    </div>
+    <!-- 统一顶部导航栏 -->
+    <CommunityHeader title="二手交易" moduleColor="#10b981" />
 
-    <!-- 搜索栏：原版 ershouIndex.jsp 结构，图标+占位符+搜索按钮 -->
+    <!-- 搜索栏 -->
     <div class="ershou-search-bar">
       <div class="search-input-wrap">
-        <i class="weui-icon-search"></i>
+        <i class="search-icon"></i>
         <input type="text" placeholder="搜搜看" v-model="keyword" @keyup.enter="doSearch" />
       </div>
       <span class="search-btn" @click="doSearch">搜索</span>
     </div>
 
-    <!-- 分类宫格：强制 4 列 x 3 行 Grid，sprite /img/ershou/menu.png -->
+    <!-- 分类宫格 -->
     <div class="category-grid">
       <div
         v-for="(cat, index) in categories"
@@ -119,12 +116,12 @@ onMounted(() => {
       @touchend="handleTouchEnd"
     >
       <!-- 下拉刷新指示器 -->
-      <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-        <span v-if="refreshing" class="pull-refresh-text">
-          <i class="weui-loading"></i> 正在刷新...
+      <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+        <span v-if="refreshing" class="community-pull-refresh__text">
+          <i class="community-loading-spinner"></i> 正在刷新...
         </span>
-        <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-        <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+        <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+        <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
       </div>
 
       <!-- 商品双列网格 -->
@@ -132,7 +129,7 @@ onMounted(() => {
         <div
           v-for="item in list"
           :key="item.id"
-          class="ershou-goods-card"
+          class="ershou-goods-card community-card"
           @click="goDetail(item.id)"
         >
           <div class="ershou-goods-card__img-wrap">
@@ -145,23 +142,23 @@ onMounted(() => {
       </div>
 
       <!-- 上拉加载更多 -->
-      <div v-if="loading && !refreshing" class="ershou-loadmore">
-        <i class="weui-loading"></i>
-        <span class="weui-loadmore__tips">正在加载</span>
+      <div v-if="loading && !refreshing" class="community-loadmore">
+        <i class="community-loading-spinner"></i>
+        <span>正在加载</span>
       </div>
-      <div v-if="finished && list.length > 0" class="ershou-loadmore">
-        <span class="weui-loadmore__tips">没有更多了</span>
+      <div v-if="finished && list.length > 0" class="community-loadmore">
+        <span>没有更多了</span>
       </div>
     </div>
 
-    <!-- WEUI Dialog 对话框 -->
+    <!-- Dialog -->
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
@@ -170,113 +167,91 @@ onMounted(() => {
 
 <style scoped>
 .ershou-home {
-  background-color: #f5f5f5;
+  background-color: var(--c-bg);
   min-height: 100vh;
   padding-bottom: 20px;
-}
-
-.ershou-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.ershou-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.ershou-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.ershou-header__placeholder {
-  min-width: 48px;
-  text-align: right;
 }
 
 .ershou-search-bar {
   display: flex;
   align-items: center;
   padding: 10px 15px;
-  background-color: #f5f5f5;
+  background-color: var(--c-bg);
 }
 .search-input-wrap {
   flex: 1;
   display: flex;
   align-items: center;
-  background-color: #fff;
-  border-radius: 20px;
+  background-color: var(--c-card);
+  border-radius: var(--radius-full);
   padding: 5px 12px;
+  box-shadow: var(--shadow-sm);
 }
-.search-input-wrap .weui-icon-search {
+.search-icon {
   display: inline-block;
   width: 16px;
   height: 16px;
   font-size: 16px;
-  color: #b2b2b2;
+  color: var(--c-text-3);
   margin-right: 5px;
   flex-shrink: 0;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23b2b2b2'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") center/contain no-repeat;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%239ca3af'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") center/contain no-repeat;
 }
 .search-input-wrap input {
   flex: 1;
   border: none;
   outline: none;
-  font-size: 14px;
+  font-size: var(--font-base);
   background: transparent;
   min-width: 0;
+  color: var(--c-text-1);
 }
 .search-btn {
-  color: #3cb395;
-  font-size: 15px;
+  color: var(--c-ershou);
+  font-size: var(--font-md);
   margin-left: 15px;
   white-space: nowrap;
   cursor: pointer;
+  font-weight: 500;
 }
 
-/* 分类宫格：强制 4 列 x 3 行 Grid，防止只显示 4 个大块不换行 */
+/* 分类宫格：白色卡片风格 */
 .category-grid {
   display: grid !important;
   grid-template-columns: repeat(4, 1fr) !important;
   grid-auto-rows: min-content;
-  width: 100%;
+  width: calc(100% - 20px);
   margin: 0 10px 15px 10px;
-  background-color: #3cb395;
-  border-radius: 4px;
+  background-color: var(--c-card);
+  border-radius: var(--radius-md);
   overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(16, 185, 129, 0.12);
 }
 .category-grid .menu-item {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 10px 0;
+  padding: 12px 0;
   min-height: 50px;
-  background: #3cc2a5;
+  background: var(--c-card);
   cursor: pointer;
-  color: #fff;
+  color: var(--c-text-1);
   text-align: center;
+  transition: background 0.2s;
 }
-.category-grid .menu-item:nth-child(odd) {
-  background: #24b19c;
+.category-grid .menu-item:active {
+  background: var(--c-bg);
 }
 .category-grid .menu-item .i {
   background: url(/img/ershou/menu.png) no-repeat;
   background-size: 88px;
   width: 22px;
   height: 16px;
-  margin: 0 0 4px;
+  margin: 0 0 6px;
   flex-shrink: 0;
+  filter: hue-rotate(10deg) saturate(1.2);
 }
 .category-grid .menu-item .ibicycle { background-position: 0 0; }
 .category-grid .menu-item .iphone { background-position: -22px 0; }
@@ -291,10 +266,10 @@ onMounted(() => {
 .category-grid .menu-item .idigital { background-position: -44px -32px; }
 .category-grid .menu-item .ilease { background-position: -66px -32px; }
 .category-grid .menu-item .t {
-  color: #fff;
+  color: var(--c-text-2);
   display: block;
   line-height: 12px;
-  font-size: 12px;
+  font-size: var(--font-sm);
 }
 
 /* 商品双列网格 */
@@ -305,17 +280,14 @@ onMounted(() => {
   padding: 0 10px 20px;
 }
 .ershou-goods-card {
-  background: #fff;
-  border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   cursor: pointer;
 }
 .ershou-goods-card__img-wrap {
   width: 100%;
   aspect-ratio: 1;
   overflow: hidden;
-  background-color: #f0f0f0;
+  background-color: var(--c-border);
 }
 .ershou-goods-card__img {
   width: 100%;
@@ -324,9 +296,9 @@ onMounted(() => {
   display: block;
 }
 .ershou-goods-card__title {
-  font-size: 14px;
+  font-size: var(--font-base);
   font-weight: 500;
-  color: #333;
+  color: var(--c-text-1);
   margin: 8px 8px 0;
   padding: 0;
   display: -webkit-box;
@@ -336,8 +308,8 @@ onMounted(() => {
   line-height: 1.35;
 }
 .ershou-goods-card__desc {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
   margin: 4px 8px 0;
   padding: 0;
   white-space: nowrap;
@@ -346,7 +318,7 @@ onMounted(() => {
 }
 .ershou-goods-card__price {
   display: block;
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: 600;
   color: #e4393c;
   margin: 6px 8px 8px;
@@ -360,112 +332,5 @@ onMounted(() => {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-y: contain;
-}
-
-/* 下拉刷新指示器 */
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-/* 加载更多 */
-.ershou-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.ershou-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-.weui-loadmore__tips {
-  font-size: 14px;
-  color: #999;
-}
-
-/* WEUI Dialog 样式 */
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-  word-wrap: break-word;
-  word-break: break-all;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #3cc395;
-  text-decoration: none;
-  border-right: 1px solid #d9d9d9;
-}
-.weui-dialog__btn:last-child {
-  border-right: none;
-}
-.weui-dialog__btn_primary {
-  color: #3cc395;
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/ershou/Index.vue
+++ b/frontend/src/views/ershou/Index.vue
@@ -1,125 +1,26 @@
 <script setup>
-import { computed } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-
-const router = useRouter()
-const route = useRoute()
-
-const activeTab = computed(() => {
-  const p = route.path
-  if (p.includes('/ershou/publish')) return 'publish'
-  if (p.includes('/ershou/profile')) return 'profile'
-  return 'home'
-})
-
-function goTo(path) {
-  router.push(path)
-}
+import CommunityTabbar from '../../components/community/CommunityTabbar.vue'
 </script>
 
 <template>
-  <div class="ershou-page weui-tab">
-    <div class="ershou-container weui-tab__panel">
+  <div class="community-page" style="--module-color: #10b981">
+    <div class="ershou-container" style="padding-bottom: 56px">
       <router-view />
     </div>
-    <!-- 原版 JSP：Tabbar 使用 <img>，强制吸底 -->
-    <div class="ershou-tabbar weui-tabbar main-nav">
-      <a
-        href="javascript:;"
-        class="ershou-tabbar__item"
-        :class="{ on: activeTab === 'home' }"
-        @click.prevent="goTo('/ershou/home')"
-      >
-        <i class="ibar weui-tabbar__icon"><img :src="activeTab === 'home' ? '/img/ershou/home_selected.png' : '/img/ershou/home_normal.png'" alt="首页"></i>
-        <p class="ershou-tabbar__label weui-tabbar__label">首页</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="ershou-tabbar__item"
-        :class="{ on: activeTab === 'publish' }"
-        @click.prevent="goTo('/ershou/publish')"
-      >
-        <i class="ibar weui-tabbar__icon"><img src="/img/ershou/publish.png" alt="发布"></i>
-        <p class="ershou-tabbar__label weui-tabbar__label">发布</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="ershou-tabbar__item"
-        :class="{ on: activeTab === 'profile' }"
-        @click.prevent="goTo('/ershou/profile')"
-      >
-        <i class="ibar weui-tabbar__icon"><img :src="activeTab === 'profile' ? '/img/ershou/personal_selected.png' : '/img/ershou/personal_normal.png'" alt="个人中心"></i>
-        <p class="ershou-tabbar__label weui-tabbar__label">个人中心</p>
-      </a>
-    </div>
+    <CommunityTabbar
+      basePath="/ershou"
+      moduleColor="#10b981"
+      :tabs="[
+        { key: 'home', label: '首页', path: '/ershou/home', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z&quot;/></svg>' },
+        { key: 'publish', label: '发布', path: '/ershou/publish', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z&quot;/></svg>' },
+        { key: 'profile', label: '我的', path: '/ershou/profile', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z&quot;/></svg>' }
+      ]"
+    />
   </div>
 </template>
 
 <style scoped>
-.ershou-page {
-  min-height: 100vh;
-  background-color: #f5f5f5;
-}
 .ershou-container {
-  padding-bottom: 20px;
   box-sizing: border-box;
-}
-.ershou-tabbar.weui-tabbar {
-  position: fixed !important;
-  bottom: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  width: 100vw !important;
-  max-width: 100%;
-  margin: 0 !important;
-  padding: 0 !important;
-  z-index: 500;
-  background-color: #3cb395;
-  display: flex;
-}
-.ershou-tabbar.main-nav {
-  height: 2.7rem;
-  color: #fff;
-}
-.ershou-tabbar__item {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: rgba(255, 255, 255, 0.85);
-  text-decoration: none;
-  font-size: 12px;
-}
-.ershou-tabbar__item.on {
-  color: #fff;
-  font-weight: 500;
-}
-.ibar {
-  display: block;
-  margin-bottom: 2px;
-}
-.ibar img {
-  height: 1.4rem;
-  display: block;
-}
-.ershou-tabbar .weui-tabbar__icon {
-  width: 24px !important;
-  height: 24px !important;
-  margin: 0 auto 2px auto !important;
-  display: block;
-}
-.ershou-tabbar .weui-tabbar__icon img {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
-.ershou-tabbar .weui-tabbar__label {
-  text-align: center !important;
-  font-size: 12px !important;
-  line-height: 1 !important;
-  margin: 0 !important;
-  padding: 0;
-  color: #fff !important;
 }
 </style>

--- a/frontend/src/views/ershou/Profile.vue
+++ b/frontend/src/views/ershou/Profile.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { getCurrentUserProfile } from '../../api/user.js'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -128,11 +129,7 @@ watch(() => route.fullPath, () => {
 
 <template>
   <div class="ershou-profile-page">
-    <div class="ershou-header unified-header">
-      <span class="ershou-header__back" @click="router.push('/ershou/home')">返回</span>
-      <h1 class="ershou-header__title">个人中心</h1>
-      <span class="ershou-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="个人中心" moduleColor="#10b981" backTo="/ershou/home" />
 
     <section class="profile">
       <i class="avt"><img class="avatar-img" :src="avatar" alt="头像"></i>
@@ -153,7 +150,7 @@ watch(() => route.fullPath, () => {
         <div v-show="activeStat === 'doing'" class="statlist">
           <p v-if="loading" class="nostatus-tip">加载中...</p>
           <template v-else>
-            <div v-for="item in doingList" :key="item.id" class="stat">
+            <div v-for="item in doingList" :key="item.id" class="stat community-card">
               <div class="info" @click="goDetail(item.id)">
                 <i class="img"><img :src="item.preview" :alt="item.name"></i>
                 <h5 class="tit">{{ item.name }}</h5>
@@ -173,7 +170,7 @@ watch(() => route.fullPath, () => {
         <div v-show="activeStat === 'sold'" class="statlist">
           <p v-if="loading" class="nostatus-tip">加载中...</p>
           <template v-else>
-            <div v-for="item in soldList" :key="item.id" class="stat">
+            <div v-for="item in soldList" :key="item.id" class="stat community-card">
               <div class="info">
                 <i class="img"><img :src="item.preview" :alt="item.name"></i>
                 <h5 class="tit">{{ item.name }}</h5>
@@ -191,7 +188,7 @@ watch(() => route.fullPath, () => {
         <div v-show="activeStat === 'off'" class="statlist">
           <p v-if="loading" class="nostatus-tip">加载中...</p>
           <template v-else>
-            <div v-for="item in offList" :key="item.id" class="stat">
+            <div v-for="item in offList" :key="item.id" class="stat community-card">
               <div class="info" @click="goDetail(item.id)">
                 <i class="img"><img :src="item.preview" :alt="item.name"></i>
                 <h5 class="tit">{{ item.name }}</h5>
@@ -210,12 +207,12 @@ watch(() => route.fullPath, () => {
     </section>
 
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
@@ -227,37 +224,8 @@ watch(() => route.fullPath, () => {
 <style scoped>
 .ershou-profile-page {
   min-height: 100vh;
-  background: #e3eeec;
+  background: var(--c-bg);
   padding-bottom: 60px;
-}
-
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.ershou-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.ershou-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.ershou-header__placeholder {
-  min-width: 48px;
-  text-align: right;
 }
 
 .avatar-img {
@@ -270,9 +238,7 @@ watch(() => route.fullPath, () => {
 
 .profile {
   position: relative;
-  background: #44c1a5;
-  border-top: 1px solid #39b89d;
-  border-bottom: 4px solid #3cab93;
+  background: linear-gradient(135deg, #10b981, #059669);
   padding: 30px 20px 20px 140px;
   min-height: 90px;
 }
@@ -293,7 +259,7 @@ watch(() => route.fullPath, () => {
   border-radius: 50%;
 }
 .profile .nm {
-  font-size: 20px;
+  font-size: var(--font-2xl);
   color: #fff;
   display: block;
   margin-bottom: 5px;
@@ -301,7 +267,7 @@ watch(() => route.fullPath, () => {
 .profile .introduction {
   color: #fff;
   line-height: 21px;
-  font-size: 12px;
+  font-size: var(--font-sm);
   display: block;
 }
 .profile .intro-p {
@@ -314,47 +280,45 @@ watch(() => route.fullPath, () => {
 .status .tabs {
   display: flex;
   margin-bottom: 10px;
-  background: #fff;
-  border-radius: 4px;
+  background: var(--c-card);
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  box-shadow: 0 0 2px #d6e0de;
+  box-shadow: var(--shadow-sm);
 }
 .status .tab {
   flex: 1;
   display: block;
   position: relative;
-  color: #44c1a5;
+  color: var(--c-ershou);
   text-align: center;
   height: 32px;
   line-height: 32px;
-  font-size: 14px;
+  font-size: var(--font-base);
   cursor: pointer;
 }
 .status .tab .line {
   width: 28px;
-  height: 1px;
-  background: #44c1a5;
+  height: 2px;
+  background: var(--c-ershou);
   position: absolute;
   left: 50%;
   margin-left: -14px;
   bottom: 0;
   display: none;
+  border-radius: 1px;
 }
 .status .tabs .on .line { display: block; }
 .status .tabs .on { font-weight: 600; }
 
 .status .stat {
-  background: #fff;
   margin-bottom: 8px;
-  border-radius: 4px;
   overflow: hidden;
-  box-shadow: 0 0 2px #d6e0de;
 }
 .status .stat .info {
   position: relative;
   padding: 8px 8px 8px 75px;
   min-height: 60px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--c-border);
 }
 .status .info .img {
   position: absolute;
@@ -363,11 +327,12 @@ watch(() => route.fullPath, () => {
   height: 60px;
   overflow: hidden;
   top: 8px;
+  border-radius: var(--radius-sm);
 }
 .status .info img { width: 100%; height: 100%; object-fit: cover; }
-.status .info h5 { color: #1c826c; font-size: 14px; line-height: 20px; margin: 0 0 4px; }
+.status .info h5 { color: var(--c-ershou); font-size: var(--font-base); line-height: 20px; margin: 0 0 4px; }
 .status .info .price { color: #eb5055; line-height: 18px; font-style: normal; }
-.status .info .tm { color: #999; font-size: 12px; margin: 0; }
+.status .info .tm { color: var(--c-text-3); font-size: var(--font-sm); margin: 0; }
 .status .stat .btns {
   display: flex;
 }
@@ -381,82 +346,27 @@ watch(() => route.fullPath, () => {
 }
 .status .btns .btn b {
   display: block;
-  color: #999;
-  border-left: 1px solid #ddd;
+  color: var(--c-text-3);
+  border-left: 1px solid var(--c-border);
   line-height: 16px;
   height: 16px;
   font-weight: normal;
 }
 .status .btns .btn:first-child b { border-left: none; }
 .readonly-hint {
-  color: #aaa;
+  color: var(--c-text-3);
   font-weight: normal;
-  font-size: 12px;
+  font-size: var(--font-sm);
   border-left: none;
 }
 
 .nostatus-tip {
   text-align: center;
-  color: #999;
-  font-size: 14px;
+  color: var(--c-text-3);
+  font-size: var(--font-base);
   padding: 24px;
   margin: 0;
-  background: #fff;
-  border-radius: 4px;
-}
-
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-  word-wrap: break-word;
-  word-break: break-all;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #3cc395;
-  text-decoration: none;
-}
-.weui-dialog__btn_primary {
-  color: #3cc395;
-  font-weight: 500;
+  background: var(--c-card);
+  border-radius: var(--radius-sm);
 }
 </style>

--- a/frontend/src/views/ershou/Publish.vue
+++ b/frontend/src/views/ershou/Publish.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { uploadFilesByPresignedUrl } from '../../utils/presignedUpload'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -233,13 +234,13 @@ onMounted(() => {
 
 <template>
   <div class="ershou-publish body1">
-    <div class="unified-header">
-      <span class="unified-header__back" @click="goBack">返回</span>
-      <h1 class="unified-header__title">{{ isEditMode ? '编辑二手商品' : '发布二手商品' }}</h1>
-      <a href="javascript:;" class="unified-header__submit" @click.prevent="submit">
-        {{ submitting ? '提交中' : (isEditMode ? '保存' : '完成') }}
-      </a>
-    </div>
+    <CommunityHeader :title="isEditMode ? '编辑二手商品' : '发布二手商品'" moduleColor="#10b981" :showBack="true" :backTo="isEditMode ? '/ershou/profile' : '/ershou/home'">
+      <template #right>
+        <a href="javascript:;" class="header-submit" @click.prevent="submit">
+          {{ submitting ? '提交中' : (isEditMode ? '保存' : '完成') }}
+        </a>
+      </template>
+    </CommunityHeader>
 
     <section class="picture">
       <div class="images">
@@ -311,12 +312,12 @@ onMounted(() => {
     </section>
 
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
@@ -339,46 +340,23 @@ onMounted(() => {
 </template>
 
 <style scoped>
-.body1 { background: #fff; }
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__submit {
+.body1 { background: var(--c-card); }
+
+.header-submit {
   min-width: 48px;
   text-align: right;
-  font-size: 14px;
-  color: #3cb395;
+  font-size: var(--font-base);
+  color: var(--c-ershou);
   text-decoration: none;
   font-weight: 500;
 }
-.unified-header__submit:hover {
-  color: #2a9d82;
+.header-submit:hover {
+  color: #059669;
 }
 
 .picture {
-  background: #3cc2a5;
-  border-top: 1px solid #39b89d;
+  background: #10b981;
+  border-top: 1px solid #0d9668;
 }
 .picture .images { padding: 25px 16px 0; margin-bottom: 5px; }
 .images .image {
@@ -388,7 +366,7 @@ onMounted(() => {
   margin: 0 6px 10px;
   vertical-align: top;
 }
-.images .image .img { width: 70px; height: 70px; overflow: hidden; display: block; }
+.images .image .img { width: 70px; height: 70px; overflow: hidden; display: block; border-radius: var(--radius-sm); }
 .images .image img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .images .image a {
   display: block;
@@ -406,6 +384,7 @@ onMounted(() => {
 .images .addimg {
   width: 68px; height: 68px;
   border: 2px solid #fff;
+  border-radius: var(--radius-sm);
   display: inline-block;
   margin: 0 6px 10px;
   vertical-align: top;
@@ -428,34 +407,34 @@ onMounted(() => {
 }
 .images .addimg .iadd .i1 { width: 100%; height: 2px; position: absolute; top: 11px; background: #fff; }
 .images .addimg .iadd .i2 { height: 100%; width: 2px; position: absolute; left: 11px; background: #fff; }
-.picture .tip { height: 24px; line-height: 24px; text-align: center; color: #fff; font-size: 14px; padding-bottom: 3px; }
+.picture .tip { height: 24px; line-height: 24px; text-align: center; color: #fff; font-size: var(--font-base); padding-bottom: 3px; }
 
 .form { padding: 0 20px; }
 .form-loading {
   margin: 16px 0 0;
-  color: #999;
-  font-size: 14px;
+  color: var(--c-text-3);
+  font-size: var(--font-base);
   text-align: center;
 }
 .form .frm {
   position: relative;
   padding-left: 90px;
-  font-size: 16px;
-  border-bottom: 2px solid #3cc2a5;
+  font-size: var(--font-lg);
+  border-bottom: 2px solid var(--c-ershou);
   min-height: 70px;
   padding-bottom: 10px;
 }
-.form .frm .frm-input { resize: none; border: none; background: none; width: 100%; font-size: 16px; color: #202020; padding: 0; margin-top: 14px; }
-.form .frmt { position: absolute; left: 0; color: #202020; height: 70px; line-height: 70px; }
+.form .frm .frm-input { resize: none; border: none; background: none; width: 100%; font-size: var(--font-lg); color: var(--c-text-1); padding: 0; margin-top: 14px; }
+.form .frmt { position: absolute; left: 0; color: var(--c-text-1); height: 70px; line-height: 70px; }
 .form .frmc { padding-top: 18px; }
-.form .frmc input { color: #202020; background: none; height: 34px; line-height: 34px; font-size: 16px; width: 100%; border: none; }
-.form .frmc b { height: 34px; line-height: 34px; font-size: 16px; width: 100%; color: #202020; display: block; position: relative; cursor: pointer; }
+.form .frmc input { color: var(--c-text-1); background: none; height: 34px; line-height: 34px; font-size: var(--font-lg); width: 100%; border: none; }
+.form .frmc b { height: 34px; line-height: 34px; font-size: var(--font-lg); width: 100%; color: var(--c-text-1); display: block; position: relative; cursor: pointer; }
 .form .frmc b .iarrow {
   background: url(/img/ershou/arrow.png) no-repeat;
   width: 8px; height: 12px; background-size: 8px;
   position: absolute; right: 10px; top: 10px;
 }
-.form .frmtip { position: absolute; bottom: 0; left: 0; background: #fe6a7c; height: 15px; line-height: 15px; font-size: 12px; color: #fff; padding: 0 3px; display: none; }
+.form .frmtip { position: absolute; bottom: 0; left: 0; background: #fe6a7c; height: 15px; line-height: 15px; font-size: var(--font-sm); color: #fff; padding: 0 3px; display: none; }
 .form .frmerr { border-color: #fe6a7c; }
 .form .frmerr .frmtip { display: block; }
 
@@ -463,71 +442,12 @@ onMounted(() => {
 .sky.show { display: block; pointer-events: auto; }
 .sky .mark { background: #000; opacity: .5; width: 100%; height: 100%; position: absolute; top: 0; display: none; z-index: 99; }
 .sky .mark.show { display: block; }
-.sky .mw { width: 225px; position: fixed; background: #fff; left: 50%; margin-left: -112px; top: 50%; margin-top: -210px; display: none; z-index: 999; pointer-events: auto; border-radius: 4px; overflow: hidden; }
+.sky .mw { width: 225px; position: fixed; background: var(--c-card); left: 50%; margin-left: -112px; top: 50%; margin-top: -210px; display: none; z-index: 999; pointer-events: auto; border-radius: var(--radius-md); overflow: hidden; box-shadow: var(--shadow-lg); }
 .sky .mw.show { display: block; }
-.sky .mwt { border-top: 4px solid #3cc3a5; height: 40px; border-bottom: 1px solid #eee; position: relative; line-height: 40px; font-size: 16px; color: #333; text-align: center; }
+.sky .mwt { border-top: 4px solid var(--c-ershou); height: 40px; border-bottom: 1px solid var(--c-divider); position: relative; line-height: 40px; font-size: var(--font-lg); color: var(--c-text-1); text-align: center; }
 .sky .mwt .mwclose { position: absolute; right: 6px; top: 0; display: block; padding: 10px; }
 .sky .mwt .imwclose { background: url(/img/ershou/mwclose.png) no-repeat; background-size: 11px; width: 11px; height: 13px; display: block; }
 .sky .mwc ul { padding: 10px 0; }
-.sky .mwc li { line-height: 30px; height: 30px; text-align: center; color: #666; font-size: 14px; }
-.sky .mwc li a { color: #666; display: block; text-decoration: none; }
-
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-  word-wrap: break-word;
-  word-break: break-all;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #3cc395;
-  text-decoration: none;
-  border-right: 1px solid #d9d9d9;
-}
-.weui-dialog__btn:last-child {
-  border-right: none;
-}
-.weui-dialog__btn_primary {
-  color: #3cc395;
-  font-weight: 500;
-}
+.sky .mwc li { line-height: 30px; height: 30px; text-align: center; color: var(--c-text-2); font-size: var(--font-base); }
+.sky .mwc li a { color: var(--c-text-2); display: block; text-decoration: none; }
 </style>

--- a/frontend/src/views/ershou/Search.vue
+++ b/frontend/src/views/ershou/Search.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -80,21 +81,17 @@ watch(
 
 <template>
   <div class="ershou-search-page">
-    <div class="unified-header">
-      <span class="unified-header__back" @click="router.back()">返回</span>
-      <h1 class="unified-header__title">搜索结果</h1>
-      <span class="unified-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="搜索结果" moduleColor="#10b981" :showBack="true" @back="router.back()" backTo="" />
 
     <div class="ershou-search-bar">
       <div class="search-input-wrap">
-        <i class="weui-icon-search"></i>
+        <i class="search-icon"></i>
         <input type="text" placeholder="搜搜看" v-model="keywordInput" @keyup.enter="doSearch" />
       </div>
       <span class="search-btn" @click="doSearch">搜索</span>
     </div>
 
-    <!-- 滚动容器：下拉刷新 + 上拉加载 -->
+    <!-- 滚动容器 -->
     <div
       v-if="keyword"
       class="ershou-scroll-container"
@@ -105,12 +102,12 @@ watch(
       @touchend="handleTouchEnd"
     >
       <!-- 下拉刷新指示器 -->
-      <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-        <span v-if="refreshing" class="pull-refresh-text">
-          <i class="weui-loading"></i> 正在刷新...
+      <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+        <span v-if="refreshing" class="community-pull-refresh__text">
+          <i class="community-loading-spinner"></i> 正在刷新...
         </span>
-        <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-        <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+        <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+        <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
       </div>
 
       <!-- 商品双列网格 -->
@@ -118,7 +115,7 @@ watch(
         <div
           v-for="item in list"
           :key="item.id"
-          class="ershou-goods-card"
+          class="ershou-goods-card community-card"
           @click="goDetail(item.id)"
         >
           <div class="ershou-goods-card__img-wrap">
@@ -131,34 +128,34 @@ watch(
       </div>
 
       <!-- 空状态 -->
-      <div v-if="!loading && !refreshing && list.length === 0" class="ershou-empty">
-        <div class="ershou-empty__icon"></div>
-        <p class="ershou-empty__text">未搜索到相关商品</p>
+      <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+        <div class="community-empty__icon">?</div>
+        <p class="community-empty__text">未搜索到相关商品</p>
       </div>
 
       <!-- 上拉加载更多 -->
-      <div v-if="loading && !refreshing" class="ershou-loadmore">
-        <i class="weui-loading"></i>
-        <span class="weui-loadmore__tips">正在加载</span>
+      <div v-if="loading && !refreshing" class="community-loadmore">
+        <i class="community-loading-spinner"></i>
+        <span>正在加载</span>
       </div>
-      <div v-if="finished && list.length > 0" class="ershou-loadmore">
-        <span class="weui-loadmore__tips">没有更多了</span>
+      <div v-if="finished && list.length > 0" class="community-loadmore">
+        <span>没有更多了</span>
       </div>
     </div>
 
     <!-- 未输入关键词提示 -->
-    <div v-if="!keyword" class="ershou-empty">
-      <p class="ershou-empty__text">请输入关键词搜索</p>
+    <div v-if="!keyword" class="community-empty">
+      <p class="community-empty__text">请输入关键词搜索</p>
     </div>
 
-    <!-- WEUI Dialog 对话框 -->
+    <!-- Dialog -->
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
@@ -168,75 +165,51 @@ watch(
 <style scoped>
 .ershou-search-page {
   min-height: 100vh;
-  background: #f5f5f5;
+  background: var(--c-bg);
   padding-bottom: 20px;
-}
-
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__placeholder {
-  min-width: 48px;
 }
 
 .ershou-search-bar {
   display: flex;
   align-items: center;
   padding: 10px 15px;
-  background-color: #f5f5f5;
+  background-color: var(--c-bg);
 }
 .search-input-wrap {
   flex: 1;
   display: flex;
   align-items: center;
-  background-color: #fff;
-  border-radius: 20px;
+  background-color: var(--c-card);
+  border-radius: var(--radius-full);
   padding: 5px 12px;
+  box-shadow: var(--shadow-sm);
 }
-.search-input-wrap .weui-icon-search {
+.search-icon {
   display: inline-block;
   width: 16px;
   height: 16px;
   font-size: 16px;
-  color: #b2b2b2;
+  color: var(--c-text-3);
   margin-right: 5px;
   flex-shrink: 0;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23b2b2b2'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") center/contain no-repeat;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%239ca3af'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") center/contain no-repeat;
 }
 .search-input-wrap input {
   flex: 1;
   border: none;
   outline: none;
-  font-size: 14px;
+  font-size: var(--font-base);
   background: transparent;
   min-width: 0;
+  color: var(--c-text-1);
 }
 .search-btn {
-  color: #3cb395;
-  font-size: 15px;
+  color: var(--c-ershou);
+  font-size: var(--font-md);
   margin-left: 15px;
   white-space: nowrap;
   cursor: pointer;
+  font-weight: 500;
 }
 
 /* 滚动容器 */
@@ -247,56 +220,6 @@ watch(
   overscroll-behavior-y: contain;
 }
 
-/* 下拉刷新指示器 */
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-/* 加载更多 */
-.ershou-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.ershou-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-.weui-loadmore__tips {
-  font-size: 14px;
-  color: #999;
-}
-
 .ershou-goods-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -304,17 +227,14 @@ watch(
   padding: 10px;
 }
 .ershou-goods-card {
-  background: #fff;
-  border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   cursor: pointer;
 }
 .ershou-goods-card__img-wrap {
   width: 100%;
   aspect-ratio: 1;
   overflow: hidden;
-  background: #f0f0f0;
+  background: var(--c-border);
 }
 .ershou-goods-card__img {
   width: 100%;
@@ -323,9 +243,9 @@ watch(
   display: block;
 }
 .ershou-goods-card__title {
-  font-size: 14px;
+  font-size: var(--font-base);
   font-weight: 500;
-  color: #333;
+  color: var(--c-text-1);
   margin: 8px 8px 0;
   padding: 0;
   display: -webkit-box;
@@ -335,8 +255,8 @@ watch(
   line-height: 1.35;
 }
 .ershou-goods-card__desc {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
   margin: 4px 8px 0;
   padding: 0;
   white-space: nowrap;
@@ -345,92 +265,11 @@ watch(
 }
 .ershou-goods-card__price {
   display: block;
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: 600;
   color: #e4393c;
   margin: 6px 8px 8px;
   padding: 0;
   font-style: normal;
-}
-
-.ershou-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 60px 20px;
-}
-.ershou-empty__icon {
-  width: 80px;
-  height: 80px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23d8d8d8'%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z'/%3E%3C/svg%3E") center/contain no-repeat;
-}
-.ershou-empty__text {
-  margin: 16px 0 0;
-  font-size: 14px;
-  color: #999;
-}
-.ershou-empty__icon + .ershou-empty__text {
-  margin-top: 16px;
-}
-
-/* WEUI Dialog 样式 */
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-  word-wrap: break-word;
-  word-break: break-all;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #3cc395;
-  text-decoration: none;
-  border-right: 1px solid #d9d9d9;
-}
-.weui-dialog__btn:last-child {
-  border-right: none;
-}
-.weui-dialog__btn_primary {
-  color: #3cc395;
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/ershou/Type.vue
+++ b/frontend/src/views/ershou/Type.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -66,13 +67,9 @@ watch(
 
 <template>
   <div class="ershou-type-page">
-    <div class="unified-header">
-      <span class="unified-header__back" @click="router.back()">返回</span>
-      <h1 class="unified-header__title">{{ typeName }}</h1>
-      <span class="unified-header__placeholder"></span>
-    </div>
+    <CommunityHeader :title="typeName" moduleColor="#10b981" :showBack="true" @back="router.back()" backTo="" />
 
-    <!-- 滚动容器：下拉刷新 + 上拉加载 -->
+    <!-- 滚动容器 -->
     <div
       class="ershou-scroll-container"
       ref="scrollContainer"
@@ -82,12 +79,12 @@ watch(
       @touchend="handleTouchEnd"
     >
       <!-- 下拉刷新指示器 -->
-      <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-        <span v-if="refreshing" class="pull-refresh-text">
-          <i class="weui-loading"></i> 正在刷新...
+      <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+        <span v-if="refreshing" class="community-pull-refresh__text">
+          <i class="community-loading-spinner"></i> 正在刷新...
         </span>
-        <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-        <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+        <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+        <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
       </div>
 
       <!-- 商品双列网格 -->
@@ -95,7 +92,7 @@ watch(
         <div
           v-for="item in list"
           :key="item.id"
-          class="ershou-goods-card"
+          class="ershou-goods-card community-card"
           @click="goDetail(item.id)"
         >
           <div class="ershou-goods-card__img-wrap">
@@ -108,18 +105,18 @@ watch(
       </div>
 
       <!-- 空状态 -->
-      <div v-if="!loading && !refreshing && list.length === 0" class="ershou-empty">
-        <div class="ershou-empty__icon"></div>
-        <p class="ershou-empty__text">暂无该分类的商品</p>
+      <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+        <div class="community-empty__icon">?</div>
+        <p class="community-empty__text">暂无该分类的商品</p>
       </div>
 
       <!-- 上拉加载更多 -->
-      <div v-if="loading && !refreshing" class="ershou-loadmore">
-        <i class="weui-loading"></i>
-        <span class="weui-loadmore__tips">正在加载</span>
+      <div v-if="loading && !refreshing" class="community-loadmore">
+        <i class="community-loading-spinner"></i>
+        <span>正在加载</span>
       </div>
-      <div v-if="finished && list.length > 0" class="ershou-loadmore">
-        <span class="weui-loadmore__tips">没有更多了</span>
+      <div v-if="finished && list.length > 0" class="community-loadmore">
+        <span>没有更多了</span>
       </div>
     </div>
   </div>
@@ -128,93 +125,16 @@ watch(
 <style scoped>
 .ershou-type-page {
   min-height: 100vh;
-  background: #f5f5f5;
+  background: var(--c-bg);
   padding-bottom: 20px;
-}
-
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__placeholder {
-  min-width: 48px;
 }
 
 /* 滚动容器 */
 .ershou-scroll-container {
-  height: calc(100vh - 44px);
+  height: calc(100vh - 51px);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-y: contain;
-}
-
-/* 下拉刷新指示器 */
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-/* 加载更多 */
-.ershou-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.ershou-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-.weui-loadmore__tips {
-  font-size: 14px;
-  color: #999;
 }
 
 .ershou-goods-grid {
@@ -224,17 +144,14 @@ watch(
   padding: 10px;
 }
 .ershou-goods-card {
-  background: #fff;
-  border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   cursor: pointer;
 }
 .ershou-goods-card__img-wrap {
   width: 100%;
   aspect-ratio: 1;
   overflow: hidden;
-  background: #f0f0f0;
+  background: var(--c-border);
 }
 .ershou-goods-card__img {
   width: 100%;
@@ -243,9 +160,9 @@ watch(
   display: block;
 }
 .ershou-goods-card__title {
-  font-size: 14px;
+  font-size: var(--font-base);
   font-weight: 500;
-  color: #333;
+  color: var(--c-text-1);
   margin: 8px 8px 0;
   padding: 0;
   display: -webkit-box;
@@ -255,8 +172,8 @@ watch(
   line-height: 1.35;
 }
 .ershou-goods-card__desc {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
   margin: 4px 8px 0;
   padding: 0;
   white-space: nowrap;
@@ -265,29 +182,11 @@ watch(
 }
 .ershou-goods-card__price {
   display: block;
-  font-size: 16px;
+  font-size: var(--font-lg);
   font-weight: 600;
   color: #e4393c;
   margin: 6px 8px 8px;
   padding: 0;
   font-style: normal;
-}
-
-.ershou-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 60px 20px;
-}
-.ershou-empty__icon {
-  width: 80px;
-  height: 80px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23d8d8d8'%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z'/%3E%3C/svg%3E") center/contain no-repeat;
-}
-.ershou-empty__text {
-  margin: 16px 0 0;
-  font-size: 14px;
-  color: #999;
 }
 </style>

--- a/frontend/src/views/express/Detail.vue
+++ b/frontend/src/views/express/Detail.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { showErrorTopTips } from '@/utils/toast.js'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -153,32 +154,27 @@ onMounted(async () => {
 
 <template>
   <div class="express-detail">
-    <!-- 统一顶部导航栏 -->
-    <div class="express-header unified-header">
-      <span class="express-header__back" @click="router.back()">返回</span>
-      <h1 class="express-header__title">表白详情</h1>
-      <span class="express-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="表白详情" moduleColor="#f43f5e" backTo="/express/home" />
 
-    <!-- 主体容器：padding-bottom 防遮挡底部输入框 -->
+    <!-- 主体容器 -->
     <div class="express-detail__container">
-      <!-- 表白卡片：与 Home 一致的 DOM 结构 -->
-      <div v-if="item" class="dating-card" style="background: #fff; border-radius: 8px; margin: 15px; box-shadow: 0 2px 8px rgba(0,0,0,0.05); overflow: hidden;">
-        <div class="card-header" style="text-align: center; font-size: 18px; padding: 20px 15px 10px; line-height: 1.5;">
+      <!-- 表白卡片 -->
+      <div v-if="item" class="community-card express-detail-card" style="animation: community-slide-up 0.4s ease both;">
+        <div class="card-header">
           <span :class="getGenderClass(item.senderGender)">{{ item.senderName }}</span>
-          <span style="color: #666; margin: 0 5px;"> ≡❤ </span>
+          <span class="card-connector"> ≡❤ </span>
           <span :class="getGenderClass(item.receiverGender)">{{ item.receiverName }}</span>
         </div>
 
-        <div class="card-body" style="text-align: center; font-size: 16px; padding: 10px 20px 20px; color: #333;">
+        <div class="card-body">
           {{ item.content }}
         </div>
 
-        <div class="card-time" style="text-align: right; font-size: 12px; color: #b2b2b2; padding: 0 15px 15px;">
+        <div class="card-time">
           {{ item.time || '刚刚' }}
         </div>
 
-        <div class="card-actions" style="display: flex; border-top: 1px solid #f0f0f0; padding: 10px 0;">
+        <div class="card-actions">
           <button type="button" class="action-btn" :class="{ 'is-liked': item.isLiked }" @click.stop="handleLike">
             {{ item.isLiked ? '♥' : '♡' }} {{ item.likeCount || 0 }}
           </button>
@@ -192,7 +188,7 @@ onMounted(async () => {
       </div>
 
       <!-- 评论区 -->
-      <div class="express-comments">
+      <div class="express-comments community-card">
         <h3 class="express-comments__title">评论列表</h3>
         <div v-if="comments.length === 0" class="express-comments__empty">
           <p>暂无评论，快来抢沙发吧！</p>
@@ -214,22 +210,22 @@ onMounted(async () => {
       </div>
     </div>
 
-    <!-- 猜名字 WEUI Dialog -->
-    <div v-if="guessDialogVisible" class="weui-mask" @click="guessDialogVisible = false"></div>
-    <div v-if="guessDialogVisible" class="weui-dialog weui-dialog--guess">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">猜名字</strong></div>
-      <div class="weui-dialog__bd">
+    <!-- 猜名字 Dialog -->
+    <div v-if="guessDialogVisible" class="community-dialog-mask" @click="guessDialogVisible = false"></div>
+    <div v-if="guessDialogVisible" class="community-dialog">
+      <div class="community-dialog__title">猜名字</div>
+      <div class="community-dialog__body">
         <input
           type="text"
-          class="weui-input weui-dialog__input"
+          class="express-dialog-input"
           placeholder="请输入你猜的真实姓名："
           v-model="guessInputValue"
           @keyup.enter="confirmGuess"
         />
       </div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_default" @click="guessDialogVisible = false">取消</a>
-        <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="confirmGuess">确定</a>
+      <div class="community-dialog__footer">
+        <button class="community-dialog__btn community-dialog__btn--cancel" @click="guessDialogVisible = false">取消</button>
+        <button class="community-dialog__btn community-dialog__btn--confirm" @click="confirmGuess">确定</button>
       </div>
     </div>
 
@@ -256,45 +252,53 @@ onMounted(async () => {
 
 <style scoped>
 .express-detail {
-  background: #f5f5f5;
+  background: var(--c-bg);
   padding-bottom: 60px;
-}
-
-.express-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.express-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.express-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.express-header__placeholder {
-  min-width: 48px;
-  text-align: right;
 }
 
 .express-detail__container {
-  padding: 15px;
+  padding: var(--space-lg);
   padding-bottom: 60px;
 }
 
-/* 操作栏按钮：点赞高亮 */
+.express-detail-card {
+  overflow: hidden;
+  margin-bottom: var(--space-lg);
+}
+
+.card-header {
+  text-align: center;
+  font-size: 18px;
+  padding: 20px var(--space-lg) 10px;
+  line-height: 1.5;
+}
+
+.card-connector {
+  color: var(--c-text-2);
+  margin: 0 5px;
+}
+
+.card-body {
+  text-align: center;
+  font-size: var(--font-lg);
+  padding: 10px 20px 20px;
+  color: var(--c-text-1);
+}
+
+.card-time {
+  text-align: right;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
+  padding: 0 var(--space-lg) var(--space-lg);
+}
+
+.card-actions {
+  display: flex;
+  border-top: 1px solid var(--c-border);
+  padding: 10px 0;
+}
+
+/* 操作栏按钮 */
 .action-btn {
   flex: 1;
   display: flex;
@@ -304,66 +308,17 @@ onMounted(async () => {
   padding: 10px 0;
   background: transparent;
   border: none;
-  border-right: 1px solid #f0f0f0;
-  font-size: 14px;
-  color: #666;
+  border-right: 1px solid var(--c-border);
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   cursor: pointer;
 }
 .action-btn:last-child {
   border-right: none;
 }
 .action-btn.is-liked {
-  color: #ff5252 !important;
+  color: #f43f5e !important;
   font-weight: bold;
-}
-/* 猜名字 Dialog */
-.weui-dialog--guess {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 320px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__input {
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid #e5e5e5;
-  border-radius: 4px;
-  font-size: 14px;
-  box-sizing: border-box;
-}
-.express-detail .weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.express-detail .weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #333;
-  text-decoration: none;
-}
-.express-detail .weui-dialog__btn_primary {
-  color: #4fc3f7;
-  font-weight: 500;
-}
-.express-detail .weui-dialog__btn_default {
-  color: #999;
-}
-.express-detail .weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
 }
 
 /* 性别虚线样式 */
@@ -376,37 +331,49 @@ onMounted(async () => {
   color: #ff8a80;
 }
 .gender-secret {
-  border-bottom: 2px dashed #333333;
-  color: #333333;
+  border-bottom: 2px dashed var(--c-text-1);
+  color: var(--c-text-1);
+}
+
+/* 猜名字 Dialog 输入框 */
+.express-dialog-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-base);
+  box-sizing: border-box;
+  outline: none;
+}
+.express-dialog-input:focus {
+  border-color: #f43f5e;
 }
 
 /* 评论区 */
 .express-comments {
-  background: #fff;
-  border-radius: 8px;
-  padding: 15px;
-  margin-bottom: 20px;
+  padding: var(--space-lg);
+  margin-bottom: var(--space-xl);
 }
 .express-comments__title {
-  margin: 0 0 15px;
-  font-size: 16px;
+  margin: 0 0 var(--space-lg);
+  font-size: var(--font-lg);
   font-weight: 500;
-  color: #333;
+  color: var(--c-text-1);
 }
 .express-comments__empty {
   text-align: center;
   padding: 40px 0;
-  color: #999;
-  font-size: 14px;
+  color: var(--c-text-3);
+  font-size: var(--font-base);
 }
 .express-comments__list {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: var(--space-lg);
 }
 .express-comment {
-  border-bottom: 1px solid #eee;
-  padding-bottom: 15px;
+  border-bottom: 1px solid var(--c-border);
+  padding-bottom: var(--space-lg);
 }
 .express-comment:last-child {
   border-bottom: none;
@@ -416,32 +383,32 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-sm);
 }
 .express-comment__floor {
-  padding: 4px 8px;
-  background: #eee;
-  color: #000;
-  font-size: 12px;
-  border-radius: 2px;
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--c-bg);
+  color: var(--c-text-1);
+  font-size: var(--font-sm);
+  border-radius: var(--radius-sm);
 }
 .express-comment__nickname {
-  color: #b3b3b3;
-  font-size: 12px;
+  color: var(--c-text-3);
+  font-size: var(--font-sm);
 }
 .express-comment__content {
-  margin: 10px 0 8px;
+  margin: 10px 0 var(--space-sm);
   padding-left: 2em;
-  font-size: 14px;
-  color: #333;
+  font-size: var(--font-base);
+  color: var(--c-text-1);
   line-height: 1.6;
   word-break: break-word;
 }
 .express-comment__time {
   margin: 0;
   text-align: right;
-  color: #b3b3b3;
-  font-size: 12px;
+  color: var(--c-text-3);
+  font-size: var(--font-sm);
 }
 
 /* 底部固定评论输入框 */
@@ -452,33 +419,39 @@ onMounted(async () => {
   right: 0;
   display: flex;
   align-items: center;
-  padding: 10px 15px;
-  background: #fff;
-  border-top: 1px solid #eee;
+  padding: 10px var(--space-lg);
+  background: var(--c-card);
+  border-top: 1px solid var(--c-border);
   z-index: 500;
 }
 .express-comment-input__field {
   flex: 1;
   height: 36px;
   padding: 0 12px;
-  border: 1px solid #ddd;
-  border-radius: 18px;
-  font-size: 14px;
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-full);
+  font-size: var(--font-base);
   outline: none;
+  color: var(--c-text-1);
+  background: var(--c-bg);
 }
 .express-comment-input__field:focus {
-  border-color: #74b9ff;
+  border-color: #f43f5e;
 }
 .express-comment-input__btn {
   margin-left: 10px;
   padding: 0 20px;
   height: 36px;
-  background-color: #74b9ff;
+  background-color: #f43f5e;
   color: #fff;
   border: none;
-  border-radius: 18px;
-  font-size: 14px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-base);
   cursor: pointer;
+  transition: opacity 0.2s;
+}
+.express-comment-input__btn:active {
+  opacity: 0.85;
 }
 .express-comment-input__btn:disabled {
   opacity: 0.6;

--- a/frontend/src/views/express/Home.vue
+++ b/frontend/src/views/express/Home.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
 import { showErrorTopTips } from '@/utils/toast.js'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 // 用于下拉刷新：模拟 scrollTop 为 window 的滚动位置
@@ -132,54 +133,49 @@ onUnmounted(() => {
 
 <template>
   <div
-    class="dating-home"
+    class="express-home"
     @touchstart="handleTouchStart"
     @touchmove="handleTouchMove($event, scrollContainer)"
     @touchend="handleTouchEnd"
   >
-    <!-- 标准 .unified-header：左侧返回，中间不写字 -->
-    <div class="dating-header unified-header">
-      <span class="dating-header__back" @click="router.push('/')">返回</span>
-      <h1 class="dating-header__title"></h1>
-      <span class="dating-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="表白墙" moduleColor="#f43f5e" />
 
-    <!-- 导航栏正下方：居中的巨大浅粉色粗体标题 -->
-    <h2 class="dating-main-title">广东第二师范学院表白墙</h2>
+    <!-- 导航栏正下方：居中的浅粉色粗体标题 -->
+    <h2 class="express-main-title">广东第二师范学院表白墙</h2>
 
-    <!-- 下拉刷新指示器（顶部，不产生滚动） -->
-    <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-      <span v-if="refreshing" class="pull-refresh-text">
-        <i class="weui-loading"></i> 正在刷新...
+    <!-- 下拉刷新指示器 -->
+    <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+      <span v-if="refreshing" class="community-pull-refresh__text">
+        <i class="community-loading-spinner"></i> 正在刷新...
       </span>
-      <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-      <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+      <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+      <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
     </div>
 
-    <!-- 表白卡片列表：body 滚动，无内层滚动容器 -->
-    <div class="dating-list">
+    <!-- 表白卡片列表 -->
+    <div class="express-list">
       <div
-        v-for="item in list"
+        v-for="(item, index) in list"
         :key="item.id"
-        class="dating-card"
-        style="background: #fff; border-radius: 8px; margin: 15px; box-shadow: 0 2px 8px rgba(0,0,0,0.05); overflow: hidden;"
+        class="community-card express-card"
+        :style="{ animationDelay: (index % 10) * 0.05 + 's' }"
         @click="goToDetail(item.id)"
       >
-        <div class="card-header" style="text-align: center; font-size: 18px; padding: 20px 15px 10px; line-height: 1.5;">
+        <div class="card-header">
           <span :class="getGenderClass(item.senderGender)">{{ item.senderName }}</span>
-          <span style="color: #666; margin: 0 5px;"> ≡❤ </span>
+          <span class="card-connector"> ≡❤ </span>
           <span :class="getGenderClass(item.receiverGender)">{{ item.receiverName }}</span>
         </div>
 
-        <div class="card-body" style="text-align: center; font-size: 16px; padding: 10px 20px 20px; color: #333;">
+        <div class="card-body">
           {{ item.content }}
         </div>
 
-        <div class="card-time" style="text-align: right; font-size: 12px; color: #b2b2b2; padding: 0 15px 15px;">
+        <div class="card-time">
           {{ item.time || '刚刚' }}
         </div>
 
-        <div class="card-actions" style="display: flex; border-top: 1px solid #f0f0f0; padding: 10px 0;">
+        <div class="card-actions">
           <button type="button" class="action-btn" :class="{ 'is-liked': item.isLiked }" @click.stop="handleLike(item)">
             {{ item.isLiked ? '♥' : '♡' }} {{ item.likeCount || 0 }}
           </button>
@@ -193,88 +189,60 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <!-- 底部图例：Tabbar 上方 -->
-    <div class="dating-legend">
+    <!-- 底部图例 -->
+    <div class="express-legend">
       蓝色下划线：男生 / 红色下划线：女生 / 黑色下划线：其他或保密
     </div>
 
     <!-- 空状态 -->
-    <div v-if="!loading && !refreshing && list.length === 0" class="dating-empty">
-      <p>暂无表白墙内容</p>
+    <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+      <div class="community-empty__icon">💌</div>
+      <p class="community-empty__text">暂无表白墙内容</p>
     </div>
 
     <!-- 上拉加载更多 -->
-    <div v-if="loading && !refreshing" class="dating-loadmore">
-      <i class="weui-loading"></i>
-      <span class="weui-loadmore__tips">正在加载</span>
+    <div v-if="loading && !refreshing" class="community-loadmore">
+      <i class="community-loading-spinner"></i>
+      <span>正在加载</span>
     </div>
-    <div v-if="finished && list.length > 0" class="dating-loadmore">
-      <span class="weui-loadmore__tips">没有更多了</span>
+    <div v-if="finished && list.length > 0" class="community-loadmore">
+      <span>没有更多了</span>
     </div>
 
-    <!-- 猜名字 WEUI Dialog -->
-    <div v-if="guessDialogVisible" class="weui-mask" @click="guessDialogVisible = false"></div>
-    <div v-if="guessDialogVisible" class="weui-dialog weui-dialog--guess">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">猜名字</strong></div>
-      <div class="weui-dialog__bd">
+    <!-- 猜名字 Dialog -->
+    <div v-if="guessDialogVisible" class="community-dialog-mask" @click="guessDialogVisible = false"></div>
+    <div v-if="guessDialogVisible" class="community-dialog">
+      <div class="community-dialog__title">猜名字</div>
+      <div class="community-dialog__body">
         <input
           type="text"
-          class="weui-input weui-dialog__input"
+          class="express-dialog-input"
           placeholder="请输入你猜的真实姓名："
           v-model="guessInputValue"
           @keyup.enter="confirmGuess"
         />
       </div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_default" @click="guessDialogVisible = false">取消</a>
-        <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="confirmGuess">确定</a>
+      <div class="community-dialog__footer">
+        <button class="community-dialog__btn community-dialog__btn--cancel" @click="guessDialogVisible = false">取消</button>
+        <button class="community-dialog__btn community-dialog__btn--confirm" @click="confirmGuess">确定</button>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.dating-home {
-  background: #f5f5f5;
-  padding-bottom: 60px;
+.express-home {
+  background: var(--c-bg);
+  padding-bottom: 20px;
 }
 
-.dating-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.dating-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.dating-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.dating-header__placeholder {
-  min-width: 48px;
-  text-align: right;
-}
-
-/* 巨大的浅粉色粗体标题：从原版 CSS 风格 */
-.dating-main-title {
+/* 浅粉色粗体标题 */
+.express-main-title {
   text-align: center;
   font-size: 22px;
   font-weight: bold;
   color: #ffb3ba;
-  margin: 16px 15px 20px;
+  margin: var(--space-lg) var(--space-lg) var(--space-xl);
   padding: 0;
   line-height: 1.3;
 }
@@ -289,45 +257,54 @@ onUnmounted(() => {
   color: #ff8a80;
 }
 .gender-secret {
-  border-bottom: 2px dashed #333333;
-  color: #333333;
-}
-
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #e53935;
-  border-radius: 50%;
-  animation: dating-spin 0.8s linear infinite;
-}
-@keyframes dating-spin {
-  to { transform: rotate(360deg); }
+  border-bottom: 2px dashed var(--c-text-1);
+  color: var(--c-text-1);
 }
 
 /* 表白卡片 */
-.dating-list {
-  padding: 0 0 20px;
-}
-.dating-card {
-  cursor: pointer;
+.express-list {
+  padding: 0 0 var(--space-xl);
 }
 
-/* 操作栏按钮：点赞高亮 */
+.express-card {
+  margin: var(--space-lg);
+  overflow: hidden;
+  animation: community-slide-up 0.4s ease both;
+}
+
+.card-header {
+  text-align: center;
+  font-size: 18px;
+  padding: 20px var(--space-lg) 10px;
+  line-height: 1.5;
+}
+
+.card-connector {
+  color: var(--c-text-2);
+  margin: 0 5px;
+}
+
+.card-body {
+  text-align: center;
+  font-size: var(--font-lg);
+  padding: 10px 20px 20px;
+  color: var(--c-text-1);
+}
+
+.card-time {
+  text-align: right;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
+  padding: 0 var(--space-lg) var(--space-lg);
+}
+
+.card-actions {
+  display: flex;
+  border-top: 1px solid var(--c-border);
+  padding: 10px 0;
+}
+
+/* 操作栏按钮 */
 .action-btn {
   flex: 1;
   display: flex;
@@ -337,100 +314,39 @@ onUnmounted(() => {
   padding: 10px 0;
   background: transparent;
   border: none;
-  border-right: 1px solid #f0f0f0;
-  font-size: 14px;
-  color: #666;
+  border-right: 1px solid var(--c-border);
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   cursor: pointer;
 }
 .action-btn:last-child {
   border-right: none;
 }
 .action-btn.is-liked {
-  color: #ff5252 !important;
+  color: #f43f5e !important;
   font-weight: bold;
 }
 
-/* 猜名字 Dialog */
-.weui-dialog--guess {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 320px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__input {
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid #e5e5e5;
-  border-radius: 4px;
-  font-size: 14px;
-  box-sizing: border-box;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #333;
-  text-decoration: none;
-}
-.weui-dialog__btn_primary {
-  color: #4fc3f7;
-  font-weight: 500;
-}
-.weui-dialog__btn_default {
-  color: #999;
-}
-.dating-home .weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-
 /* 底部图例 */
-.dating-legend {
+.express-legend {
   text-align: center;
-  font-size: 12px;
-  color: #999;
-  padding: 16px 15px 24px;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
+  padding: var(--space-lg) var(--space-lg) var(--space-xl);
   line-height: 1.5;
 }
 
-.dating-empty {
-  text-align: center;
-  padding: 60px 20px;
-  color: #999;
-  font-size: 14px;
+/* 猜名字 Dialog 输入框 */
+.express-dialog-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-base);
+  box-sizing: border-box;
+  outline: none;
 }
-
-.dating-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.dating-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #e53935;
-  border-radius: 50%;
-  animation: dating-spin 0.8s linear infinite;
+.express-dialog-input:focus {
+  border-color: #f43f5e;
 }
 </style>

--- a/frontend/src/views/express/Index.vue
+++ b/frontend/src/views/express/Index.vue
@@ -1,124 +1,20 @@
 <script setup>
-import { computed } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-
-const router = useRouter()
-const route = useRoute()
-
-const activeTab = computed(() => {
-  const p = route.path
-  if (p.includes('/express/publish')) return 'publish'
-  if (p.includes('/express/search')) return 'search'
-  return 'home'
-})
-
-function goTo(path) {
-  router.push(path)
-}
+import CommunityTabbar from '../../components/community/CommunityTabbar.vue'
 </script>
 
 <template>
-  <div class="express-page weui-tab">
-    <div class="express-container weui-tab__panel">
+  <div class="community-page" style="--module-color: #f43f5e">
+    <div style="padding-bottom: 56px">
       <router-view />
     </div>
-    <!-- 专属黑底 Tabbar：选中态红色，非选中态灰色 -->
-    <div class="express-tabbar weui-tabbar">
-      <a
-        href="javascript:;"
-        class="express-tabbar__item"
-        :class="{ on: activeTab === 'home' }"
-        @click.prevent="goTo('/express/home')"
-      >
-        <i class="express-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm2 14H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>
-          </svg>
-        </i>
-        <p class="express-tabbar__label">首页</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="express-tabbar__item"
-        :class="{ on: activeTab === 'publish' }"
-        @click.prevent="goTo('/express/publish')"
-      >
-        <i class="express-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-          </svg>
-        </i>
-        <p class="express-tabbar__label">表白</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="express-tabbar__item"
-        :class="{ on: activeTab === 'search' }"
-        @click.prevent="goTo('/express/search')"
-      >
-        <i class="express-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-          </svg>
-        </i>
-        <p class="express-tabbar__label">搜索</p>
-      </a>
-    </div>
+    <CommunityTabbar
+      basePath="/express"
+      moduleColor="#f43f5e"
+      :tabs="[
+        { key: 'home', label: '首页', path: '/express/home', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm2 14H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z&quot;/></svg>' },
+        { key: 'publish', label: '表白', path: '/express/publish', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z&quot;/></svg>' },
+        { key: 'search', label: '搜索', path: '/express/search', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z&quot;/></svg>' }
+      ]"
+    />
   </div>
 </template>
-
-<style scoped>
-.express-page {
-  background-color: #f5f5f5;
-}
-.express-container {
-  padding-bottom: 60px;
-  box-sizing: border-box;
-}
-/* 纯黑背景 Tabbar */
-.express-tabbar.weui-tabbar {
-  position: fixed !important;
-  bottom: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  width: 100vw !important;
-  max-width: 100%;
-  margin: 0 !important;
-  padding: 0 !important;
-  z-index: 500;
-  background-color: #000 !important;
-  display: flex;
-}
-.express-tabbar__item {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: #999;
-  text-decoration: none;
-  font-size: 12px;
-  padding: 8px 0;
-}
-.express-tabbar__item.on {
-  color: #e53935 !important;
-  font-weight: 500;
-}
-.express-tabbar__item.on .express-tabbar__icon {
-  color: #e53935 !important;
-}
-.express-tabbar__icon {
-  display: block;
-  margin-bottom: 4px;
-  color: #999;
-}
-.express-tabbar__item.on .express-tabbar__icon svg {
-  fill: #e53935;
-}
-.express-tabbar__label {
-  margin: 0;
-  font-size: 12px;
-  line-height: 1;
-  color: inherit;
-}
-</style>

--- a/frontend/src/views/express/Publish.vue
+++ b/frontend/src/views/express/Publish.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const formData = ref({
@@ -87,39 +88,34 @@ function submit() {
 </script>
 
 <template>
-  <div class="dating-publish">
-    <!-- 标准 .unified-header：左侧返回 -->
-    <div class="dating-header unified-header">
-      <span class="dating-header__back" @click="router.push('/express/home')">返回</span>
-      <h1 class="dating-header__title"></h1>
-      <span class="dating-header__placeholder"></span>
-    </div>
+  <div class="express-publish">
+    <CommunityHeader title="发布表白" moduleColor="#f43f5e" backTo="/express/home" />
 
-    <!-- 巨大的浅粉色粗体标题 -->
-    <h2 class="dating-main-title">广东第二师范学院表白墙</h2>
+    <!-- 浅粉色粗体标题 -->
+    <h2 class="express-main-title">广东第二师范学院表白墙</h2>
 
     <!-- 手账风表单：蓝色虚线表单框 -->
-    <div class="dating-form">
+    <div class="express-form">
       <!-- 第一个 form-section：你的信息 -->
       <div class="form-section">
         <span class="form-section-title">你的信息</span>
-        <div class="weui-cells weui-cells_form">
-          <div class="weui-cell">
-            <div class="weui-cell__hd"><label class="weui-label">昵称</label></div>
-            <div class="weui-cell__bd">
+        <div class="form-cells">
+          <div class="form-cell">
+            <div class="form-cell__hd"><label class="form-label">昵称</label></div>
+            <div class="form-cell__bd">
               <input
-                class="weui-input"
+                class="form-input"
                 type="text"
                 placeholder="请输入昵称"
                 v-model="formData.nickname"
               />
             </div>
           </div>
-          <div class="weui-cell">
-            <div class="weui-cell__hd"><label class="weui-label">真名</label></div>
-            <div class="weui-cell__bd">
+          <div class="form-cell">
+            <div class="form-cell__hd"><label class="form-label">真名</label></div>
+            <div class="form-cell__bd">
               <input
-                class="weui-input"
+                class="form-input"
                 type="text"
                 placeholder="请输入真名"
                 v-model="formData.realName"
@@ -127,10 +123,10 @@ function submit() {
               <div class="hint-text">注：真实姓名可选填，默认保密不显示！填写即可参加紧张刺激的猜名字游戏！</div>
             </div>
           </div>
-          <div class="weui-cell weui-cell_select">
-            <div class="weui-cell__hd"><label class="weui-label">性别</label></div>
-            <div class="weui-cell__bd">
-              <select class="weui-select" v-model="formData.myGender">
+          <div class="form-cell">
+            <div class="form-cell__hd"><label class="form-label">性别</label></div>
+            <div class="form-cell__bd">
+              <select class="form-select" v-model="formData.myGender">
                 <option value="">请选择</option>
                 <option value="male">男</option>
                 <option value="female">女</option>
@@ -144,22 +140,22 @@ function submit() {
       <!-- 第二个 form-section：TA的信息 -->
       <div class="form-section">
         <span class="form-section-title">TA的信息</span>
-        <div class="weui-cells weui-cells_form">
-          <div class="weui-cell">
-            <div class="weui-cell__hd"><label class="weui-label">名字</label></div>
-            <div class="weui-cell__bd">
+        <div class="form-cells">
+          <div class="form-cell">
+            <div class="form-cell__hd"><label class="form-label">名字</label></div>
+            <div class="form-cell__bd">
               <input
-                class="weui-input"
+                class="form-input"
                 type="text"
                 placeholder="请输入TA的名字"
                 v-model="formData.receiverName"
               />
             </div>
           </div>
-          <div class="weui-cell weui-cell_select">
-            <div class="weui-cell__hd"><label class="weui-label">性别</label></div>
-            <div class="weui-cell__bd">
-              <select class="weui-select" v-model="formData.receiverGender">
+          <div class="form-cell">
+            <div class="form-cell__hd"><label class="form-label">性别</label></div>
+            <div class="form-cell__bd">
+              <select class="form-select" v-model="formData.receiverGender">
                 <option value="">请选择</option>
                 <option value="male">男</option>
                 <option value="female">女</option>
@@ -173,11 +169,11 @@ function submit() {
       <!-- 表白内容 -->
       <div class="form-section">
         <span class="form-section-title">表白内容</span>
-        <div class="weui-cells weui-cells_form">
-          <div class="weui-cell">
-            <div class="weui-cell__bd">
+        <div class="form-cells">
+          <div class="form-cell">
+            <div class="form-cell__bd">
               <textarea
-                class="weui-textarea"
+                class="form-textarea"
                 placeholder="写下你想对TA说的话..."
                 rows="4"
                 v-model="formData.content"
@@ -187,7 +183,7 @@ function submit() {
         </div>
       </div>
 
-      <div class="dating-submit-wrap">
+      <div class="express-submit-wrap">
         <button
           type="button"
           class="btn-submit"
@@ -201,12 +197,12 @@ function submit() {
 
     <!-- 提示对话框 -->
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
@@ -214,46 +210,17 @@ function submit() {
 </template>
 
 <style scoped>
-.dating-publish {
-  background: #f5f5f5;
+.express-publish {
+  background: var(--c-bg);
   padding-bottom: 80px;
 }
 
-.dating-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.dating-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.dating-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.dating-header__placeholder {
-  min-width: 48px;
-  text-align: right;
-}
-
-.dating-main-title {
+.express-main-title {
   text-align: center;
   font-size: 22px;
   font-weight: bold;
   color: #ffb3ba;
-  margin: 16px 15px 20px;
+  margin: var(--space-lg) var(--space-lg) var(--space-xl);
   padding: 0;
   line-height: 1.3;
 }
@@ -261,11 +228,12 @@ function submit() {
 /* 手账风：蓝色虚线表单框 */
 .form-section {
   border: 2px dashed #81d4fa;
-  border-radius: 8px;
-  padding: 25px 15px 15px;
-  margin: 25px 15px 15px;
+  border-radius: var(--radius-md);
+  padding: 25px var(--space-lg) var(--space-lg);
+  margin: 25px var(--space-lg) var(--space-lg);
   position: relative;
-  background-color: #fff;
+  background-color: var(--c-card);
+  box-shadow: var(--shadow-sm);
 }
 .form-section-title {
   position: absolute;
@@ -275,47 +243,60 @@ function submit() {
   color: white;
   padding: 4px 10px;
   border-radius: 2px;
-  font-size: 14px;
+  font-size: var(--font-base);
   font-weight: 500;
 }
 
-/* WEUI 风格输入框 */
-.weui-cells {
+/* 表单输入框 */
+.form-cells {
   margin-top: 0;
   background-color: transparent;
 }
-.weui-cell {
-  padding: 12px 0;
-  border-bottom: 1px solid #e5e5e5;
+.form-cell {
+  display: flex;
+  align-items: flex-start;
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--c-divider);
 }
-.weui-cell:last-child {
+.form-cell:last-child {
   border-bottom: none;
 }
-.weui-label {
+.form-label {
   width: 70px;
-  font-size: 14px;
-  color: #333;
+  font-size: var(--font-base);
+  color: var(--c-text-1);
+  line-height: 2;
 }
-.weui-input,
-.weui-select,
-.weui-textarea {
-  font-size: 14px;
-  color: #333;
+.form-cell__bd {
+  flex: 1;
 }
-.weui-textarea {
-  min-height: 80px;
-  padding: 8px 0;
-}
-.weui-select {
+.form-input,
+.form-select,
+.form-textarea {
+  font-size: var(--font-base);
+  color: var(--c-text-1);
   width: 100%;
   border: none;
+  outline: none;
   background: transparent;
+  box-sizing: border-box;
+}
+.form-input {
+  height: 28px;
+}
+.form-textarea {
+  min-height: 80px;
+  padding: var(--space-sm) 0;
+  resize: vertical;
+}
+.form-select {
+  width: 100%;
   appearance: none;
   -webkit-appearance: none;
 }
 
-.dating-submit-wrap {
-  padding: 20px 15px 40px;
+.express-submit-wrap {
+  padding: var(--space-xl) var(--space-lg) 40px;
 }
 .btn-submit {
   width: 100%;
@@ -323,12 +304,17 @@ function submit() {
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #74b9ff;
+  background-color: #f43f5e;
   color: #fff;
-  border-radius: 6px;
-  font-size: 16px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-lg);
+  font-weight: 500;
   border: none;
   cursor: pointer;
+  transition: opacity 0.2s;
+}
+.btn-submit:active {
+  opacity: 0.85;
 }
 .btn-submit:disabled {
   opacity: 0.6;
@@ -336,61 +322,9 @@ function submit() {
 }
 
 .hint-text {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
   margin-top: 5px;
   line-height: 1.4;
-}
-
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #4fc3f7;
-  text-decoration: none;
-}
-.weui-dialog__btn_primary {
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/express/Search.vue
+++ b/frontend/src/views/express/Search.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -97,94 +98,99 @@ watch(
 </script>
 
 <template>
-  <div class="dating-search-page">
-    <div class="dating-header unified-header">
-      <span class="dating-header__back" @click="router.push('/express/home')">返回</span>
-      <h1 class="dating-header__title">搜索表白</h1>
-      <span class="dating-header__placeholder"></span>
-    </div>
+  <div class="express-search-page">
+    <CommunityHeader title="搜索表白" moduleColor="#f43f5e" backTo="/express/home" />
 
     <!-- 搜索栏 -->
-    <div class="dating-search-bar">
+    <div class="express-search-bar">
       <div class="search-input-wrap">
-        <i class="weui-icon-search"></i>
+        <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#9ca3af" width="16" height="16">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
         <input type="text" placeholder="搜索发件人/收件人/内容" v-model="keywordInput" @keyup.enter="doSearch" />
       </div>
       <span class="search-btn" @click="doSearch">搜索</span>
     </div>
 
-    <!-- 巨大的浅粉色标题 -->
-    <h2 class="dating-main-title">广东第二师范学院表白墙</h2>
+    <!-- 浅粉色标题 -->
+    <h2 class="express-main-title">广东第二师范学院表白墙</h2>
 
     <!-- 滚动容器 -->
     <div
-      class="dating-scroll-container"
+      class="express-scroll-container"
       ref="scrollContainer"
       @scroll="handleScroll"
       @touchstart="handleTouchStart"
       @touchmove="handleTouchMove($event, scrollContainer)"
       @touchend="handleTouchEnd"
     >
-      <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-        <span v-if="refreshing" class="pull-refresh-text">
-          <i class="weui-loading"></i> 正在刷新...
+      <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+        <span v-if="refreshing" class="community-pull-refresh__text">
+          <i class="community-loading-spinner"></i> 正在刷新...
         </span>
-        <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-        <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+        <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+        <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
       </div>
 
-      <div class="dating-list">
-        <div v-for="item in list" :key="item.id" class="dating-card">
-          <div class="dating-card__content">
-            <p class="dating-card__names">
+      <div class="express-list">
+        <div
+          v-for="(item, index) in list"
+          :key="item.id"
+          class="community-card express-card"
+          :style="{ animationDelay: (index % 10) * 0.05 + 's' }"
+        >
+          <div class="express-card__content">
+            <p class="express-card__names">
               <span :class="getGenderClass(item.senderGender)">{{ item.senderName }}</span>
-              <span class="dating-card__connector">≡❤</span>
+              <span class="express-card__connector">≡❤</span>
               <span :class="getGenderClass(item.receiverGender)">{{ item.receiverName }}</span>
             </p>
-            <p class="dating-card__text">{{ item.content }}</p>
-            <p class="dating-card__time">{{ item.time }}</p>
+            <p class="express-card__text">{{ item.content }}</p>
+            <p class="express-card__time">{{ item.time }}</p>
           </div>
-          <div class="dating-card__actions">
-            <button type="button" class="dating-action" @click="handleLike(item)">
-              <span class="dating-action__icon">♡</span>
-              <span class="dating-action__text">{{ item.likeCount || 0 }}</span>
+          <div class="express-card__actions">
+            <button type="button" class="express-action" @click="handleLike(item)">
+              <span class="express-action__icon">♡</span>
+              <span class="express-action__text">{{ item.likeCount || 0 }}</span>
             </button>
-            <button type="button" class="dating-action" @click="handleGuess(item)">
-              <span class="dating-action__icon">☆</span>
-              <span class="dating-action__text">{{ item.guessCount || 0 }}</span>
+            <button type="button" class="express-action" @click="handleGuess(item)">
+              <span class="express-action__icon">☆</span>
+              <span class="express-action__text">{{ item.guessCount || 0 }}</span>
             </button>
-            <button type="button" class="dating-action" @click="handleComment(item)">
-              <span class="dating-action__icon">💬</span>
-              <span class="dating-action__text">{{ item.commentCount || 0 }}</span>
+            <button type="button" class="express-action" @click="handleComment(item)">
+              <span class="express-action__icon">💬</span>
+              <span class="express-action__text">{{ item.commentCount || 0 }}</span>
             </button>
           </div>
         </div>
       </div>
 
-      <div class="dating-legend">
+      <div class="express-legend">
         蓝色下划线：男生 / 红色下划线：女生 / 黑色下划线：其他或保密
       </div>
 
-      <div v-if="!loading && !refreshing && list.length === 0" class="dating-empty">
-        <p>{{ keyword ? '未找到相关表白' : '输入关键词搜索' }}</p>
+      <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+        <div class="community-empty__icon">🔍</div>
+        <p class="community-empty__text">{{ keyword ? '未找到相关表白' : '输入关键词搜索' }}</p>
       </div>
 
-      <div v-if="loading && !refreshing" class="dating-loadmore">
-        <i class="weui-loading"></i>
-        <span class="weui-loadmore__tips">正在加载</span>
+      <div v-if="loading && !refreshing" class="community-loadmore">
+        <i class="community-loading-spinner"></i>
+        <span>正在加载</span>
       </div>
-      <div v-if="finished && list.length > 0" class="dating-loadmore">
-        <span class="weui-loadmore__tips">没有更多了</span>
+      <div v-if="finished && list.length > 0" class="community-loadmore">
+        <span>没有更多了</span>
       </div>
     </div>
 
+    <!-- 提示 Dialog -->
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
@@ -192,84 +198,54 @@ watch(
 </template>
 
 <style scoped>
-.dating-search-page {
+.express-search-page {
   min-height: 100vh;
-  background: #f5f5f5;
+  background: var(--c-bg);
 }
 
-.dating-header.unified-header {
+.express-search-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.dating-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.dating-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.dating-header__placeholder {
-  min-width: 48px;
-  text-align: right;
-}
-
-.dating-search-bar {
-  display: flex;
-  align-items: center;
-  padding: 10px 15px;
-  background-color: #f5f5f5;
+  padding: 10px var(--space-lg);
+  background-color: var(--c-bg);
 }
 .search-input-wrap {
   flex: 1;
   display: flex;
   align-items: center;
-  background-color: #fff;
-  border-radius: 20px;
+  background-color: var(--c-card);
+  border-radius: var(--radius-full);
   padding: 8px 12px;
+  box-shadow: var(--shadow-sm);
 }
-.search-input-wrap .weui-icon-search {
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  margin-right: 8px;
+.search-icon {
   flex-shrink: 0;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23b2b2b2'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") center/contain no-repeat;
+  margin-right: 8px;
 }
 .search-input-wrap input {
   flex: 1;
   border: none;
   outline: none;
-  font-size: 14px;
+  font-size: var(--font-base);
   background: transparent;
   min-width: 0;
+  color: var(--c-text-1);
 }
 .search-btn {
-  color: #e53935;
-  font-size: 15px;
-  margin-left: 15px;
+  color: #f43f5e;
+  font-size: var(--font-md);
+  margin-left: var(--space-lg);
   white-space: nowrap;
   cursor: pointer;
+  font-weight: 500;
 }
 
-.dating-main-title {
+.express-main-title {
   text-align: center;
   font-size: 20px;
   font-weight: bold;
   color: #ffb3ba;
-  margin: 12px 15px 16px;
+  margin: var(--space-md) var(--space-lg) var(--space-lg);
   padding: 0;
   line-height: 1.3;
 }
@@ -283,189 +259,85 @@ watch(
   color: #ff8a80;
 }
 .gender-secret {
-  border-bottom: 2px dashed #333333;
-  color: #333333;
+  border-bottom: 2px dashed var(--c-text-1);
+  color: var(--c-text-1);
 }
 
-.dating-scroll-container {
+.express-scroll-container {
   height: calc(100vh - 180px);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-y: contain;
 }
 
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #e53935;
-  border-radius: 50%;
-  animation: dating-spin 0.8s linear infinite;
-}
-@keyframes dating-spin {
-  to { transform: rotate(360deg); }
+.express-list {
+  padding: 0 var(--space-lg) var(--space-xl);
 }
 
-.dating-list {
-  padding: 0 15px 20px;
-}
-.dating-card {
-  background: #fff;
-  border-radius: 8px;
-  margin-bottom: 12px;
+.express-card {
+  margin-bottom: var(--space-md);
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  animation: community-slide-up 0.4s ease both;
 }
-.dating-card__content {
-  padding: 16px 15px 12px;
+.express-card__content {
+  padding: var(--space-lg) var(--space-lg) var(--space-md);
 }
-.dating-card__names {
+.express-card__names {
   margin: 0 0 10px;
-  font-size: 16px;
+  font-size: var(--font-lg);
   line-height: 1.5;
 }
-.dating-card__names span {
+.express-card__names span {
   display: inline;
 }
-.dating-card__connector {
+.express-card__connector {
   margin: 0 6px;
-  color: #e53935;
+  color: #f43f5e;
   font-weight: bold;
   border: none !important;
 }
-.dating-card__text {
-  margin: 0 0 8px;
-  font-size: 15px;
-  color: #333;
+.express-card__text {
+  margin: 0 0 var(--space-sm);
+  font-size: var(--font-md);
+  color: var(--c-text-1);
   line-height: 1.6;
   word-break: break-word;
 }
-.dating-card__time {
+.express-card__time {
   margin: 0;
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
 }
-.dating-card__actions {
+.express-card__actions {
   display: flex;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--c-border);
 }
-.dating-action {
+.express-action {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: var(--space-xs);
   padding: 10px 0;
   background: transparent;
   border: none;
-  border-right: 1px solid #eee;
-  font-size: 14px;
-  color: #666;
+  border-right: 1px solid var(--c-border);
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   cursor: pointer;
 }
-.dating-action:last-child {
+.express-action:last-child {
   border-right: none;
 }
-.dating-action__icon {
-  font-size: 16px;
+.express-action__icon {
+  font-size: var(--font-lg);
 }
 
-.dating-legend {
+.express-legend {
   text-align: center;
-  font-size: 12px;
-  color: #999;
-  padding: 16px 15px 24px;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
+  padding: var(--space-lg) var(--space-lg) var(--space-xl);
   line-height: 1.5;
-}
-
-.dating-empty {
-  text-align: center;
-  padding: 60px 20px;
-  color: #999;
-  font-size: 14px;
-}
-
-.dating-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.dating-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #e53935;
-  border-radius: 50%;
-  animation: dating-spin 0.8s linear infinite;
-}
-
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #e53935;
-  text-decoration: none;
-}
-.weui-dialog__btn_primary {
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/lostandfound/Detail.vue
+++ b/frontend/src/views/lostandfound/Detail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -67,14 +68,10 @@ function copyText(text) {
 <template>
   <div class="lostandfound-detail">
     <!-- 统一顶部导航栏 -->
-    <div class="unified-header">
-      <span class="unified-header__back" @click="router.back()">返回</span>
-      <h1 class="unified-header__title">详情</h1>
-      <span class="unified-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="详情" moduleColor="#3b82f6" @back="router.back()" backTo="" />
 
     <div v-if="loading" class="lostandfound-detail-loading">
-      <div class="weui-loading"></div>
+      <span class="community-loading-spinner" style="--module-color: #3b82f6"></span>
       <p>加载中</p>
     </div>
 
@@ -93,13 +90,13 @@ function copyText(text) {
       </div>
 
       <!-- 基本信息 -->
-      <div class="detail-info">
+      <div class="detail-info community-card">
         <h5 class="detail-title">{{ detail.title }}</h5>
         <p class="detail-time">发布时间：<b>{{ detail.time }}</b></p>
       </div>
 
-      <!-- 地点信息：参考原版 ItemDetail.jsp 的 .site 结构 -->
-      <p class="detail-site">
+      <!-- 地点信息 -->
+      <p class="detail-site community-card">
         <span>
           <i class="i isite"></i>
           {{ detail.type === 0 ? '丢失地点' : '捡到地点' }}：
@@ -107,8 +104,8 @@ function copyText(text) {
         {{ detail.location }}
       </p>
 
-      <!-- 发布者信息：参考原版 .userinfo .user 结构 -->
-      <div class="detail-userinfo">
+      <!-- 发布者信息 -->
+      <div class="detail-userinfo community-card">
         <a class="user" href="javascript:;">
           <i class="avt">
             <img :src="detail.seller?.avatar || '/img/avatar/default.png'" alt="头像" />
@@ -117,14 +114,14 @@ function copyText(text) {
         </a>
       </div>
 
-      <!-- 物品描述：参考原版 .userinfo .info 结构 -->
-      <div class="detail-desc">
+      <!-- 物品描述 -->
+      <div class="detail-desc community-card">
         <i class="i iinfo"></i>
         <p class="w">物品描述：{{ detail.desc }}</p>
       </div>
 
-      <!-- 联系方式：参考原版 .userinfo .contact 结构 -->
-      <div class="detail-contact">
+      <!-- 联系方式 -->
+      <div class="detail-contact community-card">
         <i class="i icontact"></i>
         <span>联系方式：</span>
         <div v-if="detail.contact?.qq" class="contact-item">
@@ -148,34 +145,7 @@ function copyText(text) {
 <style scoped>
 .lostandfound-detail {
   min-height: 100vh;
-  background: #f5f5f5;
-}
-
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__placeholder {
-  min-width: 48px;
+  background: var(--c-bg);
 }
 
 .lostandfound-detail-loading {
@@ -184,23 +154,12 @@ function copyText(text) {
   align-items: center;
   justify-content: center;
   padding: 60px 20px;
-  color: #999;
-}
-.weui-loading {
-  width: 24px;
-  height: 24px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
+  color: var(--c-text-3);
 }
 
 .detail-slider {
   width: 100%;
-  background: #fff;
+  background: var(--c-card);
   overflow-x: auto;
   overflow-y: hidden;
 }
@@ -216,34 +175,35 @@ function copyText(text) {
 }
 
 .detail-info {
-  background: #fff;
   padding: 15px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--c-border);
+  border-radius: 0;
+  margin: 0;
 }
 .detail-title {
   font-size: 18px;
   font-weight: 500;
-  color: #333;
+  color: var(--c-text-1);
   margin: 0 0 10px 0;
   padding: 0;
 }
 .detail-time {
   font-size: 13px;
-  color: #999;
+  color: var(--c-text-3);
   margin: 0;
   padding: 0;
 }
 
-/* 地点信息：参考原版 ershou-base.css .detail .site */
+/* 地点信息 */
 .detail-site {
-  background: #fff;
   padding: 15px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--c-border);
   font-size: 14px;
-  color: #666;
+  color: var(--c-text-2);
   margin: 0;
   display: flex;
   align-items: center;
+  border-radius: 0;
 }
 .detail-site .i {
   display: inline-block;
@@ -259,18 +219,18 @@ function copyText(text) {
   vertical-align: middle;
 }
 
-/* 发布者信息：参考原版 ershou-base.css .userinfo .user */
+/* 发布者信息 */
 .detail-userinfo {
-  background: #fff;
   padding: 15px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--c-border);
+  border-radius: 0;
 }
 .detail-userinfo .user {
   display: flex;
   align-items: center;
   gap: 10px;
   text-decoration: none;
-  color: #333;
+  color: var(--c-text-1);
 }
 .detail-userinfo .avt {
   width: 40px;
@@ -287,20 +247,20 @@ function copyText(text) {
 }
 .detail-userinfo .nm {
   font-size: 14px;
-  color: #333;
+  color: var(--c-text-1);
 }
 
-/* 物品描述：参考原版 ershou-base.css .userinfo .info */
+/* 物品描述 */
 .detail-desc {
   position: relative;
-  background: #fff;
   padding: 15px 15px 15px 50px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--c-border);
   font-size: 14px;
-  color: #666;
+  color: var(--c-text-2);
   min-height: 50px;
   display: flex;
   align-items: center;
+  border-radius: 0;
 }
 .detail-desc .i {
   display: inline-block;
@@ -324,14 +284,14 @@ function copyText(text) {
   line-height: 1.6;
 }
 
-/* 联系方式：参考原版 ershou-base.css .userinfo .contact */
+/* 联系方式 */
 .detail-contact {
   position: relative;
-  background: #fff;
   padding: 15px 15px 15px 50px;
   font-size: 14px;
-  color: #666;
+  color: var(--c-text-2);
   min-height: 50px;
+  border-radius: 0;
 }
 .detail-contact .i {
   display: inline-block;
@@ -359,7 +319,7 @@ function copyText(text) {
   align-items: center;
   justify-content: space-between;
   padding: 8px 0;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--c-border);
 }
 .contact-item:last-child {
   border-bottom: none;
@@ -368,10 +328,10 @@ function copyText(text) {
 .contact-item a {
   padding: 4px 12px;
   font-size: 13px;
-  color: #3cb395;
+  color: #3b82f6;
   background: transparent;
-  border: 1px solid #3cb395;
-  border-radius: 4px;
+  border: 1px solid #3b82f6;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   text-decoration: none;
 }

--- a/frontend/src/views/lostandfound/Home.vue
+++ b/frontend/src/views/lostandfound/Home.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const activeType = ref(0) // 0: 寻物, 1: 招领
@@ -49,11 +50,7 @@ onMounted(() => {
 <template>
   <div class="lostandfound-home">
     <!-- 统一顶部导航栏 -->
-    <div class="unified-header">
-      <span class="unified-header__back" @click="router.push('/')">返回</span>
-      <h1 class="unified-header__title">失物招领</h1>
-      <span class="unified-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="失物招领" moduleColor="#3b82f6" />
 
     <!-- Tab 切换：寻物启事 / 失物招领 -->
     <div class="weui-navbar">
@@ -75,12 +72,12 @@ onMounted(() => {
       @touchend="handleTouchEnd"
     >
       <!-- 下拉刷新指示器 -->
-      <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-        <span v-if="refreshing" class="pull-refresh-text">
-          <i class="weui-loading"></i> 正在刷新...
+      <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+        <span v-if="refreshing" class="community-pull-refresh__text">
+          <span class="community-loading-spinner" style="--module-color: #3b82f6"></span> 正在刷新...
         </span>
-        <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-        <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+        <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+        <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
       </div>
 
       <!-- 失物招领列表（双列网格，参考原版 base.css .list width: 46.5%） -->
@@ -88,7 +85,7 @@ onMounted(() => {
         <div
           v-for="item in list"
           :key="item.id"
-          class="lostandfound-item"
+          class="lostandfound-item community-card"
           @click="goDetail(item.id)"
         >
           <div class="lostandfound-item__img-wrap">
@@ -106,18 +103,18 @@ onMounted(() => {
       </div>
 
       <!-- 空状态 -->
-      <div v-if="!loading && !refreshing && list.length === 0" class="lostandfound-empty">
-        <div class="lostandfound-empty__icon"></div>
-        <p class="lostandfound-empty__text">暂无{{ activeType === 0 ? '寻物' : '招领' }}信息</p>
+      <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+        <div class="community-empty__icon">📭</div>
+        <p class="community-empty__text">暂无{{ activeType === 0 ? '寻物' : '招领' }}信息</p>
       </div>
 
       <!-- 上拉加载更多 -->
-      <div v-if="loading && !refreshing" class="lostandfound-loadmore">
-        <i class="weui-loading"></i>
-        <span class="weui-loadmore__tips">正在加载</span>
+      <div v-if="loading && !refreshing" class="community-loadmore">
+        <span class="community-loading-spinner" style="--module-color: #3b82f6"></span>
+        <span>正在加载</span>
       </div>
-      <div v-if="finished && list.length > 0" class="lostandfound-loadmore">
-        <span class="weui-loadmore__tips">没有更多了</span>
+      <div v-if="finished && list.length > 0" class="community-loadmore">
+        <span>没有更多了</span>
       </div>
     </div>
   </div>
@@ -125,56 +122,27 @@ onMounted(() => {
 
 <style scoped>
 .lostandfound-home {
-  background-color: #f5f5f5;
+  background-color: var(--c-bg);
   min-height: 100vh;
-}
-
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__placeholder {
-  min-width: 48px;
-  text-align: right;
 }
 
 /* WEUI Navbar Tab 切换 */
 .weui-navbar {
   display: flex;
-  background-color: #fff;
-  border-bottom: 1px solid #e5e5e5;
+  background-color: var(--c-card);
+  border-bottom: 1px solid var(--c-divider);
 }
 .weui-navbar__item {
   flex: 1;
   padding: 13px 0;
   text-align: center;
   font-size: 15px;
-  color: #666;
+  color: var(--c-text-2);
   cursor: pointer;
   position: relative;
 }
 .weui-navbar__item.weui-bar__item_on {
-  color: #3cb395;
+  color: var(--c-lostandfound);
 }
 .weui-navbar__item.weui-bar__item_on::after {
   content: '';
@@ -183,45 +151,18 @@ onMounted(() => {
   left: 0;
   right: 0;
   height: 2px;
-  background-color: #3cb395;
+  background-color: var(--c-lostandfound);
 }
 
 /* 滚动容器 */
 .lostandfound-scroll-container {
-  height: calc(100vh - 88px);
+  height: calc(100vh - 95px);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-y: contain;
 }
 
-/* 下拉刷新指示器 */
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-/* 失物招领列表（双列网格，参考原版 base.css .list width: 46.5%） */
+/* 失物招领列表（双列网格） */
 .lostandfound-list {
   margin: 10px auto;
   width: 100%;
@@ -234,18 +175,16 @@ onMounted(() => {
   width: 46.5%;
   position: relative;
   margin: 4px 0 4px 2%;
-  background: #fff;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   overflow: hidden;
   cursor: pointer;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 .lostandfound-item__img-wrap {
   width: 100%;
   height: 170px;
   position: relative;
   overflow: hidden;
-  background: #f0f0f0;
+  background: var(--c-border);
 }
 .lostandfound-item__img-wrap img {
   width: 100%;
@@ -255,7 +194,7 @@ onMounted(() => {
 .lostandfound-item__placeholder {
   width: 100%;
   height: 100%;
-  background: #f0f0f0;
+  background: var(--c-border);
 }
 .lostandfound-item__tag {
   position: absolute;
@@ -265,7 +204,7 @@ onMounted(() => {
   font-size: 11px;
   color: #fff;
   background-color: #ff9800;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   z-index: 1;
 }
 .lostandfound-item__tag.tag-found {
@@ -277,7 +216,7 @@ onMounted(() => {
 .lostandfound-item__title {
   font-size: 14px;
   font-weight: 500;
-  color: #333;
+  color: var(--c-text-1);
   margin: 0 0 4px 0;
   padding: 0;
   display: -webkit-box;
@@ -288,7 +227,7 @@ onMounted(() => {
 }
 .lostandfound-item__desc {
   font-size: 12px;
-  color: #999;
+  color: var(--c-text-3);
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -296,47 +235,5 @@ onMounted(() => {
   -webkit-box-orient: vertical;
   overflow: hidden;
   line-height: 1.4;
-}
-
-/* 空状态 */
-.lostandfound-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 60px 20px;
-}
-.lostandfound-empty__icon {
-  width: 80px;
-  height: 80px;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23d8d8d8'%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z'/%3E%3C/svg%3E") center/contain no-repeat;
-}
-.lostandfound-empty__text {
-  margin: 16px 0 0;
-  font-size: 14px;
-  color: #999;
-}
-
-/* 加载更多 */
-.lostandfound-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.lostandfound-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-.weui-loadmore__tips {
-  font-size: 14px;
-  color: #999;
 }
 </style>

--- a/frontend/src/views/lostandfound/Index.vue
+++ b/frontend/src/views/lostandfound/Index.vue
@@ -1,120 +1,27 @@
 <script setup>
-import { computed } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-
-const router = useRouter()
-const route = useRoute()
-
-const activeTab = computed(() => {
-  const p = route.path
-  if (p.includes('/lostandfound/publish')) return 'publish'
-  if (p.includes('/lostandfound/profile')) return 'profile'
-  return 'home'
-})
-
-function goTo(path) {
-  router.push(path)
-}
+import CommunityTabbar from '../../components/community/CommunityTabbar.vue'
 </script>
 
 <template>
-  <div class="lostandfound-page">
+  <div class="community-page" style="--module-color: #3b82f6">
     <div class="lostandfound-container">
       <router-view />
     </div>
-    <!-- 底部 Tabbar -->
-    <div class="lostandfound-tabbar">
-      <a
-        href="javascript:;"
-        class="tabbar-item"
-        :class="{ on: activeTab === 'home' }"
-        @click.prevent="goTo('/lostandfound/home')"
-      >
-        <i class="tabbar-icon">
-          <img :src="activeTab === 'home' ? '/img/lostandfound/lost_selected.png' : '/img/lostandfound/lost_normal.png'" alt="首页" style="width: 24px; height: 24px; display: block;" />
-        </i>
-        <p class="tabbar-label">首页</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="tabbar-item"
-        :class="{ on: activeTab === 'publish' }"
-        @click.prevent="goTo('/lostandfound/publish')"
-      >
-        <i class="tabbar-icon">
-          <img src="/img/lostandfound/publish.png" alt="发布" style="width: 24px; height: 24px; display: block;" />
-        </i>
-        <p class="tabbar-label">发布</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="tabbar-item"
-        :class="{ on: activeTab === 'profile' }"
-        @click.prevent="goTo('/lostandfound/profile')"
-      >
-        <i class="tabbar-icon">
-          <img :src="activeTab === 'profile' ? '/img/lostandfound/personal_selected.png' : '/img/lostandfound/personal_normal.png'" alt="个人中心" style="width: 24px; height: 24px; display: block;" />
-        </i>
-        <p class="tabbar-label">个人中心</p>
-      </a>
-    </div>
+    <CommunityTabbar
+      basePath="/lostandfound"
+      moduleColor="#3b82f6"
+      :tabs="[
+        { key: 'home', label: '首页', path: '/lostandfound/home', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z&quot;/></svg>' },
+        { key: 'publish', label: '发布', path: '/lostandfound/publish', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z&quot;/></svg>' },
+        { key: 'profile', label: '我的', path: '/lostandfound/profile', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z&quot;/></svg>' }
+      ]"
+    />
   </div>
 </template>
 
 <style scoped>
-.lostandfound-page {
-  min-height: 100vh;
-  background-color: #f5f5f5;
-}
 .lostandfound-container {
-  padding-bottom: 20px;
+  padding-bottom: 56px;
   box-sizing: border-box;
-}
-.lostandfound-tabbar {
-  position: fixed !important;
-  bottom: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  width: 100vw !important;
-  max-width: 100%;
-  margin: 0 !important;
-  padding: 0 !important;
-  z-index: 500;
-  background-color: #3cb395;
-  display: flex;
-  height: 2.7rem;
-}
-.tabbar-item {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: rgba(255, 255, 255, 0.85);
-  text-decoration: none;
-  font-size: 12px;
-}
-.tabbar-item.on {
-  color: #fff;
-  font-weight: 500;
-}
-.tabbar-icon {
-  width: 24px !important;
-  height: 24px !important;
-  margin: 0 auto 2px auto !important;
-  display: block;
-}
-.tabbar-icon img {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
-.tabbar-label {
-  text-align: center !important;
-  font-size: 12px !important;
-  line-height: 1 !important;
-  margin: 0 !important;
-  padding: 0;
-  color: #fff !important;
 }
 </style>

--- a/frontend/src/views/lostandfound/Profile.vue
+++ b/frontend/src/views/lostandfound/Profile.vue
@@ -3,6 +3,7 @@ import { onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { getCurrentUserProfile } from '../../api/user.js'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -120,11 +121,7 @@ watch(() => route.fullPath, () => {
 
 <template>
   <div class="lostandfound-profile">
-    <div class="unified-header">
-      <span class="unified-header__back" @click="router.push('/lostandfound/home')">返回</span>
-      <h1 class="unified-header__title">个人中心</h1>
-      <span class="unified-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="个人中心" moduleColor="#3b82f6" backTo="/lostandfound/home" />
 
     <section class="profile-section">
       <i class="avt">
@@ -156,7 +153,7 @@ watch(() => route.fullPath, () => {
             <div v-if="lostList.length === 0" class="nostatus">
               <p class="tip">暂无寻物信息</p>
             </div>
-            <div v-for="item in lostList" :key="item.id" class="stat">
+            <div v-for="item in lostList" :key="item.id" class="stat community-card">
               <div class="info" @click="goDetail(item.id)">
                 <i class="img">
                   <img :src="item.image" alt="" />
@@ -178,7 +175,7 @@ watch(() => route.fullPath, () => {
             <div v-if="foundList.length === 0" class="nostatus">
               <p class="tip">暂无招领信息</p>
             </div>
-            <div v-for="item in foundList" :key="item.id" class="stat">
+            <div v-for="item in foundList" :key="item.id" class="stat community-card">
               <div class="info" @click="goDetail(item.id)">
                 <i class="img">
                   <img :src="item.image" alt="" />
@@ -200,7 +197,7 @@ watch(() => route.fullPath, () => {
             <div v-if="didFoundList.length === 0" class="nostatus">
               <p class="tip">暂无已找回信息</p>
             </div>
-            <div v-for="item in didFoundList" :key="item.id" class="stat">
+            <div v-for="item in didFoundList" :key="item.id" class="stat community-card">
               <div class="info">
                 <i class="img">
                   <img :src="item.image" alt="" />
@@ -215,12 +212,12 @@ watch(() => route.fullPath, () => {
     </section>
 
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog" style="--module-color: #3b82f6">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
@@ -230,41 +227,12 @@ watch(() => route.fullPath, () => {
 <style scoped>
 .lostandfound-profile {
   min-height: 100vh;
-  background: #e3eeec;
-}
-
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__placeholder {
-  min-width: 48px;
+  background: var(--c-bg);
 }
 
 .profile-section {
   position: relative;
-  background: #44c1a5;
-  border-top: 1px solid #39b89d;
-  border-bottom: 4px solid #3cab93;
+  background: linear-gradient(135deg, #3b82f6, #60a5fa);
   padding: 30px 20px 20px 140px;
   min-height: 90px;
 }
@@ -293,7 +261,7 @@ watch(() => route.fullPath, () => {
   margin-bottom: 5px;
 }
 .profile-section .introduction {
-  color: #fff;
+  color: rgba(255, 255, 255, 0.9);
   line-height: 21px;
   font-size: 12px;
   display: block;
@@ -310,7 +278,6 @@ watch(() => route.fullPath, () => {
 }
 .status-section .tabs {
   display: flex;
-  margin-bottom: 10px;
   list-style: none;
   padding: 0;
   margin: 10px 0;
@@ -319,14 +286,14 @@ watch(() => route.fullPath, () => {
   flex: 1;
   display: block;
   position: relative;
-  color: #44c1a5;
+  color: var(--c-lostandfound);
   text-align: center;
   height: 32px;
   line-height: 32px;
   font-size: 14px;
   cursor: pointer;
-  background: #fff;
-  border-radius: 4px 4px 0 0;
+  background: var(--c-card);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   margin-right: 5px;
 }
 .status-section .tab:last-child {
@@ -335,7 +302,7 @@ watch(() => route.fullPath, () => {
 .status-section .tab .line {
   width: 28px;
   height: 1px;
-  background: #44c1a5;
+  background: var(--c-lostandfound);
   position: absolute;
   left: 50%;
   margin-left: -14px;
@@ -343,7 +310,7 @@ watch(() => route.fullPath, () => {
   display: none;
 }
 .status-section .tab.on {
-  background: #44c1a5;
+  background: var(--c-lostandfound);
   color: #fff;
 }
 .status-section .tab.on .line {
@@ -362,15 +329,14 @@ watch(() => route.fullPath, () => {
 }
 
 .stat {
-  background: #fff;
   margin-bottom: 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 .stat .info {
   position: relative;
   padding: 8px 8px 8px 75px;
   min-height: 60px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--c-border);
   cursor: pointer;
 }
 .stat .info .img {
@@ -380,6 +346,7 @@ watch(() => route.fullPath, () => {
   height: 60px;
   overflow: hidden;
   display: block;
+  border-radius: var(--radius-sm);
 }
 .stat .info .img img {
   width: 100%;
@@ -387,14 +354,14 @@ watch(() => route.fullPath, () => {
   object-fit: cover;
 }
 .stat .info h5.tit {
-  color: #1c826c;
+  color: var(--c-lostandfound);
   font-size: 14px;
   line-height: 20px;
   margin: 0 0 4px 0;
   padding: 0;
 }
 .stat .info .tm {
-  color: #999;
+  color: var(--c-text-3);
   font-size: 12px;
   margin: 0;
   padding: 0;
@@ -410,8 +377,8 @@ watch(() => route.fullPath, () => {
 }
 .stat .btns .btn b {
   display: block;
-  color: #999;
-  border-left: 1px solid #ddd;
+  color: var(--c-text-3);
+  border-left: 1px solid var(--c-divider);
   text-align: center;
   line-height: 16px;
   height: 16px;
@@ -435,8 +402,8 @@ watch(() => route.fullPath, () => {
   height: 88px;
   transform: translateX(-50%);
   border-radius: 28px;
-  background: linear-gradient(180deg, #eefcf8 0%, #daf4ec 100%);
-  box-shadow: inset 0 0 0 1px #c7ebe0;
+  background: linear-gradient(180deg, #eff6ff 0%, #dbeafe 100%);
+  box-shadow: inset 0 0 0 1px #bfdbfe;
 }
 .nostatus::after {
   content: '';
@@ -446,68 +413,13 @@ watch(() => route.fullPath, () => {
   width: 30px;
   height: 30px;
   transform: translateX(-50%) rotate(45deg);
-  border-right: 3px solid rgba(68, 193, 165, 0.6);
-  border-bottom: 3px solid rgba(68, 193, 165, 0.6);
+  border-right: 3px solid rgba(59, 130, 246, 0.6);
+  border-bottom: 3px solid rgba(59, 130, 246, 0.6);
 }
 .nostatus .tip {
   text-align: center;
-  color: #44c1a5;
+  color: var(--c-lostandfound);
   margin-bottom: 25px;
   font-size: 14px;
-}
-
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-  word-wrap: break-word;
-  word-break: break-all;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #3cc395;
-  text-decoration: none;
-}
-.weui-dialog__btn_primary {
-  color: #3cc395;
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/lostandfound/Publish.vue
+++ b/frontend/src/views/lostandfound/Publish.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { uploadFilesByPresignedUrl } from '../../utils/presignedUpload'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -227,13 +228,18 @@ onMounted(() => {
 
 <template>
   <div class="lostandfound-publish">
-    <div class="unified-header">
-      <span class="unified-header__back" @click="goBack">返回</span>
-      <h1 class="unified-header__title">{{ isEditMode ? '编辑信息' : '发布信息' }}</h1>
-      <a href="javascript:;" class="unified-header__submit" @click.prevent="submit">
-        {{ submitting ? '提交中' : (isEditMode ? '保存' : '完成') }}
-      </a>
-    </div>
+    <CommunityHeader
+      :title="isEditMode ? '编辑信息' : '发布信息'"
+      moduleColor="#3b82f6"
+      @back="goBack()"
+      backTo=""
+    >
+      <template #right>
+        <a href="javascript:;" class="publish-submit-btn" @click.prevent="submit">
+          {{ submitting ? '提交中' : (isEditMode ? '保存' : '完成') }}
+        </a>
+      </template>
+    </CommunityHeader>
 
     <div class="publish-form">
       <p v-if="pageLoading" class="page-loading">正在加载信息...</p>
@@ -325,27 +331,27 @@ onMounted(() => {
     </div>
 
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog" style="--module-color: #3b82f6">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</button>
         </div>
       </div>
     </div>
 
     <div v-if="itemTypePickerVisible">
-      <div class="weui-mask" @click="closeItemTypePicker"></div>
-      <div class="weui-dialog weui-dialog--list">
-        <div class="weui-dialog__hd"><strong class="weui-dialog__title">选择物品分类</strong></div>
-        <div class="weui-dialog__bd weui-dialog__bd--scroll">
-          <div v-for="(label, index) in itemTypeNames" :key="label" class="weui-dialog__item" @click="selectItemType(index)">
+      <div class="community-dialog-mask" @click="closeItemTypePicker"></div>
+      <div class="community-dialog community-dialog--list" style="--module-color: #3b82f6">
+        <div class="community-dialog__title">选择物品分类</div>
+        <div class="community-dialog__body community-dialog__body--scroll">
+          <div v-for="(label, index) in itemTypeNames" :key="label" class="community-dialog__item" @click="selectItemType(index)">
             {{ label }}
           </div>
         </div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_default" @click="closeItemTypePicker">取消</a>
+        <div class="community-dialog__footer">
+          <button class="community-dialog__btn community-dialog__btn--cancel" @click="closeItemTypePicker">取消</button>
         </div>
       </div>
     </div>
@@ -355,49 +361,24 @@ onMounted(() => {
 <style scoped>
 .lostandfound-publish {
   min-height: 100vh;
-  background: #e3eeec;
+  background: var(--c-bg);
 }
 
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.unified-header__back {
+.publish-submit-btn {
   font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-}
-.unified-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.unified-header__submit {
-  font-size: 14px;
-  color: #3cb395;
+  color: #3b82f6;
   text-decoration: none;
-  min-width: 48px;
-  text-align: right;
+  font-weight: 500;
 }
 
 .publish-form {
   padding: 0;
-  background: #e3eeec;
 }
 
 .page-loading {
   margin: 16px 0 0;
   text-align: center;
-  color: #999;
+  color: var(--c-text-3);
   font-size: 14px;
 }
 
@@ -405,16 +386,16 @@ onMounted(() => {
   position: relative;
   padding-left: 90px;
   font-size: 16px;
-  border-bottom: 2px solid #3cc2a5;
+  border-bottom: 1px solid var(--c-divider);
   min-height: 70px;
-  background: #fff;
+  background: var(--c-card);
   margin: 0 10px;
   border-radius: 0;
 }
 .form-frmt {
   position: absolute;
   left: 0;
-  color: #202020;
+  color: var(--c-text-1);
   height: 70px;
   line-height: 70px;
   padding-left: 15px;
@@ -424,7 +405,7 @@ onMounted(() => {
   padding-top: 18px;
 }
 .form-frmc input {
-  color: #202020;
+  color: var(--c-text-1);
   background: none;
   height: 34px;
   line-height: 34px;
@@ -442,7 +423,7 @@ onMounted(() => {
   padding-top: 0;
 }
 .select-value {
-  color: #202020;
+  color: var(--c-text-1);
   font-size: 16px;
 }
 .select-arrow {
@@ -482,8 +463,8 @@ onMounted(() => {
 }
 
 .picture-section {
-  background: #3cc2a5;
-  border-top: 1px solid #39b89d;
+  background: #3b82f6;
+  border-top: 1px solid #2563eb;
   margin-top: 20px;
 }
 .picture-images {
@@ -570,79 +551,23 @@ onMounted(() => {
   padding-bottom: 3px;
 }
 
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog--list {
+/* Dialog overrides for picker list */
+.community-dialog--list {
   max-width: 320px;
 }
-.weui-dialog__hd {
-  padding: 20px 20px 10px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  font-weight: 500;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-  word-wrap: break-word;
-  word-break: break-all;
-}
-.weui-dialog__bd--scroll {
+.community-dialog__body--scroll {
   max-height: 280px;
   overflow-y: auto;
   padding: 0;
+  text-align: left;
 }
-.weui-dialog__item {
+.community-dialog__item {
   padding: 14px 20px;
-  border-top: 1px solid #f0f0f0;
-  color: #333;
+  border-top: 1px solid var(--c-border);
+  color: var(--c-text-1);
   cursor: pointer;
 }
-.weui-dialog__item:first-child {
+.community-dialog__item:first-child {
   border-top: none;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #d9d9d9;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 15px 0;
-  text-align: center;
-  font-size: 17px;
-  color: #3cc395;
-  text-decoration: none;
-  border-right: 1px solid #d9d9d9;
-}
-.weui-dialog__btn:last-child {
-  border-right: none;
-}
-.weui-dialog__btn_primary {
-  color: #3cc395;
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/views/photograph/Detail.vue
+++ b/frontend/src/views/photograph/Detail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -105,22 +106,17 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="photograph-detail">
-    <!-- 统一顶部导航栏 -->
-    <div class="unified-header">
-      <div class="header-left" @click="goBack">‹</div>
-      <div class="header-title">作品详情</div>
-      <div class="header-right"></div>
-    </div>
+  <div class="community-page photograph-detail" :style="{ '--module-color': '#06b6d4' }">
+    <CommunityHeader title="作品详情" moduleColor="#06b6d4" @back="goBack" :backTo="''" :showBack="true" />
 
-    <div v-if="loading" class="loading">
-      <i class="weui-loading"></i>
+    <div v-if="loading" class="community-loadmore" style="padding: 60px var(--space-xl);">
+      <i class="community-loading-spinner"></i>
       <span>加载中...</span>
     </div>
 
     <div v-else-if="work" class="detail-main">
       <!-- 顶部数据看板 -->
-      <div class="photo-stats">
+      <div class="community-card photo-stats" style="animation: community-slide-up 0.3s ease both;">
         <div class="stat-item">
           <div class="num">{{ work.photoCount || (images.length || 1) }}</div>
           <div class="label">照片总数</div>
@@ -156,7 +152,7 @@ onMounted(async () => {
       </div>
 
       <!-- 作品信息与互动区 -->
-          <div class="detail-info">
+      <div class="community-card detail-info" style="animation: community-slide-up 0.4s ease both; animation-delay: 0.1s;">
         <h2 class="detail-title">{{ work.title }}</h2>
         <div class="detail-meta">
           <div class="author">
@@ -172,12 +168,12 @@ onMounted(async () => {
         <p class="detail-desc">{{ work.description || work.content }}</p>
 
         <div class="card-btn-group">
-          <div class="am-btn-group am-btn-group-justify">
-            <a class="am-btn am-btn-photo" :class="{ liked: work.isLiked }" href="javascript:;" role="button" @click.stop="toggleLike">
+          <div class="btn-group-justify">
+            <a class="btn-action" :class="{ liked: work.isLiked }" href="javascript:;" role="button" @click.stop="toggleLike">
               <i :class="work.isLiked ? 'am-icon-check-square' : 'am-icon-check-square-o'"></i
               >{{ work.likeCount ?? work.likes }} 点赞
             </a>
-            <a class="am-btn am-btn-photo" href="javascript:;" role="button">
+            <a class="btn-action" href="javascript:;" role="button">
               <i class="am-icon-th-list"></i>{{ work.commentCount || (work.comments ? work.comments.length : 0) }} 评论
             </a>
           </div>
@@ -207,16 +203,14 @@ onMounted(async () => {
       <button type="button" @click="submitComment">发送</button>
     </div>
 
-    <!-- WEUI 对话框 -->
+    <!-- 对话框 -->
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd">
-          <strong class="weui-dialog__title">提示</strong>
-        </div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <a href="javascript:" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
         </div>
       </div>
     </div>
@@ -224,103 +218,32 @@ onMounted(async () => {
 </template>
 
 <style scoped>
-.photograph-detail {
-  min-height: 100vh;
-  background: #f8f8f8;
-}
-
-/* 统一顶部导航栏 */
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.header-left {
-  padding: 0 10px;
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  min-width: 48px;
-  font-size: 24px;
-  font-weight: 300 !important;
-  color: #333;
-}
-.header-left i,
-.header-left svg,
-.header-left img {
-  font-size: 24px !important;
-  width: 24px !important;
-  height: 24px !important;
-  font-weight: 300 !important;
-  transform: scale(1.4);
-  transform-origin: center center;
-}
-.header-left svg {
-  stroke-width: 1 !important;
-}
-.header-title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.header-right {
-  min-width: 48px;
-  text-align: right;
-}
-
-.loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 60px 20px;
-  gap: 10px;
-  color: #999;
-}
-.loading .weui-loading {
-  width: 20px;
-  height: 20px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 .detail-main {
-  padding-bottom: 80px; /* 预留底部输入框高度 */
+  padding-bottom: 80px;
 }
 
 /* 顶部数据看板 */
 .photo-stats {
-  margin: 12px 15px;
-  border-radius: 8px;
+  margin: var(--space-md) var(--space-lg);
   display: flex;
-  overflow: hidden; /* 确保圆角生效 */
+  overflow: hidden;
 }
 .photo-stats .stat-item {
   flex: 1;
   text-align: center;
 }
 .photo-stats .num {
-  font-size: 24px;
+  font-size: var(--font-2xl);
   font-weight: bold;
-  background: #009688;
+  padding: var(--space-sm) 0;
+  background: var(--c-photograph);
   color: #fff;
 }
 .photo-stats .label {
-  font-size: 14px;
-  background: #05574f;
+  font-size: var(--font-base);
+  padding: var(--space-xs) 0;
+  background: #058da0;
+  background: color-mix(in srgb, var(--c-photograph) 70%, #000);
   color: #fff;
 }
 
@@ -346,32 +269,35 @@ onMounted(async () => {
 .carousel-dots {
   display: flex;
   justify-content: center;
-  margin: 8px 0 4px 0;
+  margin: var(--space-sm) 0 var(--space-xs) 0;
 }
 .carousel-dots span {
   width: 6px;
   height: 6px;
-  border-radius: 50%;
-  background: #ccc;
+  border-radius: var(--radius-full);
+  background: var(--c-divider);
   margin: 0 3px;
+  transition: background 0.2s;
 }
 .carousel-dots .active {
-  background: #009688;
+  background: var(--c-photograph);
 }
 
 .detail-info {
-  padding: 15px;
-  background: #fff;
+  margin: var(--space-md) var(--space-lg);
+  padding: var(--space-lg);
 }
 .detail-title {
-  font-size: 20px;
-  margin: 0 0 10px 0;
+  font-size: var(--font-2xl);
+  font-weight: 600;
+  color: var(--c-text-1);
+  margin: 0 0 var(--space-md) 0;
 }
 .detail-meta {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-sm);
 }
 .author {
   display: flex;
@@ -380,87 +306,77 @@ onMounted(async () => {
 .author-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
-  margin-right: 8px;
+  border-radius: var(--radius-full);
+  margin-right: var(--space-sm);
 }
 .author-name {
-  font-size: 14px;
-  color: #555;
-}
-.likes {
-  display: flex;
-  align-items: center;
-  font-size: 14px;
-  color: #e91e63;
-}
-.likes i {
-  margin-right: 4px;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
 }
 .detail-time {
-  font-size: 12px;
-  color: #999;
-  margin-bottom: 10px;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
+  margin-bottom: var(--space-md);
 }
 .detail-desc {
-  font-size: 15px;
-  color: #333;
+  font-size: var(--font-md);
+  color: var(--c-text-1);
   line-height: 1.6;
 }
 
-/* 互动按钮样式：复用 am-btn-photo */
+/* 互动按钮 */
 .card-btn-group {
-  font-size: 20px;
-  padding: 10px 0;
+  padding: var(--space-md) 0;
 }
-.am-btn-group-justify {
+.btn-group-justify {
   display: flex;
+  gap: var(--space-sm);
 }
-.am-btn {
+.btn-action {
   flex: 1;
   text-align: center;
-  padding: 8px 0;
+  padding: var(--space-sm) 0;
   border: none;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-}
-.am-btn-photo {
   color: #fff;
-  background-color: #518379;
-  border-color: #ffffff;
-  font-size: 80%;
+  background-color: var(--c-photograph);
+  font-size: var(--font-base);
+  text-decoration: none;
+  transition: opacity 0.2s;
 }
-.am-btn-photo:hover {
-  color: #ffeb3b !important;
+.btn-action:active {
+  opacity: 0.85;
 }
-.am-btn-photo.liked {
-  background-color: #2e8b57 !important;
-  color: #fff !important;
+.btn-action.liked {
+  background-color: #0592aa;
+  background-color: color-mix(in srgb, var(--c-photograph) 80%, #000);
 }
-.am-btn-photo.liked:hover {
-  color: #fff !important;
-}
-.am-btn-photo i {
-  margin-right: 4px;
+.btn-action i {
+  margin-right: var(--space-xs);
 }
 
-/* 评论列表：头像+气泡框 */
+/* 评论列表 */
 .comment-list {
-  margin-top: 10px;
+  margin-top: var(--space-md);
+  border-top: 1px solid var(--c-border);
+  padding-top: var(--space-md);
 }
 .comment-item {
   display: flex;
   align-items: flex-start;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 .comment-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
-  margin-right: 8px;
+  border-radius: var(--radius-full);
+  margin-right: var(--space-sm);
 }
 .comment-bubble {
-  background: #f5f5f5;
-  border-radius: 4px;
-  padding: 6px 10px;
+  background: var(--c-bg);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
   position: relative;
   max-width: 80%;
 }
@@ -471,23 +387,23 @@ onMounted(async () => {
   top: 10px;
   border-width: 6px;
   border-style: solid;
-  border-color: transparent #f5f5f5 transparent transparent;
+  border-color: transparent var(--c-bg) transparent transparent;
 }
 .comment-author {
   margin: 0;
-  font-size: 13px;
-  font-weight: bold;
-  color: #555;
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--c-text-2);
 }
 .comment-text {
   margin: 2px 0;
-  font-size: 14px;
-  color: #333;
+  font-size: var(--font-base);
+  color: var(--c-text-1);
 }
 .comment-time {
   margin: 0;
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-xs);
+  color: var(--c-text-3);
 }
 
 /* 底部评论输入栏 */
@@ -498,79 +414,37 @@ onMounted(async () => {
   right: 0;
   display: flex;
   align-items: center;
-  padding: 8px 10px;
-  background: #fff;
-  border-top: 1px solid #ddd;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--c-card);
+  border-top: 1px solid var(--c-border);
+  box-shadow: var(--shadow-sm);
 }
 .comment-input-bar input {
   flex: 1;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 6px 8px;
-  font-size: 14px;
-  margin-right: 8px;
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-full);
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--font-base);
+  margin-right: var(--space-sm);
+  color: var(--c-text-1);
+  transition: border-color 0.2s;
+}
+.comment-input-bar input:focus {
+  outline: none;
+  border-color: var(--c-photograph);
 }
 .comment-input-bar button {
-  padding: 6px 12px;
+  padding: var(--space-sm) var(--space-lg);
   border: none;
-  border-radius: 4px;
-  background: #27ae60;
+  border-radius: var(--radius-full);
+  background: var(--c-photograph);
   color: #fff;
-  font-size: 14px;
+  font-size: var(--font-base);
+  font-weight: 500;
   cursor: pointer;
+  transition: opacity 0.2s;
 }
-
-/* WEUI 对话框样式（简化版） */
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-}
-.weui-dialog__hd {
-  padding: 1.2em 1.6em 0.5em;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-weight: 400;
-  font-size: 18px;
-}
-.weui-dialog__bd {
-  padding: 0 1.6em 0.8em;
-  min-height: 40px;
-  font-size: 15px;
-  line-height: 1.5;
-  color: #999;
-  text-align: center;
-}
-.weui-dialog__ft {
-  position: relative;
-  line-height: 42px;
-  display: flex;
-  border-top: 1px solid #d5d5d6;
-}
-.weui-dialog__btn {
-  flex: 1;
-  text-align: center;
-  text-decoration: none;
-  color: #3cc51f;
-  font-size: 17px;
-}
-.weui-dialog__btn_primary {
-  color: #0bb20c;
+.comment-input-bar button:active {
+  opacity: 0.85;
 }
 </style>

--- a/frontend/src/views/photograph/Home.vue
+++ b/frontend/src/views/photograph/Home.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const scrollContainer = ref(null)
@@ -68,13 +69,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="photograph-home">
-    <!-- 统一顶部导航栏：左侧返回，中间标题，右侧留空 -->
-    <div class="unified-header">
-      <div class="header-left" @click="router.push('/')">‹</div>
-      <div class="header-title">拍好校园</div>
-      <div class="header-right"></div>
-    </div>
+  <div class="community-page photograph-home" :style="{ '--module-color': '#06b6d4' }">
+    <CommunityHeader title="拍好校园" moduleColor="#06b6d4" backTo="/" />
 
     <!-- 列表滚动容器：单列卡片列表 -->
     <div
@@ -86,20 +82,21 @@ onMounted(() => {
       @touchend="handleTouchEnd"
     >
       <!-- 下拉刷新指示器 -->
-      <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-        <span v-if="refreshing" class="pull-refresh-text">
-          <i class="weui-loading"></i> 正在刷新...
+      <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+        <span v-if="refreshing" class="community-pull-refresh__text">
+          <i class="community-loading-spinner"></i> 正在刷新...
         </span>
-        <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-        <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+        <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+        <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
       </div>
 
-      <!-- 照片卡片列表：参考 .card 结构 -->
-      <div id="card-box">
+      <!-- 照片卡片列表 -->
+      <div class="card-list">
         <div
-          v-for="item in list"
+          v-for="(item, index) in list"
           :key="item.id"
-          class="card"
+          class="community-card card"
+          :style="{ animationDelay: (index % 10) * 0.05 + 's' }"
           @click="goDetail(item.id)"
         >
           <div class="card-img">
@@ -120,9 +117,9 @@ onMounted(() => {
 
           <!-- 卡片下方按钮组：点赞 + 评论 -->
           <div class="card-btn-group">
-            <div class="am-btn-group am-btn-group-justify">
+            <div class="btn-group-justify">
               <a
-                class="am-btn am-btn-photo"
+                class="btn-action"
                 :class="{ liked: item.isLiked }"
                 href="javascript:;"
                 role="button"
@@ -131,7 +128,7 @@ onMounted(() => {
                 <i :class="item.isLiked ? 'am-icon-check-square' : 'am-icon-check-square-o'"></i
                 >{{ item.likeCount ?? item.likes }} 点赞
               </a>
-              <a class="am-btn am-btn-photo" href="javascript:;" role="button">
+              <a class="btn-action" href="javascript:;" role="button">
                 <i class="am-icon-th-list"></i>{{ item.commentCount ?? 0 }} 评论
               </a>
             </div>
@@ -141,17 +138,18 @@ onMounted(() => {
       </div>
 
       <!-- 空状态 -->
-      <div v-if="!loading && !refreshing && list.length === 0" class="photograph-empty">
-        <p>暂无照片作品</p>
+      <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+        <div class="community-empty__icon">📷</div>
+        <p class="community-empty__text">暂无照片作品</p>
       </div>
 
       <!-- 上拉加载更多 -->
-      <div v-if="loading && !refreshing" class="photograph-loadmore">
-        <i class="weui-loading"></i>
-        <span class="weui-loadmore__tips">正在加载</span>
+      <div v-if="loading && !refreshing" class="community-loadmore">
+        <i class="community-loading-spinner"></i>
+        <span>正在加载</span>
       </div>
-      <div v-if="finished && list.length > 0" class="photograph-loadmore">
-        <span class="weui-loadmore__tips">没有更多了</span>
+      <div v-if="finished && list.length > 0" class="community-loadmore">
+        <span>没有更多了</span>
       </div>
     </div>
 
@@ -171,102 +169,25 @@ onMounted(() => {
 </template>
 
 <style scoped>
-.photograph-home {
-  min-height: 100vh;
-  background: #f8f8f8;
-}
-
-/* 统一顶部导航栏 */
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.header-left {
-  padding: 0 10px;
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  min-width: 48px;
-  font-size: 24px;
-  font-weight: 300 !important;
-  color: #333;
-}
-.header-left i,
-.header-left svg,
-.header-left img {
-  font-size: 24px !important;
-  width: 24px !important;
-  height: 24px !important;
-  font-weight: 300 !important;
-  transform: scale(1.4);
-  transform-origin: center center;
-}
-.header-left svg {
-  stroke-width: 1 !important;
-}
-.header-right {
-  width: 48px;
-  text-align: center;
-}
-.header-title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  color: #333;
-}
-
 /* 滚动容器 */
 .photograph-scroll-container {
-  height: calc(100vh - 44px - 80px);
+  height: calc(100vh - 51px - 80px);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding-bottom: 80px;
 }
 
-/* 下拉刷新指示器 */
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+/* 卡片列表 */
+.card-list {
+  padding: var(--space-md);
 }
 
-/* 卡片样式：参考 photograph/index.css .card */
+/* 卡片样式 */
 .card {
-  background-color: #fff;
-  border: 1px solid transparent;
-  border-radius: 0;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.28);
-  width: 95%;
-  height: auto;
-  margin: 0 auto 30px auto;
+  width: 100%;
+  margin-bottom: var(--space-lg);
+  overflow: hidden;
+  animation: community-slide-up 0.4s ease both;
 }
 .card-img-tag img {
   width: 100%;
@@ -276,68 +197,66 @@ onMounted(() => {
 .card-img {
   position: relative;
 }
-.card-img {
-  position: relative;
-}
 .card-name {
-  margin: 10px;
-  font-size: 20px;
-  font-family: sans-serif;
+  margin: var(--space-md);
+  font-size: var(--font-2xl);
+  font-weight: 600;
+  color: var(--c-text-1);
   clear: both;
 }
 .card-say {
-  margin: 10px;
-  font-size: 15px;
+  margin: 0 var(--space-md) var(--space-md);
+  font-size: var(--font-md);
+  color: var(--c-text-2);
+  line-height: 1.5;
 }
 
-/* 多图角标：参考 .tags + .img-num */
+/* 多图角标 */
 .tags {
   position: absolute;
-  right: 10px;
-  bottom: 10px;
+  right: var(--space-sm);
+  bottom: var(--space-sm);
   display: inline-flex;
 }
 .img-num {
-  background: #f39c12;
+  background: var(--c-photograph);
   color: #fff;
-  border-radius: 2px;
-  padding: 2px 6px;
-  font-size: 12px;
+  border-radius: var(--radius-sm);
+  padding: 2px 8px;
+  font-size: var(--font-sm);
+  font-weight: 500;
 }
 
-/* 卡片按钮组：参考 .card-btn-group + .am-btn-photo */
+/* 卡片按钮组 */
 .card-btn-group {
-  font-size: 20px;
-  padding: 0 10px 10px 10px;
+  padding: 0 var(--space-md) var(--space-md);
 }
-.am-btn-group-justify {
+.btn-group-justify {
   display: flex;
+  gap: var(--space-sm);
 }
-.am-btn {
+.btn-action {
   flex: 1;
   text-align: center;
-  padding: 8px 0;
+  padding: var(--space-sm) 0;
   border: none;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-}
-.am-btn-photo {
   color: #fff;
-  background-color: #518379;
-  border-color: #ffffff;
-  font-size: 80%;
+  background-color: var(--c-photograph);
+  font-size: var(--font-base);
+  text-decoration: none;
+  transition: opacity 0.2s;
 }
-.am-btn-photo:hover {
-  color: #ffeb3b !important;
+.btn-action:active {
+  opacity: 0.85;
 }
-.am-btn-photo.liked {
-  background-color: #2e8b57 !important;
-  color: #fff !important;
+.btn-action.liked {
+  background-color: #0592aa;
+  background-color: color-mix(in srgb, var(--c-photograph) 80%, #000);
 }
-.am-btn-photo.liked:hover {
-  color: #fff !important;
-}
-.am-btn-photo i {
-  margin-right: 4px;
+.btn-action i {
+  margin-right: var(--space-xs);
 }
 
 /* 底部三色操作栏 */
@@ -347,53 +266,40 @@ onMounted(() => {
   left: 0;
   right: 0;
   display: flex;
-  box-shadow: 0 -1px 5px #989898;
+  box-shadow: var(--shadow-lg);
+  border-top: 1px solid var(--c-border);
 }
 .photo-toolbar .toolbar-btn {
   flex: 1;
   text-align: center;
-  padding: 8px 0;
+  padding: var(--space-sm) 0;
   color: #fff;
-  font-size: 14px;
+  font-size: var(--font-base);
+  font-weight: 500;
   cursor: pointer;
+  transition: opacity 0.2s;
+}
+.photo-toolbar .toolbar-btn:active {
+  opacity: 0.85;
 }
 .photo-toolbar .life {
-  background-color: #e84c3d; /* 类似 am-btn-danger */
+  background-color: #e84c3d;
+}
+.photo-toolbar .life.active {
+  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.2);
 }
 .photo-toolbar .campus {
-  background-color: #3498db; /* 类似 am-btn-primary */
+  background-color: #3498db;
+}
+.photo-toolbar .campus.active {
+  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.2);
 }
 .photo-toolbar .upload {
-  background-color: #27ae60; /* 类似 am-btn-success */
+  background-color: var(--c-photograph);
 }
 
-/* 空状态与加载更多 */
-.photograph-empty {
-  text-align: center;
-  padding: 60px 20px;
-  color: #999;
-  font-size: 14px;
-}
-.photograph-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.photograph-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-.weui-loadmore__tips {
-  font-size: 14px;
-  color: #999;
+.card-img-tag {
+  margin: 0;
+  padding: 0;
 }
 </style>
-

--- a/frontend/src/views/photograph/Publish.vue
+++ b/frontend/src/views/photograph/Publish.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { uploadFilesByPresignedUrl } from '../../utils/presignedUpload'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 
@@ -101,53 +102,43 @@ const submit = async () => {
 </script>
 
 <template>
-  <div class="photograph-publish">
-    <!-- 统一顶部导航栏 -->
-    <div class="unified-header">
-      <div class="header-left" @click="goBack">‹</div>
-      <div class="header-title">拍好校园</div>
-      <div class="header-right"></div>
-    </div>
+  <div class="community-page photograph-publish" :style="{ '--module-color': '#06b6d4' }">
+    <CommunityHeader title="拍好校园" moduleColor="#06b6d4" @back="goBack" :backTo="''" :showBack="true" />
 
-    <!-- 上传表单：参考 upload.jsp 结构 -->
-    <section id="upload">
-      <div class="am-form-group">
-        <label>标题/名字<span class="red-text">*</span> </label>
+    <!-- 上传表单 -->
+    <section class="publish-form">
+      <div class="form-group">
+        <label class="form-label">标题/名字<span class="required">*</span></label>
         <input
           type="text"
           maxlength="25"
-          id="title"
-          class="am-form-field am-round"
+          class="form-input"
           placeholder="输入照片标题或你的名字"
           v-model="form.title"
         />
       </div>
-      <div class="am-form-group">
-        <label>照片类型</label>
-        <label>
-          <input type="radio" name="type" value="1" v-model="form.type" />
-          生活照
-        </label>
-        <label>
-          <input type="radio" name="type" value="2" v-model="form.type" />
-          校园照
-        </label>
+      <div class="form-group">
+        <label class="form-label">照片类型</label>
+        <div class="radio-group">
+          <label class="radio-item">
+            <input type="radio" name="type" value="1" v-model="form.type" />
+            <span>生活照</span>
+          </label>
+          <label class="radio-item">
+            <input type="radio" name="type" value="2" v-model="form.type" />
+            <span>校园照</span>
+          </label>
+        </div>
       </div>
 
-      <div style="margin-bottom: 10px">
-        <i class="am-icon-picture-o"></i>选择主图<span class="red-text">*</span>
-      </div>
+      <label class="form-label upload-label">选择主图<span class="required">*</span></label>
       <div class="main-upload-box">
         <input type="file" accept="image/*" class="hidden-file-input" @change="onMainImageChange" />
         <div v-if="!mainImageUrl" class="upload-plus">+</div>
         <img v-else :src="mainImageUrl" class="preview-img" alt="主图预览" />
       </div>
 
-      <br />
-
-      <div style="margin-bottom: 10px">
-        <i class="am-icon-picture-o"></i>选择副图(选填，可多选，最多三张)
-      </div>
+      <label class="form-label upload-label">选择副图（选填，最多三张）</label>
       <div class="sub-upload-list">
         <div v-for="(_, idx) in 3" :key="idx" class="sub-upload-box">
           <input type="file" accept="image/*" class="hidden-file-input" @change="onSubImageChange($event, idx)" />
@@ -156,39 +147,30 @@ const submit = async () => {
         </div>
       </div>
 
-      <br />
+      <button class="btn-clear" type="button" @click="clearImages">清空图片</button>
 
-      <button class="weui-btn weui-btn_default clear-button" type="button" @click="clearImages">
-        <i class="am-icon-trash"></i>清空图片
-      </button>
-
-      <div class="am-form-group" id="say-something">
-        <label>说点什么吧</label>
+      <div class="form-group" style="margin-top: var(--space-lg);">
+        <label class="form-label">说点什么吧</label>
         <textarea
-          class="am-form-field am-radius"
+          class="form-textarea"
           rows="4"
-          id="content"
           placeholder="选填，可以填写感慨/对大学的期待..."
           v-model="form.content"
         ></textarea>
-        <span id="word-count">{{ (form.content || '').length }}/150字</span>
+        <span class="word-count">{{ (form.content || '').length }}/150字</span>
       </div>
 
-      <br />
-
-      <button type="button" class="weui-btn weui-btn_primary submit-button" @click="submit">确认提交</button>
+      <button type="button" class="btn-submit" @click="submit">确认提交</button>
     </section>
 
-    <!-- WEUI 对话框 -->
+    <!-- 对话框 -->
     <div v-if="dialogVisible">
-      <div class="weui-mask" @click="dialogVisible = false"></div>
-      <div class="weui-dialog">
-        <div class="weui-dialog__hd">
-          <strong class="weui-dialog__title">提示</strong>
-        </div>
-        <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-        <div class="weui-dialog__ft">
-          <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+      <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+      <div class="community-dialog">
+        <div class="community-dialog__title">提示</div>
+        <div class="community-dialog__body">{{ dialogMessage }}</div>
+        <div class="community-dialog__footer">
+          <a href="javascript:" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
         </div>
       </div>
     </div>
@@ -205,70 +187,62 @@ const submit = async () => {
 </template>
 
 <style scoped>
-.photograph-publish {
-  min-height: 100vh;
-  background: #f8f8f8;
+.publish-form {
+  padding: var(--space-xl);
 }
 
-/* 统一顶部导航栏 */
-.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
+.form-group {
+  margin-bottom: var(--space-lg);
 }
-.header-left {
-  padding: 0 10px;
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  min-width: 48px;
-  font-size: 24px;
-  font-weight: 300 !important;
-  color: #333;
-}
-.header-left i,
-.header-left svg,
-.header-left img {
-  font-size: 24px !important;
-  width: 24px !important;
-  height: 24px !important;
-  font-weight: 300 !important;
-  transform: scale(1.4);
-  transform-origin: center center;
-}
-.header-left svg {
-  stroke-width: 1 !important;
-}
-.header-title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
+
+.form-label {
+  display: block;
+  font-size: var(--font-md);
   font-weight: 500;
-  color: #333;
-}
-.header-right {
-  width: 48px;
-  text-align: center;
+  color: var(--c-text-1);
+  margin-bottom: var(--space-sm);
 }
 
-#upload {
-  padding: 20px;
+.upload-label {
+  margin-bottom: var(--space-md);
 }
 
-.am-form-group {
-  margin-bottom: 15px;
+.required {
+  color: #ef4444;
+  font-weight: bold;
+  margin-left: 2px;
 }
-.am-form-field {
+
+.form-input {
   width: 100%;
   box-sizing: border-box;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-base);
+  color: var(--c-text-1);
+  background: var(--c-card);
+  transition: border-color 0.2s;
 }
-.red-text {
-  color: red;
-  font-weight: bold;
+.form-input:focus {
+  outline: none;
+  border-color: var(--c-photograph);
+}
+
+.radio-group {
+  display: flex;
+  gap: var(--space-lg);
+}
+.radio-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-base);
+  color: var(--c-text-2);
+  cursor: pointer;
+}
+.radio-item input[type="radio"] {
+  accent-color: var(--c-photograph);
 }
 
 .main-upload-box,
@@ -277,14 +251,15 @@ const submit = async () => {
   overflow: hidden;
 }
 .main-upload-box {
-  border: 2px dashed #4fc3f7;
-  border-radius: 4px;
+  border: 2px dashed var(--c-photograph);
+  border-radius: var(--radius-md);
   height: 160px;
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-lg);
   cursor: pointer;
+  transition: border-color 0.2s;
 }
 .hidden-file-input {
   position: absolute;
@@ -298,7 +273,7 @@ const submit = async () => {
 }
 .upload-plus {
   font-size: 40px;
-  color: #ccc;
+  color: var(--c-text-3);
   z-index: 1;
   pointer-events: none;
 }
@@ -313,18 +288,22 @@ const submit = async () => {
 
 .sub-upload-list {
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 20px;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
 }
 .sub-upload-box {
-  width: 31%;
+  flex: 1;
   aspect-ratio: 1 / 1;
-  border: 2px dashed #aed581;
-  border-radius: 4px;
+  border: 2px dashed var(--c-divider);
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  transition: border-color 0.2s;
+}
+.sub-upload-box:hover {
+  border-color: var(--c-photograph);
 }
 .sub-upload-box .upload-plus {
   font-size: 24px;
@@ -338,101 +317,60 @@ const submit = async () => {
   inset: 0;
 }
 
-.clear-button {
+.btn-clear {
   width: 100%;
-  background-color: #f5f5f5;
-  color: #333;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 10px;
-  font-size: 14px;
+  background-color: var(--c-bg);
+  color: var(--c-text-2);
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--font-base);
   cursor: pointer;
+  transition: background-color 0.2s;
 }
-.clear-button:hover {
-  background-color: #e8e8e8;
-}
-
-#say-something {
-  margin-top: 20px;
-}
-#word-count {
-  float: right;
-  font-size: 14px;
-  color: #777;
+.btn-clear:active {
+  background-color: var(--c-border);
 }
 
-.submit-button {
-  display: block;
-  margin: 0 auto;
+.form-textarea {
   width: 100%;
-  background-color: #27ae60;
+  box-sizing: border-box;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-base);
+  color: var(--c-text-1);
+  background: var(--c-card);
+  resize: vertical;
+  transition: border-color 0.2s;
+}
+.form-textarea:focus {
+  outline: none;
+  border-color: var(--c-photograph);
+}
+
+.word-count {
+  float: right;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
+  margin-top: var(--space-xs);
+}
+
+.btn-submit {
+  display: block;
+  margin: var(--space-xl) auto 0;
+  width: 100%;
+  background-color: var(--c-photograph);
   color: #fff;
   border: none;
-  border-radius: 4px;
-  padding: 12px;
-  font-size: 16px;
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  font-size: var(--font-lg);
   font-weight: 500;
   cursor: pointer;
+  transition: opacity 0.2s;
 }
-.submit-button:hover {
-  background-color: #229954;
-}
-.submit-button:active {
-  background-color: #1e8449;
-}
-
-/* WEUI 对话框样式（简化版） */
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-}
-.weui-dialog__hd {
-  padding: 1.2em 1.6em 0.5em;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-weight: 400;
-  font-size: 18px;
-}
-.weui-dialog__bd {
-  padding: 0 1.6em 0.8em;
-  min-height: 40px;
-  font-size: 15px;
-  line-height: 1.5;
-  color: #999;
-  text-align: center;
-}
-.weui-dialog__ft {
-  position: relative;
-  line-height: 42px;
-  display: flex;
-  border-top: 1px solid #d5d5d6;
-}
-.weui-dialog__btn {
-  flex: 1;
-  text-align: center;
-  text-decoration: none;
-  color: #3cc51f;
-  font-size: 17px;
-}
-.weui-dialog__btn_primary {
-  color: #0bb20c;
+.btn-submit:active {
+  opacity: 0.85;
 }
 </style>
-

--- a/frontend/src/views/secret/Detail.vue
+++ b/frontend/src/views/secret/Detail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -229,22 +230,17 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="secret-detail">
-    <!-- 统一顶部导航栏：与二手交易模块一致 -->
-    <div class="ershou-header unified-header">
-      <span class="ershou-header__back" @click="router.back()">返回</span>
-      <h1 class="ershou-header__title">树洞详情</h1>
-      <span class="ershou-header__placeholder"></span>
-    </div>
+  <div class="community-page secret-detail" style="--module-color: #8b5cf6">
+    <CommunityHeader title="树洞详情" moduleColor="#8b5cf6" backTo="/secret/home" />
 
     <div v-if="loading" class="loading">
-      <i class="weui-loading"></i>
+      <i class="community-loading-spinner"></i>
       <span>加载中...</span>
     </div>
 
     <div v-else-if="secret" class="all">
       <!-- 树洞信息：参考原版 .secret -->
-      <div :id="secret.id" class="secret" :class="`theme${secret.theme || 1}`">
+      <div :id="secret.id" class="secret community-card" :class="`theme${secret.theme || 1}`">
         <section class="section" @click="playAudio">
           <template v-if="secret.type === 0">
             {{ secret.content }}
@@ -291,7 +287,8 @@ onBeforeUnmount(() => {
       <div
         v-for="(comment, index) in comments"
         :key="comment.id"
-        class="discuss"
+        class="discuss community-card"
+        :style="{ animationDelay: index * 0.05 + 's' }"
       >
         <img :src="`/img/avatar/${comment.avatarTheme || 1}.png`" alt="" />
         <div class="info">
@@ -299,6 +296,11 @@ onBeforeUnmount(() => {
           <span>{{ index + 1 }}楼 {{ comment.publishTime }}</span>
         </div>
       </div>
+    </div>
+
+    <div v-else class="community-empty">
+      <div class="community-empty__icon">📭</div>
+      <p class="community-empty__text">树洞不存在或已删除</p>
     </div>
 
     <!-- 底部固定输入框：参考原版 .form -->
@@ -314,16 +316,14 @@ onBeforeUnmount(() => {
     </div>
   </div>
 
-  <!-- WEUI 对话框 -->
+  <!-- 对话框 -->
   <div v-if="dialogVisible">
-    <div class="weui-mask" @click="dialogVisible = false"></div>
-    <div class="weui-dialog">
-      <div class="weui-dialog__hd">
-        <strong class="weui-dialog__title">提示</strong>
-      </div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div class="community-dialog" style="--module-color: #8b5cf6">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
   </div>
@@ -332,47 +332,8 @@ onBeforeUnmount(() => {
 <style scoped>
 .secret-detail {
   min-height: 100vh;
-  background: #ececec;
+  background: var(--c-bg);
   padding-bottom: 3.3rem;
-}
-
-/* 统一顶部导航栏：复用二手交易样式 */
-.ershou-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.ershou-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.ershou-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.ershou-header__placeholder {
-  min-width: 48px;
-  text-align: right;
-}
-
-.weui-cells__title {
-  padding: 10px 15px;
-  font-size: 14px;
-  color: #888;
-  cursor: pointer;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
 }
 
 .loading {
@@ -381,18 +342,7 @@ onBeforeUnmount(() => {
   justify-content: center;
   padding: 60px 20px;
   gap: 10px;
-  color: #999;
-}
-.loading .weui-loading {
-  width: 20px;
-  height: 20px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
+  color: var(--c-text-3);
 }
 
 .all {
@@ -410,7 +360,9 @@ onBeforeUnmount(() => {
   position: relative;
   color: #fff;
   height: 240px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
+  border-left: 4px solid var(--c-secret);
+  box-shadow: var(--shadow-sm);
 }
 
 /* 卡片内容区域强制水平/垂直居中 */
@@ -433,19 +385,19 @@ onBeforeUnmount(() => {
 }
 .secret .section .voice-status {
   margin-top: 12px;
-  font-size: 14px;
+  font-size: var(--font-sm);
   opacity: 0.95;
 }
 .secret .section .voice-time {
   margin-top: 6px;
-  font-size: 13px;
+  font-size: var(--font-xs);
   opacity: 0.8;
 }
 .secret .section .voice-progress {
   width: min(220px, 80%);
   height: 6px;
   margin-top: 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: rgba(255, 255, 255, 0.3);
   overflow: hidden;
   cursor: pointer;
@@ -467,7 +419,7 @@ onBeforeUnmount(() => {
   left: 0;
   width: 100%;
   font-size: 0;
-  border-radius: 0 0 8px 8px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 .secret footer div {
   width: 50%;
@@ -500,7 +452,7 @@ onBeforeUnmount(() => {
 
 /* 主题颜色：参考原版 secret-detail.css */
 .theme1 {
-  background-color: #fff;
+  background-color: var(--c-card);
   color: #000;
 }
 .theme1 > footer {
@@ -554,18 +506,20 @@ onBeforeUnmount(() => {
 /* 评论列表：参考原版 secret-detail.css .discuss */
 .discuss {
   line-height: 1.5rem;
-  margin: 0 10px;
-  background: #fff;
-  padding: 10px;
-  border: #e0e0e0 solid;
-  border-width: 0 1px;
+  margin: var(--space-sm) 10px;
+  background: var(--c-card);
+  padding: var(--space-sm);
+  border-left: 4px solid var(--c-secret);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
   display: flex;
   gap: 10px;
+  animation: community-slide-up 0.3s ease both;
 }
 .discuss img {
   width: 2.5rem;
   height: 2.5rem;
-  border-radius: 1.25rem;
+  border-radius: var(--radius-full);
   vertical-align: top;
   flex-shrink: 0;
 }
@@ -576,17 +530,18 @@ onBeforeUnmount(() => {
 .discuss p {
   font-weight: bolder;
   margin-bottom: 5px;
+  color: var(--c-text-1);
 }
 .discuss span {
-  font-size: 0.8rem;
-  color: #6f6f6f;
+  font-size: var(--font-xs);
+  color: var(--c-text-3);
 }
 
 /* 底部固定输入框：参考原版 secret-detail.css .form */
 .form {
-  border-top: 1px solid #cacacd;
+  border-top: 1px solid var(--c-divider);
   padding: 0.5rem;
-  background: #fff;
+  background: var(--c-card);
   position: fixed;
   bottom: 0;
   left: 0;
@@ -599,10 +554,9 @@ onBeforeUnmount(() => {
 }
 .form input {
   line-height: 2.2rem;
-  border: #bfc7cd 1px solid;
+  border: 1px solid var(--c-divider);
   flex: 1;
-  border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-radius: var(--radius-sm);
   text-indent: 5px;
   font-size: 1rem;
   padding: 0 10px;
@@ -614,69 +568,12 @@ onBeforeUnmount(() => {
 }
 .submit {
   line-height: 2.2rem;
-  border: #bfc7cd 1px solid;
+  border: 1px solid var(--c-divider);
   width: 20%;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   text-align: center;
-  border-left: none;
-  color: #3cb395;
+  color: var(--c-secret);
   cursor: pointer;
   font-size: 1rem;
-}
-
-/* WEUI 对话框样式 */
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-}
-.weui-dialog__hd {
-  padding: 1.2em 1.6em 0.5em;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-weight: 400;
-  font-size: 18px;
-}
-.weui-dialog__bd {
-  padding: 0 1.6em 0.8em;
-  min-height: 40px;
-  font-size: 15px;
-  line-height: 1.5;
-  word-wrap: break-word;
-  word-break: break-all;
-  color: #999;
-  text-align: center;
-}
-.weui-dialog__ft {
-  position: relative;
-  line-height: 42px;
-  display: flex;
-  border-top: 1px solid #d5d5d6;
-}
-.weui-dialog__btn {
-  flex: 1;
-  text-align: center;
-  text-decoration: none;
-  color: #3cc51f;
-  font-size: 17px;
-}
-.weui-dialog__btn_primary {
-  color: #0bb20c;
 }
 </style>

--- a/frontend/src/views/secret/Home.vue
+++ b/frontend/src/views/secret/Home.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const scrollContainer = ref(null)
@@ -54,13 +55,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="secret-home">
-    <!-- 统一顶部导航栏：与二手交易模块一致 -->
-    <div class="ershou-header unified-header">
-      <span class="ershou-header__back" @click="router.push('/')">返回</span>
-      <h1 class="ershou-header__title">校园树洞</h1>
-      <span class="ershou-header__placeholder"></span>
-    </div>
+  <div class="community-page secret-home" style="--module-color: #8b5cf6">
+    <CommunityHeader title="校园树洞" moduleColor="#8b5cf6" backTo="/" />
 
     <!-- 顶部操作区：参考原版 secretIndex.jsp 的 header -->
     <header>
@@ -81,22 +77,23 @@ onMounted(() => {
       @touchend="handleTouchEnd"
     >
       <!-- 下拉刷新指示器 -->
-      <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-        <span v-if="refreshing" class="pull-refresh-text">
-          <i class="weui-loading"></i> 正在刷新...
+      <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+        <span v-if="refreshing" class="community-pull-refresh__text">
+          <i class="community-loading-spinner"></i> 正在刷新...
         </span>
-        <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-        <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+        <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+        <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
       </div>
 
       <!-- 树洞信息列表：参考原版 .secret 结构 -->
       <div id="list" class="secret-list">
         <div
-          v-for="item in list"
+          v-for="(item, index) in list"
           :key="item.id"
           :id="item.id"
-          class="secret"
+          class="secret community-card"
           :class="`theme${item.theme || 1}`"
+          :style="{ animationDelay: index * 0.05 + 's' }"
         >
           <a href="javascript:;" @click.prevent="goDetail(item.id)">
             <section class="section">
@@ -141,17 +138,18 @@ onMounted(() => {
       </div>
 
       <!-- 空状态 -->
-      <div v-if="!loading && !refreshing && list.length === 0" class="secret-empty">
-        <p>暂无树洞信息</p>
+      <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+        <div class="community-empty__icon">📭</div>
+        <p class="community-empty__text">暂无树洞信息</p>
       </div>
 
       <!-- 上拉加载更多 -->
-      <div v-if="loading && !refreshing" class="secret-loadmore">
-        <i class="weui-loading"></i>
-        <span class="weui-loadmore__tips">正在加载</span>
+      <div v-if="loading && !refreshing" class="community-loadmore">
+        <i class="community-loading-spinner"></i>
+        <span>正在加载</span>
       </div>
-      <div v-if="finished && list.length > 0" class="secret-loadmore">
-        <span class="weui-loadmore__tips">没有更多了</span>
+      <div v-if="finished && list.length > 0" class="community-loadmore">
+        <span>没有更多了</span>
       </div>
     </div>
   </div>
@@ -160,37 +158,7 @@ onMounted(() => {
 <style scoped>
 .secret-home {
   min-height: 100vh;
-  background: #ececec;
-}
-
-/* 统一顶部导航栏：复用二手交易样式 */
-.ershou-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.ershou-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.ershou-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.ershou-header__placeholder {
-  min-width: 48px;
-  text-align: right;
+  background: var(--c-bg);
 }
 
 /* 顶部操作区：参考原版 secret-index.css header */
@@ -210,11 +178,11 @@ header i {
   padding: 0 1.5rem;
   display: inline-block;
   line-height: 3rem;
-  border-radius: 1.5rem;
-  border: 1px solid #d3d3d3;
-  color: #2a5997;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--c-divider);
+  color: var(--c-secret);
   text-decoration: none;
-  background-color: #fff;
+  background-color: var(--c-card);
   font-size: 1.1rem;
   font-weight: bolder;
   vertical-align: top;
@@ -247,33 +215,6 @@ header i {
   overscroll-behavior-y: contain;
 }
 
-/* 下拉刷新指示器 */
-.pull-refresh-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transition: height 0.3s;
-}
-.pull-refresh-text {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #999;
-}
-.pull-refresh-text .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
 /* 树洞列表：参考原版 secret-index.css .secret */
 .secret-list {
   padding: 0;
@@ -287,7 +228,9 @@ header i {
   color: #fff;
   height: 240px;
   padding: 0 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
+  border-left: 4px solid var(--c-secret);
+  animation: community-slide-up 0.3s ease both;
 }
 .secret > a {
   display: block;
@@ -321,7 +264,7 @@ header i {
   left: 0;
   width: 100%;
   font-size: 0;
-  border-radius: 0 0 8px 8px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 .secret footer div {
   width: 50%;
@@ -354,7 +297,7 @@ header i {
 
 /* 主题颜色：参考原版 secret-index.css .theme1-.theme12 */
 .theme1 {
-  background-color: #fff;
+  background-color: var(--c-card);
   color: #000;
 }
 .theme1 > footer {
@@ -403,36 +346,5 @@ header i {
 }
 .theme12 {
   background-color: #daa6a1;
-}
-
-/* 空状态 */
-.secret-empty {
-  text-align: center;
-  padding: 60px 20px;
-  color: #999;
-  font-size: 14px;
-}
-
-/* 加载更多 */
-.secret-loadmore {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  color: #999;
-  font-size: 14px;
-  gap: 8px;
-}
-.secret-loadmore .weui-loading {
-  width: 16px;
-  height: 16px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-.weui-loadmore__tips {
-  font-size: 14px;
-  color: #999;
 }
 </style>

--- a/frontend/src/views/secret/Profile.vue
+++ b/frontend/src/views/secret/Profile.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const secretList = ref([])
@@ -29,37 +30,30 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="secret-profile">
-    <!-- 顶部标题行：左侧返回 + 中间标题 -->
-    <div class="custom-secret-header">
-      <div class="header-left" @click="goBack">
-        <i class="weui-icon-back"></i>
-      </div>
-
-      <div class="header-center">
-        <!-- 如需铃铛图标，可启用下行 -->
-        <!-- <img src="/img/secret/msg.png" class="bell-icon" alt="bell" /> -->
-        <span>我的树洞</span>
-      </div>
-
-      <div class="header-right"></div>
-    </div>
+  <div class="community-page secret-profile" style="--module-color: #8b5cf6">
+    <CommunityHeader title="我的树洞" moduleColor="#8b5cf6" backTo="/secret/home" />
 
     <div v-if="loading" class="loading">
-      <i class="weui-loading"></i>
+      <i class="community-loading-spinner"></i>
       <span>加载中...</span>
     </div>
 
     <!-- 发布的树洞消息列表：参考原版 secretProfile.jsp -->
     <div v-else class="msg-list">
-      <div v-for="secret in secretList" :key="secret.id" class="msg">
+      <div
+        v-for="(secret, index) in secretList"
+        :key="secret.id"
+        class="msg community-card"
+        :style="{ animationDelay: index * 0.05 + 's' }"
+      >
         <a href="javascript:;" @click.prevent="router.push(`/secret/detail/${secret.id}`)">
           <p>{{ secret.type === 0 ? secret.content : '语音消息' }}</p>
         </a>
         <i class="toggle"></i>
       </div>
-      <div v-if="secretList.length === 0" class="empty">
-        <p>暂无发布的树洞</p>
+      <div v-if="secretList.length === 0" class="community-empty">
+        <div class="community-empty__icon">📭</div>
+        <p class="community-empty__text">暂无发布的树洞</p>
       </div>
     </div>
   </div>
@@ -68,63 +62,7 @@ onMounted(() => {
 <style scoped>
 .secret-profile {
   min-height: 100vh;
-  background: #ececec;
-}
-
-/* 顶部标题行（三段式 Flex 布局） */
-.custom-secret-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 15px;
-  background-color: #fff;
-  border-bottom: 1px solid #f0f0f0;
-}
-.custom-secret-header .header-left {
-  width: 40px;
-  cursor: pointer;
-  color: #333;
-  display: flex;
-  align-items: center;
-}
-.custom-secret-header .header-center {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 17px;
-  font-weight: bold;
-  color: #3b3f5c;
-}
-.custom-secret-header .header-center i,
-.custom-secret-header .header-center img,
-.custom-secret-header .header-center svg {
-  width: 20px;
-  height: 20px;
-  margin-right: 6px;
-}
-.custom-secret-header .header-right {
-  width: 40px;
-}
-
-.notice {
-  padding: 15px;
-  background: #fff;
-  font-size: 16px;
-  font-weight: bold;
-  border-bottom: 1px solid #e5e5e5;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.inotice {
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  background-image: url(/img/secret/msg.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
+  background: var(--c-bg);
 }
 
 .loading {
@@ -133,41 +71,33 @@ onMounted(() => {
   justify-content: center;
   padding: 60px 20px;
   gap: 10px;
-  color: #999;
-}
-.loading .weui-loading {
-  width: 20px;
-  height: 20px;
-  border: 2px solid #e5e5e5;
-  border-top-color: #3cb395;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
+  color: var(--c-text-3);
 }
 
 .msg-list {
-  padding: 10px;
+  padding: var(--space-sm);
 }
 .msg {
-  background: #fff;
-  margin-bottom: 10px;
-  padding: 15px;
-  border-radius: 8px;
+  background: var(--c-card);
+  margin-bottom: var(--space-sm);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  border-left: 4px solid var(--c-secret);
+  box-shadow: var(--shadow-sm);
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-height: 80px;
+  animation: community-slide-up 0.3s ease both;
 }
 .msg a {
   flex: 1;
   text-decoration: none;
-  color: #333;
+  color: var(--c-text-1);
 }
 .msg p {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--font-base);
   line-height: 1.5;
   display: flex;
   align-items: center;
@@ -178,16 +108,9 @@ onMounted(() => {
   width: 10px;
   height: 10px;
   margin-left: 12px;
-  border-top: 2px solid #b8bcc6;
-  border-right: 2px solid #b8bcc6;
+  border-top: 2px solid var(--c-text-3);
+  border-right: 2px solid var(--c-text-3);
   transform: rotate(45deg);
   opacity: 0.8;
-}
-
-.empty {
-  text-align: center;
-  padding: 60px 20px;
-  color: #999;
-  font-size: 14px;
 }
 </style>

--- a/frontend/src/views/secret/Publish.vue
+++ b/frontend/src/views/secret/Publish.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { uploadFileByPresignedUrl } from '../../utils/presignedUpload'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 
@@ -372,16 +373,11 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="secret-publish">
-    <!-- 统一顶部导航栏：与二手交易模块一致 -->
-    <div class="ershou-header unified-header">
-      <span class="ershou-header__back" @click="router.back()">返回</span>
-      <h1 class="ershou-header__title">发布小秘密</h1>
-      <span class="ershou-header__placeholder"></span>
-    </div>
+  <div class="community-page secret-publish" style="--module-color: #8b5cf6">
+    <CommunityHeader title="发布小秘密" moduleColor="#8b5cf6" backTo="/secret/home" />
 
     <!-- 树洞发布框：参考原版 secretPublish.jsp -->
-    <div class="form" :class="`theme${formData.theme}`" :style="{ color: formData.theme === 1 ? '#000' : '#fff' }">
+    <div class="form community-card" :class="`theme${formData.theme}`" :style="{ color: formData.theme === 1 ? '#000' : '#fff' }">
       <form>
         <header>
           <i class="back" @click="router.back()"></i>
@@ -457,7 +453,7 @@ onBeforeUnmount(() => {
             id="voice_volume"
             style="position:relative;height:25px;margin-top:5px;right:10px;width:85px;background:#cdcdcd;float: right"
           >
-            <div id="volume" :style="{ width: voiceVolume + '%', height: '100%', background: '#3cb395' }"></div>
+            <div id="volume" :style="{ width: voiceVolume + '%', height: '100%', background: 'var(--c-secret)' }"></div>
           </div>
         </div>
         <div style="float:right;margin-top:15px">
@@ -520,16 +516,14 @@ onBeforeUnmount(() => {
     </div>
   </div>
 
-  <!-- WEUI 对话框 -->
+  <!-- 对话框 -->
   <div v-if="dialogVisible">
-    <div class="weui-mask" @click="dialogVisible = false"></div>
-    <div class="weui-dialog">
-      <div class="weui-dialog__hd">
-        <strong class="weui-dialog__title">提示</strong>
-      </div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div class="community-dialog" style="--module-color: #8b5cf6">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
   </div>
@@ -538,47 +532,17 @@ onBeforeUnmount(() => {
 <style scoped>
 .secret-publish {
   min-height: 100vh;
-  background: #f5f5f5;
+  background: var(--c-bg);
   position: relative;
-}
-
-/* 统一顶部导航栏：复用二手交易样式 */
-.ershou-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #eee;
-}
-.ershou-header__back {
-  font-size: 14px;
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  text-align: left;
-}
-.ershou-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-.ershou-header__placeholder {
-  min-width: 48px;
-  text-align: right;
 }
 
 /* 表单容器：参考原版 secret-publish.css .form */
 .form {
   position: relative;
-  background-color: #fff;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   margin: 10px;
   padding-bottom: 20px;
+  border-left: 4px solid var(--c-secret);
 }
 
 header {
@@ -616,7 +580,7 @@ header span {
   right: 1rem;
   top: 0;
   cursor: pointer;
-  color: #3cb395;
+  color: var(--c-secret);
 }
 
 .edit {
@@ -642,7 +606,7 @@ header span {
   width: 100%;
   margin: 0 auto;
   border: none;
-  font-size: 18px;
+  font-size: var(--font-xl);
   overflow-x: hidden;
   line-height: 24px;
   background-color: inherit;
@@ -660,16 +624,16 @@ textarea::-webkit-input-placeholder {
   position: absolute;
   bottom: 0.6rem;
   right: 1rem;
-  font-size: 14px;
-  color: #999;
+  font-size: var(--font-base);
+  color: var(--c-text-3);
 }
 
 .bar {
-  border: solid #d5d5d5;
+  border: solid var(--c-divider);
   border-width: 1px 0;
   padding: 10px;
   overflow: hidden;
-  background: #fff;
+  background: var(--c-card);
 }
 .bar i {
   width: 23px;
@@ -690,7 +654,7 @@ textarea::-webkit-input-placeholder {
   position: relative;
   z-index: 10 !important;
   pointer-events: auto !important;
-  background-color: #f5f5f5;
+  background-color: var(--c-bg);
 }
 
 .themes {
@@ -703,7 +667,7 @@ textarea::-webkit-input-placeholder {
   flex: 1;
   height: 2.7rem;
   position: relative;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 .selected {
@@ -716,8 +680,8 @@ textarea::-webkit-input-placeholder {
   right: -0.5rem;
   top: -0.5rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, #34d399 0%, #059669 100%);
-  box-shadow: 0 0.2rem 0.5rem rgba(5, 150, 105, 0.28);
+  background: linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%);
+  box-shadow: 0 0.2rem 0.5rem rgba(139, 92, 246, 0.28);
 }
 .selected::before {
   content: '';
@@ -730,7 +694,7 @@ textarea::-webkit-input-placeholder {
 
 /* 主题颜色：参考原版 secret-publish.css */
 .theme1 {
-  background-color: #fff;
+  background-color: var(--c-card);
   color: #000;
 }
 .theme2 {
@@ -769,68 +733,12 @@ textarea::-webkit-input-placeholder {
 
 .switch-text {
   margin-top: 1rem;
-  color: grey;
+  color: var(--c-text-3);
   text-align: center;
 }
 .switch-link {
   display: inline;
-  color: deepskyblue;
+  color: var(--c-secret);
   cursor: pointer;
-}
-
-/* WEUI 对话框样式 */
-.weui-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-}
-.weui-dialog__hd {
-  padding: 1.2em 1.6em 0.5em;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-weight: 400;
-  font-size: 18px;
-}
-.weui-dialog__bd {
-  padding: 0 1.6em 0.8em;
-  min-height: 40px;
-  font-size: 15px;
-  line-height: 1.5;
-  word-wrap: break-word;
-  word-break: break-all;
-  color: #999;
-  text-align: center;
-}
-.weui-dialog__ft {
-  position: relative;
-  line-height: 42px;
-  display: flex;
-  border-top: 1px solid #d5d5d6;
-}
-.weui-dialog__btn {
-  flex: 1;
-  text-align: center;
-  text-decoration: none;
-  color: #3cc51f;
-  font-size: 17px;
-}
-.weui-dialog__btn_primary {
-  color: #0bb20c;
 }
 </style>

--- a/frontend/src/views/topic/Detail.vue
+++ b/frontend/src/views/topic/Detail.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import request from '../../utils/request'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -51,14 +52,10 @@ onMounted(async () => {
 
 <template>
   <div class="topic-detail">
-    <div class="topic-header unified-header">
-      <span class="topic-header__back" @click="router.back()">返回</span>
-      <h1 class="topic-header__title">话题详情</h1>
-      <span class="topic-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="话题详情" moduleColor="#6366f1" @back="router.back()" backTo="" />
 
-    <div v-if="loading" class="topic-loading">
-      <i class="weui-loading"></i>
+    <div v-if="loading" class="community-loadmore">
+      <i class="community-loading-spinner"></i>
       <span>加载中...</span>
     </div>
 
@@ -86,66 +83,27 @@ onMounted(async () => {
       </div>
     </div>
 
-    <div v-else class="topic-empty">话题不存在或已被删除</div>
+    <div v-else class="community-empty">
+      <div class="community-empty__text">话题不存在或已被删除</div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .topic-detail {
   min-height: 100vh;
-  background: #f5f5f5;
-}
-
-.topic-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.topic-header__back {
-  color: #333;
-  cursor: pointer;
-  min-width: 48px;
-  font-size: 14px;
-}
-
-.topic-header__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
-
-.topic-header__placeholder {
-  min-width: 48px;
-}
-
-.topic-loading,
-.topic-empty {
-  padding: 40px 16px;
-  color: #999;
-  font-size: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
+  background: var(--c-bg);
 }
 
 .topic-detail__content {
-  padding: 16px;
+  padding: var(--space-lg);
 }
 
 .topic-card {
-  background: #fff;
-  border-radius: 14px;
-  padding: 16px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+  background: var(--c-card);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-sm);
 }
 
 .topic-card__meta {
@@ -156,27 +114,27 @@ onMounted(async () => {
 }
 
 .topic-card__tag {
-  color: #10b981;
-  font-size: 16px;
+  color: var(--c-topic);
+  font-size: var(--font-lg);
   font-weight: 600;
 }
 
 .topic-card__time {
-  color: #999;
-  font-size: 12px;
+  color: var(--c-text-3);
+  font-size: var(--font-sm);
   flex-shrink: 0;
 }
 
 .topic-card__text {
-  margin-top: 16px;
-  font-size: 15px;
+  margin-top: var(--space-lg);
+  font-size: var(--font-md);
   line-height: 1.7;
-  color: #333;
+  color: var(--c-text-1);
   white-space: pre-wrap;
 }
 
 .topic-card__images {
-  margin-top: 16px;
+  margin-top: var(--space-lg);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
@@ -184,29 +142,31 @@ onMounted(async () => {
 
 .topic-card__image {
   width: 100%;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   object-fit: cover;
-  background: #f3f4f6;
+  background: var(--c-bg);
 }
 
 .topic-card__footer {
-  margin-top: 16px;
+  margin-top: var(--space-lg);
   display: flex;
   justify-content: flex-end;
 }
 
 .topic-like-btn {
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   padding: 8px 14px;
-  font-size: 13px;
-  color: #10b981;
-  background: #ecfdf5;
+  font-size: var(--font-base);
+  color: var(--c-topic);
+  background: #eeeff8;
+  background: color-mix(in srgb, var(--c-topic) 10%, white);
+  cursor: pointer;
+  transition: all 0.2s;
 }
 
 .topic-like-btn.is-liked {
-  color: #999;
-  background: #f3f4f6;
+  color: var(--c-text-3);
+  background: var(--c-bg);
 }
-
 </style>

--- a/frontend/src/views/topic/Home.vue
+++ b/frontend/src/views/topic/Home.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { useScrollLoad } from '../../composables/useScrollLoad'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const scrollContainer = ref({ get scrollTop() { return window.pageYOffset || document.documentElement.scrollTop } })
@@ -80,23 +81,20 @@ onUnmounted(() => {
     @touchmove="handleTouchMove($event, scrollContainer)"
     @touchend="handleTouchEnd"
   >
-    <div class="topic-header unified-header">
-      <span class="topic-header__back" @click="router.push('/')">返回</span>
-      <h1 class="topic-header__title">话题</h1>
-      <span class="topic-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="话题" moduleColor="#6366f1" />
 
-    <div class="pull-refresh-indicator" :style="{ height: pullY + 'px' }">
-      <span v-if="refreshing" class="pull-refresh-text"><i class="weui-loading"></i> 正在刷新...</span>
-      <span v-else-if="pullY > 50" class="pull-refresh-text">释放立即刷新</span>
-      <span v-else-if="pullY > 0" class="pull-refresh-text">下拉刷新</span>
+    <div class="community-pull-refresh" :style="{ height: pullY + 'px' }">
+      <span v-if="refreshing" class="community-pull-refresh__text"><i class="community-loading-spinner"></i> 正在刷新...</span>
+      <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
+      <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
     </div>
 
     <div class="topic-list">
       <div
-        v-for="item in list"
+        v-for="(item, index) in list"
         :key="item.id"
         class="topic-card"
+        :style="{ animationDelay: (index * 0.05) + 's' }"
       >
         <!-- 卡片头部 -->
         <div class="topic-card__header">
@@ -140,44 +138,25 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <div v-if="!loading && !refreshing && list.length === 0" class="topic-empty">暂无话题</div>
-    <div v-if="loading && !refreshing" class="topic-loadmore"><i class="weui-loading"></i> 正在加载</div>
-    <div v-if="finished && list.length > 0" class="topic-loadmore">没有更多了</div>
+    <div v-if="!loading && !refreshing && list.length === 0" class="community-empty">
+      <div class="community-empty__text">暂无话题</div>
+    </div>
+    <div v-if="loading && !refreshing" class="community-loadmore"><i class="community-loading-spinner"></i> 正在加载</div>
+    <div v-if="finished && list.length > 0" class="community-loadmore">没有更多了</div>
 
     <!-- 图片预览 Lightbox -->
-    <div v-if="previewVisible" class="topic-lightbox" @click="closeImagePreview">
-      <img :src="previewImage" class="topic-lightbox__img" />
+    <div v-if="previewVisible" class="community-lightbox" @click="closeImagePreview">
+      <img :src="previewImage" />
     </div>
   </div>
 </template>
 
 <style scoped>
 .topic-home {
-  background: #f5f5f5;
+  background: var(--c-bg);
   min-height: 100vh;
   padding-bottom: 60px;
 }
-
-.topic-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-.topic-header__back { color: #333; cursor: pointer; min-width: 48px; font-size: 14px; }
-.topic-header__title { flex: 1; text-align: center; font-size: 16px; font-weight: 500; margin: 0; color: #333; }
-.topic-header__placeholder { min-width: 48px; }
-
-.pull-refresh-indicator { display: flex; align-items: center; justify-content: center; overflow: hidden; transition: height 0.3s; }
-.pull-refresh-text { font-size: 14px; color: #999; }
-.pull-refresh-text .weui-loading {
-  width: 16px; height: 16px; border: 2px solid #e5e5e5; border-top-color: #10b981; border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-@keyframes spin { to { transform: rotate(360deg); } }
 
 .topic-list {
   padding: 15px;
@@ -187,10 +166,11 @@ onUnmounted(() => {
 }
 
 .topic-card {
-  background: #fff;
-  border-radius: 12px;
+  background: var(--c-card);
+  border-radius: var(--radius-md);
   padding: 15px;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.03);
+  box-shadow: var(--shadow-sm);
+  animation: community-slide-up 0.3s ease both;
 }
 
 .topic-card__header {
@@ -209,30 +189,30 @@ onUnmounted(() => {
   flex: 1;
 }
 .topic-card__name {
-  font-size: 15px;
+  font-size: var(--font-md);
   font-weight: 600;
-  color: #333;
+  color: var(--c-text-1);
   margin-bottom: 4px;
 }
 .topic-card__time {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
 }
 
 .topic-card__content {
   margin-bottom: 12px;
   line-height: 1.6;
-  font-size: 15px;
-  color: #333;
+  font-size: var(--font-md);
+  color: var(--c-text-1);
 }
 .topic-card__tag {
-  color: #10b981;
-  font-size: 16px;
+  color: var(--c-topic);
+  font-size: var(--font-lg);
   font-weight: 500;
   margin-right: 6px;
 }
 .topic-card__text {
-  color: #333;
+  color: var(--c-text-1);
 }
 
 .topic-card__images {
@@ -281,7 +261,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: flex-end;
   padding-top: 8px;
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--c-border);
 }
 .topic-like-btn {
   display: flex;
@@ -289,55 +269,22 @@ onUnmounted(() => {
   gap: 4px;
   background: none;
   border: none;
-  font-size: 14px;
-  color: #666;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   cursor: pointer;
   padding: 4px 8px;
   border-radius: 4px;
   transition: all 0.2s;
 }
 .topic-like-btn__icon {
-  font-size: 18px;
+  font-size: var(--font-xl);
   transition: transform 0.2s;
 }
 .topic-like-btn.is-liked {
-  color: #10b981;
+  color: var(--c-topic);
 }
 .topic-like-btn.is-liked .topic-like-btn__icon {
   transform: scale(1.2);
-  animation: like-bounce 0.3s ease;
-}
-@keyframes like-bounce {
-  0%, 100% { transform: scale(1.2); }
-  50% { transform: scale(1.4); }
-}
-
-.topic-empty,
-.topic-loadmore {
-  text-align: center;
-  padding: 40px 20px;
-  color: #999;
-  font-size: 14px;
-}
-.topic-loadmore .weui-loading {
-  width: 16px; height: 16px; border: 2px solid #e5e5e5; border-top-color: #10b981; border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  display: inline-block; vertical-align: middle; margin-right: 6px;
-}
-
-.topic-lightbox {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.9);
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-}
-.topic-lightbox__img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
+  animation: community-like-bounce 0.3s ease;
 }
 </style>

--- a/frontend/src/views/topic/Index.vue
+++ b/frontend/src/views/topic/Index.vue
@@ -1,134 +1,27 @@
 <script setup>
-import { computed } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-
-const router = useRouter()
-const route = useRoute()
-
-const activeTab = computed(() => {
-  const p = route.path
-  if (p.includes('/topic/publish')) return 'publish'
-  if (p.includes('/topic/search')) return 'search'
-  return 'home'
-})
-
-function goTo(path) {
-  router.push(path)
-}
+import CommunityTabbar from '../../components/community/CommunityTabbar.vue'
 </script>
 
 <template>
-  <div class="topic-page">
+  <div class="community-page" style="--module-color: #6366f1">
     <div class="topic-container">
       <router-view />
     </div>
-    <!-- 专属底部 Tabbar：亮绿色主题 -->
-    <div class="topic-tabbar">
-      <a
-        href="javascript:;"
-        class="topic-tabbar__item"
-        :class="{ active: activeTab === 'home' }"
-        @click.prevent="goTo('/topic/home')"
-      >
-        <i class="topic-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
-          </svg>
-        </i>
-        <p class="topic-tabbar__label">首页</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="topic-tabbar__item"
-        :class="{ active: activeTab === 'publish' }"
-        @click.prevent="goTo('/topic/publish')"
-      >
-        <i class="topic-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-          </svg>
-        </i>
-        <p class="topic-tabbar__label">发布</p>
-      </a>
-      <a
-        href="javascript:;"
-        class="topic-tabbar__item"
-        :class="{ active: activeTab === 'search' }"
-        @click.prevent="goTo('/topic/search')"
-      >
-        <i class="topic-tabbar__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="22" height="22">
-            <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-          </svg>
-        </i>
-        <p class="topic-tabbar__label">搜索</p>
-      </a>
-    </div>
+    <CommunityTabbar
+      basePath="/topic"
+      moduleColor="#6366f1"
+      :tabs="[
+        { key: 'home', label: '首页', path: '/topic/home', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z&quot;/></svg>' },
+        { key: 'publish', label: '发布', path: '/topic/publish', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z&quot;/></svg>' },
+        { key: 'search', label: '搜索', path: '/topic/search', icon: '<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;currentColor&quot;><path d=&quot;M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z&quot;/></svg>' }
+      ]"
+    />
   </div>
 </template>
 
 <style scoped>
-.topic-page {
-  min-height: 100vh;
-  background-color: #f5f5f5;
-}
 .topic-container {
-  padding-bottom: 60px;
+  padding-bottom: 56px;
   box-sizing: border-box;
-}
-
-.topic-tabbar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 60px;
-  background: #fff;
-  border-top: 1px solid #e5e5e5;
-  display: flex;
-  z-index: 500;
-  box-shadow: 0 -2px 8px rgba(0,0,0,0.04);
-}
-
-.topic-tabbar__item {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: #999;
-  text-decoration: none;
-  font-size: 12px;
-  padding: 6px 0;
-  transition: all 0.3s ease;
-}
-
-.topic-tabbar__item.active {
-  color: #10b981;
-  font-weight: 500;
-}
-
-.topic-tabbar__item.active .topic-tabbar__icon {
-  color: #10b981;
-  transform: scale(1.1);
-}
-
-.topic-tabbar__icon {
-  display: block;
-  margin-bottom: 4px;
-  color: #999;
-  transition: all 0.3s ease;
-}
-
-.topic-tabbar__item.active .topic-tabbar__icon svg {
-  fill: #10b981;
-}
-
-.topic-tabbar__label {
-  margin: 0;
-  font-size: 12px;
-  line-height: 1;
-  color: inherit;
 }
 </style>

--- a/frontend/src/views/topic/Publish.vue
+++ b/frontend/src/views/topic/Publish.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { uploadFilesByPresignedUrl } from '../../utils/presignedUpload'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const topicTag = ref('')
@@ -66,7 +67,7 @@ async function submit() {
     showDialog('内容不能超过250字')
     return
   }
-  
+
   submitting.value = true
   const topic = topicTag.value.trim()
   const contentVal = content.value.trim()
@@ -93,13 +94,13 @@ async function submit() {
 
 <template>
   <div class="topic-publish">
-    <div class="topic-publish__header">
-      <span class="topic-publish__cancel" @click="router.back()">取消</span>
-      <h1 class="topic-publish__title">发布话题</h1>
-      <button type="button" class="topic-publish__submit" :disabled="submitting" @click="submit">
-        {{ submitting ? '提交中...' : '提交' }}
-      </button>
-    </div>
+    <CommunityHeader title="发布话题" moduleColor="#6366f1" @back="router.back()" backTo="">
+      <template #right>
+        <button type="button" class="topic-publish__submit" :disabled="submitting" @click="submit">
+          {{ submitting ? '提交中...' : '提交' }}
+        </button>
+      </template>
+    </CommunityHeader>
 
     <div class="topic-publish__content">
       <!-- 话题输入区 -->
@@ -157,12 +158,12 @@ async function submit() {
     </div>
 
     <!-- 提示对话框 -->
-    <div v-if="dialogVisible" class="weui-mask" @click="dialogVisible = false"></div>
-    <div v-if="dialogVisible" class="weui-dialog">
-      <div class="weui-dialog__hd"><strong class="weui-dialog__title">提示</strong></div>
-      <div class="weui-dialog__bd">{{ dialogMessage }}</div>
-      <div class="weui-dialog__ft">
-        <a href="javascript:;" class="weui-dialog__btn weui-dialog__btn_primary" @click="dialogVisible = false">确定</a>
+    <div v-if="dialogVisible" class="community-dialog-mask" @click="dialogVisible = false"></div>
+    <div v-if="dialogVisible" class="community-dialog">
+      <div class="community-dialog__title">提示</div>
+      <div class="community-dialog__body">{{ dialogMessage }}</div>
+      <div class="community-dialog__footer">
+        <a href="javascript:;" class="community-dialog__btn community-dialog__btn--confirm" @click="dialogVisible = false">确定</a>
       </div>
     </div>
   </div>
@@ -170,40 +171,18 @@ async function submit() {
 
 <style scoped>
 .topic-publish {
-  background: #f5f5f5;
+  background: var(--c-bg);
   min-height: 100vh;
   padding-bottom: 60px;
 }
 
-.topic-publish__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 15px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-.topic-publish__cancel {
-  color: #666;
-  font-size: 14px;
-  cursor: pointer;
-}
-.topic-publish__title {
-  flex: 1;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  margin: 0;
-  color: #333;
-}
 .topic-publish__submit {
   padding: 6px 20px;
-  background: #10b981;
+  background: var(--c-topic);
   color: #fff;
   border: none;
-  border-radius: 20px;
-  font-size: 14px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-base);
   cursor: pointer;
   transition: opacity 0.3s;
 }
@@ -219,14 +198,14 @@ async function submit() {
 .topic-input-wrap {
   display: flex;
   align-items: center;
-  background: #fff;
-  border-radius: 8px;
+  background: var(--c-card);
+  border-radius: var(--radius-sm);
   padding: 12px 15px;
   margin-bottom: 15px;
 }
 .topic-input__prefix {
-  font-size: 18px;
-  color: #10b981;
+  font-size: var(--font-xl);
+  color: var(--c-topic);
   font-weight: 600;
   margin-right: 8px;
 }
@@ -234,15 +213,15 @@ async function submit() {
   flex: 1;
   border: none;
   outline: none;
-  font-size: 15px;
-  color: #333;
+  font-size: var(--font-md);
+  color: var(--c-text-1);
   background: transparent;
 }
 
 .content-input-wrap {
   position: relative;
-  background: #fff;
-  border-radius: 8px;
+  background: var(--c-card);
+  border-radius: var(--radius-sm);
   padding: 15px;
   margin-bottom: 15px;
 }
@@ -250,8 +229,8 @@ async function submit() {
   width: 100%;
   border: none;
   outline: none;
-  font-size: 16px;
-  color: #333;
+  font-size: var(--font-lg);
+  color: var(--c-text-1);
   line-height: 1.6;
   resize: none;
   background: transparent;
@@ -261,16 +240,16 @@ async function submit() {
   position: absolute;
   bottom: 10px;
   right: 15px;
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
 }
 .content-counter.is-over {
   color: #e53935;
 }
 
 .image-upload-wrap {
-  background: #fff;
-  border-radius: 8px;
+  background: var(--c-card);
+  border-radius: var(--radius-sm);
   padding: 15px;
 }
 .image-grid {
@@ -281,7 +260,7 @@ async function submit() {
 .image-item {
   position: relative;
   aspect-ratio: 1;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
   background: #f0f0f0;
 }
@@ -309,14 +288,14 @@ async function submit() {
 }
 .image-upload-btn {
   aspect-ratio: 1;
-  border: 2px dashed #ddd;
-  border-radius: 8px;
+  border: 2px dashed var(--c-divider);
+  border-radius: var(--radius-sm);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  background: #fafafa;
+  background: var(--c-bg);
   position: relative;
 }
 .image-upload-btn input {
@@ -327,56 +306,11 @@ async function submit() {
 }
 .upload-icon {
   font-size: 32px;
-  color: #999;
+  color: var(--c-text-3);
   margin-bottom: 4px;
 }
 .upload-text {
-  font-size: 12px;
-  color: #999;
-}
-
-.weui-mask {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.6);
-  z-index: 1000;
-}
-.weui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 85%;
-  max-width: 300px;
-  background: #fff;
-  border-radius: 8px;
-  z-index: 1001;
-  overflow: hidden;
-}
-.weui-dialog__hd {
-  padding: 16px;
-  text-align: center;
-}
-.weui-dialog__title {
-  font-size: 17px;
-  color: #333;
-}
-.weui-dialog__bd {
-  padding: 10px 20px;
-  text-align: center;
-  font-size: 15px;
-  color: #666;
-}
-.weui-dialog__ft {
-  display: flex;
-  border-top: 1px solid #eee;
-}
-.weui-dialog__btn {
-  flex: 1;
-  padding: 14px;
-  text-align: center;
-  color: #10b981;
-  text-decoration: none;
-  font-weight: 500;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
 }
 </style>

--- a/frontend/src/views/topic/Search.vue
+++ b/frontend/src/views/topic/Search.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
 import { showErrorTopTips } from '@/utils/toast.js'
+import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
 const keyword = ref('')
@@ -49,11 +50,7 @@ function doSearch() {
 
 <template>
   <div class="topic-search">
-    <div class="topic-header unified-header">
-      <span class="topic-header__back" @click="router.back()">返回</span>
-      <h1 class="topic-header__title">搜索话题</h1>
-      <span class="topic-header__placeholder"></span>
-    </div>
+    <CommunityHeader title="搜索话题" moduleColor="#6366f1" @back="router.back()" backTo="" showBack />
 
     <div class="topic-search__bar">
       <input
@@ -66,13 +63,16 @@ function doSearch() {
       <button type="button" class="topic-search__btn" @click="doSearch">搜索</button>
     </div>
 
-    <div v-if="searching" class="topic-search__loading">搜索中...</div>
-    <div v-else-if="searchResults.length === 0 && keyword" class="topic-search__empty">暂无结果</div>
+    <div v-if="searching" class="community-loadmore"><i class="community-loading-spinner"></i> 搜索中...</div>
+    <div v-else-if="searchResults.length === 0 && keyword" class="community-empty">
+      <div class="community-empty__text">暂无结果</div>
+    </div>
     <div v-else class="topic-list">
       <div
-        v-for="item in searchResults"
+        v-for="(item, index) in searchResults"
         :key="item.id"
         class="topic-card"
+        :style="{ animationDelay: (index * 0.05) + 's' }"
       >
         <div class="topic-card__header">
           <img :src="item.userAvatar || '/img/avatar/default.png'" class="topic-card__avatar" />
@@ -107,60 +107,39 @@ function doSearch() {
 
 <style scoped>
 .topic-search {
-  background: #f5f5f5;
+  background: var(--c-bg);
   min-height: 100vh;
   padding-bottom: 60px;
 }
-
-.topic-header.unified-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 44px;
-  padding: 0 12px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-}
-.topic-header__back { color: #333; cursor: pointer; min-width: 48px; font-size: 14px; }
-.topic-header__title { flex: 1; text-align: center; font-size: 16px; font-weight: 500; margin: 0; color: #333; }
-.topic-header__placeholder { min-width: 48px; }
 
 .topic-search__bar {
   display: flex;
   gap: 10px;
   padding: 15px;
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
+  background: var(--c-card);
+  border-bottom: 1px solid var(--c-border);
 }
 .topic-search__input {
   flex: 1;
   height: 36px;
   padding: 0 12px;
-  border: 1px solid #e5e5e5;
-  border-radius: 18px;
-  font-size: 14px;
+  border: 1px solid var(--c-divider);
+  border-radius: var(--radius-full);
+  font-size: var(--font-base);
   outline: none;
 }
 .topic-search__input:focus {
-  border-color: #10b981;
+  border-color: var(--c-topic);
 }
 .topic-search__btn {
   padding: 0 20px;
   height: 36px;
-  background: #10b981;
+  background: var(--c-topic);
   color: #fff;
   border: none;
-  border-radius: 18px;
-  font-size: 14px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-base);
   cursor: pointer;
-}
-
-.topic-search__loading,
-.topic-search__empty {
-  text-align: center;
-  padding: 40px 20px;
-  color: #999;
-  font-size: 14px;
 }
 
 .topic-list {
@@ -171,10 +150,11 @@ function doSearch() {
 }
 
 .topic-card {
-  background: #fff;
-  border-radius: 12px;
+  background: var(--c-card);
+  border-radius: var(--radius-md);
   padding: 15px;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.03);
+  box-shadow: var(--shadow-sm);
+  animation: community-slide-up 0.3s ease both;
 }
 
 .topic-card__header {
@@ -193,30 +173,30 @@ function doSearch() {
   flex: 1;
 }
 .topic-card__name {
-  font-size: 15px;
+  font-size: var(--font-md);
   font-weight: 600;
-  color: #333;
+  color: var(--c-text-1);
   margin-bottom: 4px;
 }
 .topic-card__time {
-  font-size: 12px;
-  color: #999;
+  font-size: var(--font-sm);
+  color: var(--c-text-3);
 }
 
 .topic-card__content {
   margin-bottom: 12px;
   line-height: 1.6;
-  font-size: 15px;
-  color: #333;
+  font-size: var(--font-md);
+  color: var(--c-text-1);
 }
 .topic-card__tag {
-  color: #10b981;
-  font-size: 16px;
+  color: var(--c-topic);
+  font-size: var(--font-lg);
   font-weight: 500;
   margin-right: 6px;
 }
 .topic-card__text {
-  color: #333;
+  color: var(--c-text-1);
 }
 
 .topic-card__images {
@@ -249,7 +229,7 @@ function doSearch() {
   display: flex;
   justify-content: flex-end;
   padding-top: 8px;
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--c-border);
 }
 .topic-like-btn {
   display: flex;
@@ -257,26 +237,22 @@ function doSearch() {
   gap: 4px;
   background: none;
   border: none;
-  font-size: 14px;
-  color: #666;
+  font-size: var(--font-base);
+  color: var(--c-text-2);
   cursor: pointer;
   padding: 4px 8px;
   border-radius: 4px;
   transition: all 0.2s;
 }
 .topic-like-btn__icon {
-  font-size: 18px;
+  font-size: var(--font-xl);
   transition: transform 0.2s;
 }
 .topic-like-btn.is-liked {
-  color: #10b981;
+  color: var(--c-topic);
 }
 .topic-like-btn.is-liked .topic-like-btn__icon {
   transform: scale(1.2);
-  animation: like-bounce 0.3s ease;
-}
-@keyframes like-bounce {
-  0%, 100% { transform: scale(1.2); }
-  50% { transform: scale(1.4); }
+  animation: community-like-bounce 0.3s ease;
 }
 </style>


### PR DESCRIPTION
## Summary

- Introduced shared community design system: `community-theme.css` (design tokens), `CommunityTabbar.vue`, `CommunityHeader.vue`
- Refactored all 8 community modules (ershou, lostandfound, secret, express, topic, delivery, dating, photograph) to use unified styling
- Each module retains a unique accent color (green/blue/purple/rose/indigo/amber/pink/cyan) while sharing consistent card, layout, animation, and interaction patterns
- Added page transition animations scoped to community routes only, card entrance animations, skeleton loading utilities
- Academic/main system WeUI pages are completely untouched
- Net reduction of ~2120 lines of CSS

## Changes

| Area | Detail |
|------|--------|
| New files | `community-theme.css`, `CommunityTabbar.vue`, `CommunityHeader.vue` |
| Modified | 40 Vue files across 8 community modules + `App.vue` + `main.js` |
| Bug fixes | Fixed `CommunityHeader` double-navigation, removed broken `handleLike` in dating/Home |
| Compat | Added `color-mix()` CSS fallbacks for older browsers |

## Codex review fixes (0a52d99a)

Addressed all outstanding Codex review feedback from PR #66–#69:

- **Feature toggle migration**: Added localStorage migration logic for renamed feature IDs (`book`/`cardInfo` → `collection`/`card`) to prevent users losing home screen entries after upgrade
- **Old route redirects**: Added compatibility redirects for `/collection/*` → `/library/*` and `/book` → `/library/borrow` so existing bookmarks and history entries still work
- **Delivery detail back navigation**: Fixed `CommunityHeader` in delivery/Detail.vue to use `router.back()` instead of defaulting to home page
- **Ershou detail error messages**: Now displays backend-specific error messages for sold/taken-down items (e.g. "已下架的二手交易信息不能查看")
- **Restored feature entries**: Added `pe` (体测查询) and `about` (关于应用) back to `ALL_FEATURES`

## Test plan

- [ ] Verify each community module loads correctly (home, detail, publish, profile pages)
- [ ] Verify tabbar navigation works in modules with Index wrapper (ershou, lostandfound, topic, express, delivery)
- [ ] Verify back button navigation in all detail/publish pages
- [ ] Verify academic pages (grade, schedule, CET, etc.) are visually unchanged
- [ ] Verify main layout tabbar (home, info, profile) is unaffected
- [ ] Verify `/collection`, `/collection/search`, `/book` redirect to `/library/*`
- [ ] Verify delivery detail back button returns to previous page (not home)
- [ ] Verify sold/taken-down ershou items show specific error message
- [ ] Verify 体测查询 and 关于应用 appear on home screen
- [ ] Build passes: `cd frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)