### PR TITLE
test: complete test suite, Vue test repairs, Playwright E2E, Codex fixes

### DIFF
--- a/frontend/e2e/login.spec.js
+++ b/frontend/e2e/login.spec.js
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+
+test('login page renders', async ({ page }) => {
+  await page.goto('/login')
+  await expect(page.locator('input')).toBeVisible()
+})
+
+test('redirects to login when not authenticated', async ({ page }) => {
+  await page.goto('/home')
+  await expect(page).toHaveURL(/login/)
+})

--- a/frontend/e2e/playwright.config.js
+++ b/frontend/e2e/playwright.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
-  testDir: './e2e',
+  testDir: '.',
   use: { baseURL: 'http://localhost:5173' },
   webServer: {
     command: 'npm run dev',

--- a/frontend/e2e/playwright.config.js
+++ b/frontend/e2e/playwright.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  use: { baseURL: 'http://localhost:5173' },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: true
+  }
+})

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -2,7 +2,7 @@ import { createI18n } from 'vue-i18n'
 import zhCN from './locales/zh-CN.json'
 
 function detectBrowserLocale() {
-  const lang = navigator.language
+  const lang = (typeof navigator !== 'undefined' && navigator.language) || 'zh-CN'
   const supported = ['zh-CN', 'zh-HK', 'zh-TW', 'en', 'ja', 'ko']
   if (supported.includes(lang)) return lang
   if (lang.startsWith('zh')) return 'zh-CN'
@@ -12,9 +12,13 @@ function detectBrowserLocale() {
   return 'zh-CN'
 }
 
+function getSavedLocale() {
+  try { return localStorage.getItem('locale') } catch (e) { return null }
+}
+
 const i18n = createI18n({
   legacy: false,
-  locale: localStorage.getItem('locale') || detectBrowserLocale(),
+  locale: getSavedLocale() || detectBrowserLocale(),
   fallbackLocale: 'zh-CN',
   messages: { 'zh-CN': zhCN }
 })

--- a/frontend/test/setup.js
+++ b/frontend/test/setup.js
@@ -1,0 +1,11 @@
+if (typeof globalThis.localStorage === 'undefined') {
+  const store = {}
+  globalThis.localStorage = {
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, value) => { store[key] = String(value) },
+    removeItem: (key) => { delete store[key] },
+    clear: () => { Object.keys(store).forEach(k => delete store[k]) },
+    get length() { return Object.keys(store).length },
+    key: (i) => Object.keys(store)[i] ?? null
+  }
+}

--- a/frontend/test/unit/router/router.test.js
+++ b/frontend/test/unit/router/router.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AUTH_WHITELIST,
+  hasToken,
+  isWhitelisted,
+  resolveNavigationTarget,
+} from '../../../src/router/index.js'
+
+describe('router auth helpers', () => {
+
+  it('reads token state from the provided storage object', () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue('jwt-token'),
+    }
+
+    expect(hasToken(storage)).toBe(true)
+    expect(storage.getItem).toHaveBeenCalledWith('token')
+    expect(hasToken({ getItem: () => '' })).toBe(false)
+  })
+
+  it('matches whitelisted paths by exact match and nested prefixes', () => {
+    expect(AUTH_WHITELIST).toContain('/about')
+    expect(isWhitelisted('/about')).toBe(true)
+    expect(isWhitelisted('/policy/privacy')).toBe(true)
+    expect(isWhitelisted('/secret/home')).toBe(false)
+  })
+
+  it('resolves navigation redirects for logged-in and anonymous users', () => {
+    expect(resolveNavigationTarget('/', false)).toBe('/login')
+    expect(resolveNavigationTarget('/', true)).toBe('/home')
+    expect(resolveNavigationTarget('/login', true)).toBe('/home')
+    expect(resolveNavigationTarget('/about/account', false)).toBeNull()
+    expect(resolveNavigationTarget('/secret/home', false)).toBe('/login')
+    expect(resolveNavigationTarget('/secret/home', true)).toBeNull()
+  })
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
     globals: true,
     clearMocks: true,
     restoreMocks: true,
+    setupFiles: ['./test/setup.js'],
   },
   server: {
     // /api 代理到 Java 后端


### PR DESCRIPTION
## Summary

### Test Suite
- Mapper integration tests with H2 (9 cases)
- Service unit tests: photograph, dating, userdata (16 cases)
- Contract tests: photograph, dating (5 cases)
- i18n filter tests (5 cases)
- Playwright E2E config + login spec

### Vue Test Repairs
- Fix i18n.js localStorage/navigator guards for test env
- Add test/setup.js polyfill, fix testDir path
- 4 files, 16 tests all passing (was 2 failing)

### Codex Review Fixes (PR #74)
- P1: Marketplace upload propagates R2 failure
- P2: Comment limit 200→50 (matches DB varchar(50))
- P2: IllegalArgumentException handler in GlobalRestExceptionHandler
- P2: Playwright testDir corrected

## Test plan
- [x] `./gradlew clean test` — 126 tests pass
- [x] `npx vitest run` — 16/16 pass
- [x] `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)