### PR TITLE
feat(frontend): dark mode with CSS variables and Appearance page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,18 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>广东第二师范学院校园助手系统</title>
+    <script>
+      ;(function(){
+        var t='system';
+        try{t=localStorage.getItem('theme')||'system'}catch(e){}
+        var dark=t==='dark'||(t==='system'&&window.matchMedia('(prefers-color-scheme:dark)').matches);
+        document.documentElement.setAttribute('data-theme',dark?'dark':'light');
+        var step=1;
+        try{var raw=localStorage.getItem('font_scale_step');if(raw!==null){var p=parseInt(raw,10);if(p>=0&&p<=3)step=p}}catch(e){}
+        var scales=[0.85,1.0,1.15,1.3];
+        document.documentElement.style.fontSize=(16*(scales[step]||1.0))+'px';
+      })()
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/components/community/CommunityHeader.vue
+++ b/frontend/src/components/community/CommunityHeader.vue
@@ -49,7 +49,7 @@ function handleBack() {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: #fff;
+  background: var(--c-card);
 }
 
 .community-header__accent {

--- a/frontend/src/components/community/CommunityTabbar.vue
+++ b/frontend/src/components/community/CommunityTabbar.vue
@@ -51,8 +51,8 @@ function goTo(path) {
   right: 0;
   width: 100%;
   height: 56px;
-  background: #fff;
-  border-top: 1px solid #f3f4f6;
+  background: var(--c-card);
+  border-top: 1px solid var(--c-border);
   display: flex;
   z-index: 500;
   box-shadow: 0 -1px 8px rgba(0, 0, 0, 0.04);
@@ -64,7 +64,7 @@ function goTo(path) {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: #9ca3af;
+  color: var(--c-text-3);
   text-decoration: none;
   font-size: 12px;
   padding: 6px 0;

--- a/frontend/src/components/info/HistoryBlock.vue
+++ b/frontend/src/components/info/HistoryBlock.vue
@@ -50,7 +50,7 @@ defineProps({
   display: block;
   width: 4px;
   height: 16px;
-  background: #09bb07;
+  background: var(--color-primary);
   border-radius: 2px;
   margin-right: 8px;
 }
@@ -62,7 +62,7 @@ defineProps({
 }
 .history-date {
   font-weight: 600;
-  color: #09bb07;
+  color: var(--color-primary);
 }
 .history-desc {
   font-size: 14px;

--- a/frontend/src/components/info/InteractionBlock.vue
+++ b/frontend/src/components/info/InteractionBlock.vue
@@ -135,7 +135,7 @@ function getActionLabel(item) {
   display: block;
   width: 4px;
   height: 16px;
-  background: #09bb07;
+  background: var(--color-primary);
   border-radius: 2px;
   margin-right: 8px;
 }
@@ -244,7 +244,7 @@ function getActionLabel(item) {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #09bb07;
+  background: var(--color-primary);
   flex-shrink: 0;
 }
 
@@ -253,6 +253,6 @@ function getActionLabel(item) {
 }
 
 .interaction-item__state.is-unread {
-  color: #09bb07;
+  color: var(--color-primary);
 }
 </style>

--- a/frontend/src/components/info/NoticeBlock.vue
+++ b/frontend/src/components/info/NoticeBlock.vue
@@ -76,7 +76,7 @@ const visibleNotices = computed(() => {
   display: block;
   width: 4px;
   height: 16px;
-  background: #09bb07;
+  background: var(--color-primary);
   border-radius: 2px;
   margin-right: 8px;
 }

--- a/frontend/src/layout/MainLayout.vue
+++ b/frontend/src/layout/MainLayout.vue
@@ -82,6 +82,10 @@ watch(
   filter: brightness(0) saturate(100%) invert(48%) sepia(79%) saturate(2476%) hue-rotate(86deg);
 }
 .weui-tabbar .weui-bar__item_on .weui-tabbar__label {
-  color: #09bb07;
+  color: var(--color-primary);
+}
+.weui-tabbar {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-divider);
 }
 </style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -128,5 +128,25 @@
   },
   "router": {
     "siteTitle": "GdeiAssistant - Guangdong University of Education"
+  },
+  "appearance": {
+    "title": "Interface & Appearance",
+    "theme": {
+      "label": "Theme",
+      "system": "Follow System",
+      "light": "Light Mode",
+      "dark": "Dark Mode"
+    },
+    "font": {
+      "label": "Font Size",
+      "small": "Small",
+      "standard": "Standard",
+      "large": "Large",
+      "xlarge": "Extra Large",
+      "preview": "Preview: GdeiAssistant Campus Helper"
+    },
+    "language": {
+      "label": "Language"
+    }
   }
 }

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -128,5 +128,25 @@
   },
   "router": {
     "siteTitle": "広東第二師範学院キャンパスアシスタント"
+  },
+  "appearance": {
+    "title": "インターフェースと外観",
+    "theme": {
+      "label": "テーマ",
+      "system": "システムに従う",
+      "light": "ライトモード",
+      "dark": "ダークモード"
+    },
+    "font": {
+      "label": "フォントサイズ",
+      "small": "小",
+      "standard": "標準",
+      "large": "大",
+      "xlarge": "特大",
+      "preview": "プレビュー：広東第二師範学院キャンパスアシスタント"
+    },
+    "language": {
+      "label": "言語"
+    }
   }
 }

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -128,5 +128,25 @@
   },
   "router": {
     "siteTitle": "광둥제2사범대학교 캠퍼스 어시스턴트"
+  },
+  "appearance": {
+    "title": "인터페이스 및 외관",
+    "theme": {
+      "label": "테마",
+      "system": "시스템 설정 따르기",
+      "light": "라이트 모드",
+      "dark": "다크 모드"
+    },
+    "font": {
+      "label": "글꼴 크기",
+      "small": "작게",
+      "standard": "표준",
+      "large": "크게",
+      "xlarge": "매우 크게",
+      "preview": "미리보기: 광동제2사범학원 캠퍼스 도우미"
+    },
+    "language": {
+      "label": "언어"
+    }
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -128,5 +128,25 @@
   },
   "router": {
     "siteTitle": "广东第二师范学院校园助手系统"
+  },
+  "appearance": {
+    "title": "界面和外观",
+    "theme": {
+      "label": "主题",
+      "system": "跟随系统",
+      "light": "浅色模式",
+      "dark": "深色模式"
+    },
+    "font": {
+      "label": "字体大小",
+      "small": "小",
+      "standard": "标准",
+      "large": "大",
+      "xlarge": "超大",
+      "preview": "预览：广东第二师范学院校园助手"
+    },
+    "language": {
+      "label": "语言"
+    }
   }
 }

--- a/frontend/src/locales/zh-HK.json
+++ b/frontend/src/locales/zh-HK.json
@@ -128,5 +128,25 @@
   },
   "router": {
     "siteTitle": "廣東第二師範學院校園助手系統"
+  },
+  "appearance": {
+    "title": "介面和外觀",
+    "theme": {
+      "label": "主題",
+      "system": "跟隨系統",
+      "light": "淺色模式",
+      "dark": "深色模式"
+    },
+    "font": {
+      "label": "字體大小",
+      "small": "小",
+      "standard": "標準",
+      "large": "大",
+      "xlarge": "超大",
+      "preview": "預覽：廣東第二師範學院校園助手"
+    },
+    "language": {
+      "label": "語言"
+    }
   }
 }

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -128,5 +128,25 @@
   },
   "router": {
     "siteTitle": "廣東第二師範學院校園助手系統"
+  },
+  "appearance": {
+    "title": "介面和外觀",
+    "theme": {
+      "label": "主題",
+      "system": "跟隨系統",
+      "light": "淺色模式",
+      "dark": "深色模式"
+    },
+    "font": {
+      "label": "字體大小",
+      "small": "小",
+      "standard": "標準",
+      "large": "大",
+      "xlarge": "超大",
+      "preview": "預覽：廣東第二師範學院校園助手"
+    },
+    "language": {
+      "label": "語言"
+    }
   }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,6 +5,9 @@ import './styles/community-theme.css'
 import App from './App.vue'
 import router from './router'
 import i18n from './i18n'
+import { initTheme } from './theme.js'
+
+initTheme()
 
 const app = createApp(App)
 app.use(router)

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -119,6 +119,12 @@ const routes = [
     component: About
   },
   {
+    path: '/appearance',
+    name: 'Appearance',
+    component: () => import('../views/AppearancePage.vue'),
+    meta: { titleKey: 'appearance.title' }
+  },
+  {
     path: '/grade',
     name: 'Grade',
     component: Grade

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -15,11 +14,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-primary);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-primary-hover);
 }
 
 * {
@@ -47,12 +46,12 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-surface-raised);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-primary);
 }
 button:focus,
 button:focus-visible {
@@ -69,17 +68,4 @@ button:focus-visible {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/frontend/src/styles/community-theme.css
+++ b/frontend/src/styles/community-theme.css
@@ -3,7 +3,24 @@
    仅作用于社区模块，不影响教务系统/主系统的 WeUI 样式
    ============================================================ */
 
-:root {
+:root,
+[data-theme="light"] {
+  color-scheme: light;
+
+  /* 基础主题变量 */
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f9fafb;
+  --color-bg-tertiary: #f3f4f6;
+  --color-surface: #ffffff;
+  --color-surface-raised: #ffffff;
+  --color-text-primary: #1f2937;
+  --color-text-secondary: #4b5563;
+  --color-text-tertiary: #9ca3af;
+  --color-border: #e5e7eb;
+  --color-divider: #f3f4f6;
+  --color-primary: #047857;
+  --color-primary-hover: #065f46;
+
   /* 模块专属色 */
   --c-ershou: #10b981;
   --c-lostandfound: #3b82f6;
@@ -22,6 +39,7 @@
   --c-card: #ffffff;
   --c-border: #f3f4f6;
   --c-divider: #e5e7eb;
+  --c-shadow: rgba(0, 0, 0, 0.06);
 
   /* 圆角 */
   --radius-sm: 8px;
@@ -49,6 +67,45 @@
   --font-lg: 16px;
   --font-xl: 18px;
   --font-2xl: 20px;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-bg-primary: #121212;
+  --color-bg-secondary: #1a1a1a;
+  --color-bg-tertiary: #242424;
+  --color-surface: #1e1e1e;
+  --color-surface-raised: #2a2a2a;
+  --color-text-primary: #e5e7eb;
+  --color-text-secondary: #9ca3af;
+  --color-text-tertiary: #9295a0;
+  --color-border: #374151;
+  --color-divider: #2a2a2a;
+  --color-primary: #34D399;
+  --color-primary-hover: #6EE7B7;
+
+  --c-ershou: #34d399;
+  --c-lostandfound: #60a5fa;
+  --c-secret: #a78bfa;
+  --c-express: #fb7185;
+  --c-topic: #818cf8;
+  --c-delivery: #fbbf24;
+  --c-dating: #f472b6;
+  --c-photograph: #22d3ee;
+
+  --c-text-1: #e5e7eb;
+  --c-text-2: #9ca3af;
+  --c-text-3: #9295a0;
+  --c-bg: #121212;
+  --c-card: #1e1e1e;
+  --c-border: #374151;
+  --c-divider: #2a2a2a;
+  --c-shadow: rgba(0, 0, 0, 0.3);
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.2);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.25);
 }
 
 /* ============================================================
@@ -116,7 +173,7 @@
   position: relative;
   aspect-ratio: 1;
   overflow: hidden;
-  background: #f0f0f0;
+  background: var(--color-bg-tertiary);
   cursor: pointer;
 }
 
@@ -364,7 +421,7 @@
    ============================================================ */
 
 .community-skeleton {
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background: linear-gradient(90deg, var(--color-bg-tertiary) 25%, var(--color-surface-raised) 50%, var(--color-bg-tertiary) 75%);
   background-size: 200% 100%;
   animation: community-shimmer 1.5s ease-in-out infinite;
   border-radius: var(--radius-sm);

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,0 +1,56 @@
+const THEME_KEY = 'theme'
+const FONT_SCALE_KEY = 'font_scale_step'
+const FONT_SCALES = [0.85, 1.0, 1.15, 1.3]
+
+function getMediaDark() {
+  return window.matchMedia('(prefers-color-scheme: dark)')
+}
+
+function resolveEffectiveTheme(mode) {
+  if (mode === 'light' || mode === 'dark') return mode
+  return getMediaDark().matches ? 'dark' : 'light'
+}
+
+function applyTheme(effective) {
+  document.documentElement.setAttribute('data-theme', effective)
+}
+
+function applyFontScale(step) {
+  const scale = FONT_SCALES[step] || 1.0
+  document.documentElement.style.fontSize = (16 * scale) + 'px'
+}
+
+export function getThemeMode() {
+  try { return localStorage.getItem(THEME_KEY) || 'system' } catch { return 'system' }
+}
+
+export function setThemeMode(mode) {
+  localStorage.setItem(THEME_KEY, mode)
+  applyTheme(resolveEffectiveTheme(mode))
+}
+
+export function getFontScaleStep() {
+  try {
+    const raw = localStorage.getItem(FONT_SCALE_KEY)
+    if (raw === null) return 1
+    const v = parseInt(raw, 10)
+    return (v >= 0 && v <= 3) ? v : 1
+  } catch { return 1 }
+}
+
+export function setFontScaleStep(step) {
+  localStorage.setItem(FONT_SCALE_KEY, String(step))
+  applyFontScale(step)
+}
+
+export function initTheme() {
+  const mode = getThemeMode()
+  applyTheme(resolveEffectiveTheme(mode))
+  applyFontScale(getFontScaleStep())
+
+  getMediaDark().addEventListener('change', () => {
+    if (getThemeMode() === 'system') {
+      applyTheme(resolveEffectiveTheme('system'))
+    }
+  })
+}

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -388,7 +388,7 @@ onMounted(() => {
 
 .menu-subitem:hover {
   background-color: #f0f0f0;
-  color: #09bb07;
+  color: var(--color-primary);
 }
 
 .menu-subitem:last-child {
@@ -418,7 +418,7 @@ onMounted(() => {
 
 .weui-btn_primary {
   width: 100%;
-  background-color: #09bb07;
+  background-color: var(--color-primary);
 }
 
 .about-content {
@@ -446,7 +446,7 @@ onMounted(() => {
   transform: translateX(-50%);
   width: 40px;
   height: 2px;
-  background-color: #09bb07;
+  background-color: var(--color-primary);
 }
 
 .about-description {
@@ -559,7 +559,7 @@ onMounted(() => {
 }
 
 .footer-beian a:hover {
-  color: #09bb07;
+  color: var(--color-primary);
   text-decoration: underline;
 }
 
@@ -597,7 +597,7 @@ onMounted(() => {
 }
 
 .cookie-link:hover {
-  color: #09bb07;
+  color: var(--color-primary);
 }
 
 .cookie-close {
@@ -616,6 +616,6 @@ onMounted(() => {
 }
 
 .cookie-close:hover {
-  color: #09bb07;
+  color: var(--color-primary);
 }
 </style>

--- a/frontend/src/views/AppearancePage.vue
+++ b/frontend/src/views/AppearancePage.vue
@@ -1,0 +1,179 @@
+<script setup>
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { setLocale as setI18nLocale } from '@/i18n'
+import { getThemeMode, setThemeMode, getFontScaleStep, setFontScaleStep } from '@/theme'
+
+const { t } = useI18n()
+
+const theme = ref(getThemeMode())
+const fontStep = ref(getFontScaleStep())
+
+const themeOptions = [
+  { value: 'system', labelKey: 'appearance.theme.system' },
+  { value: 'light', labelKey: 'appearance.theme.light' },
+  { value: 'dark', labelKey: 'appearance.theme.dark' },
+]
+
+const fontLabels = [
+  'appearance.font.small',
+  'appearance.font.standard',
+  'appearance.font.large',
+  'appearance.font.xlarge',
+]
+
+const fontScales = [0.85, 1.0, 1.15, 1.3]
+
+const locales = [
+  { code: 'zh-CN', label: '简体中文' },
+  { code: 'zh-HK', label: '繁體中文（香港）' },
+  { code: 'zh-TW', label: '繁體中文（台灣）' },
+  { code: 'en', label: 'English' },
+  { code: 'ja', label: '日本語' },
+  { code: 'ko', label: '한국어' },
+]
+
+const selectedLocale = ref(localStorage.getItem('locale') || 'zh-CN')
+
+function onThemeChange(value) {
+  theme.value = value
+  setThemeMode(value)
+}
+
+function onFontChange(e) {
+  const step = Number(e.target.value)
+  fontStep.value = step
+  setFontScaleStep(step)
+}
+
+function onLocaleChange(code) {
+  selectedLocale.value = code
+  setI18nLocale(code)
+}
+</script>
+
+<template>
+  <div class="appearance-page">
+    <div class="appearance-header">
+      <a class="back-link" @click="$router.back()">←</a>
+      <h2>{{ t('appearance.title') }}</h2>
+    </div>
+
+    <div class="appearance-section">
+      <h3 class="section-title">{{ t('appearance.theme.label') }}</h3>
+      <div class="option-list">
+        <div
+          v-for="opt in themeOptions"
+          :key="opt.value"
+          class="option-item"
+          @click="onThemeChange(opt.value)"
+        >
+          <span>{{ t(opt.labelKey) }}</span>
+          <span v-if="theme === opt.value" class="check-icon">✓</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="appearance-section">
+      <h3 class="section-title">{{ t('appearance.font.label') }}</h3>
+      <div class="font-card">
+        <input
+          type="range"
+          min="0"
+          max="3"
+          step="1"
+          :value="fontStep"
+          class="font-slider"
+          @input="onFontChange"
+        />
+        <div class="font-labels">
+          <span v-for="(lbl, i) in fontLabels" :key="i">{{ t(lbl) }}</span>
+        </div>
+        <p class="font-preview" :style="{ fontSize: (16 * fontScales[fontStep]) + 'px' }">
+          {{ t('appearance.font.preview') }}
+        </p>
+      </div>
+    </div>
+
+    <div class="appearance-section">
+      <h3 class="section-title">{{ t('appearance.language.label') }}</h3>
+      <div class="option-list">
+        <div
+          v-for="loc in locales"
+          :key="loc.code"
+          class="option-item"
+          @click="onLocaleChange(loc.code)"
+        >
+          <span>{{ loc.label }}</span>
+          <span v-if="selectedLocale === loc.code" class="check-icon">✓</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.appearance-page {
+  min-height: 100vh;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+}
+.appearance-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-divider);
+}
+.appearance-header h2 { margin: 0; font-size: 1.1rem; }
+.back-link {
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+.section-title {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  padding: 16px 16px 8px;
+  margin: 0;
+}
+.option-list {
+  background: var(--color-surface);
+}
+.option-item {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-divider);
+}
+.option-item:hover {
+  background: var(--color-bg-tertiary);
+}
+.check-icon {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+.font-card {
+  background: var(--color-surface);
+  padding: 16px;
+}
+.font-slider {
+  width: 100%;
+  accent-color: var(--color-primary);
+}
+.font-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  margin-top: 4px;
+}
+.font-preview {
+  margin-top: 12px;
+  color: var(--color-text-primary);
+}
+</style>

--- a/frontend/src/views/Info.vue
+++ b/frontend/src/views/Info.vue
@@ -325,7 +325,7 @@ onMounted(() => {
   height: 42px;
   border-radius: 12px;
   background: #e8f7ef;
-  color: #09bb07;
+  color: var(--color-primary);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -73,19 +73,9 @@
     </div>
 
     <div class="weui-cells">
-      <div class="weui-cell">
-        <div class="weui-cell__bd"><p>{{ $t('profile.language') }}</p></div>
-        <div class="weui-cell__ft">
-          <select v-model="selectedLocale" class="locale-select" @change="changeLocale">
-            <option value="zh-CN">简体中文</option>
-            <option value="zh-HK">繁體中文（香港）</option>
-            <option value="zh-TW">繁體中文（台灣）</option>
-            <option value="en">English</option>
-            <option value="ja">日本語</option>
-            <option value="ko">한국어</option>
-          </select>
-        </div>
-      </div>
+      <a class="weui-cell weui-cell_access" href="javascript:" @click.prevent="handleNav('/appearance')">
+        <div class="weui-cell__bd"><p>{{ $t('appearance.title') }}</p></div><div class="weui-cell__ft"></div>
+      </a>
     </div>
 
     <div class="weui-cells">
@@ -730,7 +720,7 @@ onBeforeUnmount(() => {
 .page_title {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   padding: 40px 0 20px 0;
   margin: 0;

--- a/frontend/src/views/about/Account.vue
+++ b/frontend/src/views/about/Account.vue
@@ -61,7 +61,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;

--- a/frontend/src/views/about/CookiePolicy.vue
+++ b/frontend/src/views/about/CookiePolicy.vue
@@ -103,7 +103,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;

--- a/frontend/src/views/about/IntellectualProperty.vue
+++ b/frontend/src/views/about/IntellectualProperty.vue
@@ -52,7 +52,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;
@@ -80,7 +80,7 @@ const router = useRouter()
 }
 
 .weui-article a {
-  color: #09bb07;
+  color: var(--color-primary);
   text-decoration: underline;
 }
 </style>

--- a/frontend/src/views/about/License.vue
+++ b/frontend/src/views/about/License.vue
@@ -93,7 +93,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;

--- a/frontend/src/views/about/PrivacyPolicy.vue
+++ b/frontend/src/views/about/PrivacyPolicy.vue
@@ -194,7 +194,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;

--- a/frontend/src/views/about/Security.vue
+++ b/frontend/src/views/about/Security.vue
@@ -169,7 +169,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;

--- a/frontend/src/views/about/SocialPolicy.vue
+++ b/frontend/src/views/about/SocialPolicy.vue
@@ -115,7 +115,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;

--- a/frontend/src/views/about/UserAgreement.vue
+++ b/frontend/src/views/about/UserAgreement.vue
@@ -236,7 +236,7 @@ const router = useRouter()
 }
 
 .back-btn {
-  color: #09bb07;
+  color: var(--color-primary);
   font-size: 15px;
   cursor: pointer;
   margin-right: 16px;

--- a/frontend/src/views/book/Book.vue
+++ b/frontend/src/views/book/Book.vue
@@ -240,7 +240,7 @@ function confirmRenew() {
 .page-title-green {
   text-align: center;
   font-size: 22px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 0 0 6px 0;
 }

--- a/frontend/src/views/card/CardInfo.vue
+++ b/frontend/src/views/card/CardInfo.vue
@@ -214,7 +214,7 @@ onMounted(() => {
 
 .page-title-green {
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 0;
   line-height: 1.2;
@@ -287,7 +287,7 @@ onMounted(() => {
 }
 
 .card-info-footer-link {
-  color: #09bb07;
+  color: var(--color-primary);
   text-decoration: none;
 }
 
@@ -358,7 +358,7 @@ onMounted(() => {
 }
 
 .weui-dialog__btn_primary {
-  color: #09bb07;
+  color: var(--color-primary);
   border-left: 1px solid #e5e5e5;
 }
 

--- a/frontend/src/views/card/CardList.vue
+++ b/frontend/src/views/card/CardList.vue
@@ -170,7 +170,7 @@ onMounted(() => {
 
 .page-title-green {
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 0 0 20px 0;
   line-height: 1.2;

--- a/frontend/src/views/card/CardRecordSearch.vue
+++ b/frontend/src/views/card/CardRecordSearch.vue
@@ -96,7 +96,7 @@ function goBack() {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 6px 0;
   line-height: 1.2;

--- a/frontend/src/views/cet/Cet.vue
+++ b/frontend/src/views/cet/Cet.vue
@@ -291,7 +291,7 @@ onMounted(() => {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 20px 0;
   line-height: 1.2;
@@ -318,7 +318,7 @@ onMounted(() => {
 }
 
 .cet-page-desc__link {
-  color: #09bb07;
+  color: var(--color-primary);
   text-decoration: none;
 }
 
@@ -332,7 +332,7 @@ onMounted(() => {
 
 .weui-vcode-placeholder {
   font-size: 14px;
-  color: #09bb07;
+  color: var(--color-primary);
   cursor: pointer;
 }
 

--- a/frontend/src/views/cet/CetSave.vue
+++ b/frontend/src/views/cet/CetSave.vue
@@ -140,7 +140,7 @@ onMounted(() => {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 20px 0;
   line-height: 1.2;

--- a/frontend/src/views/collection/CollectionDetail.vue
+++ b/frontend/src/views/collection/CollectionDetail.vue
@@ -87,7 +87,7 @@ onMounted(() => {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 20px 0;
   line-height: 1.2;

--- a/frontend/src/views/collection/CollectionList.vue
+++ b/frontend/src/views/collection/CollectionList.vue
@@ -127,7 +127,7 @@ onMounted(() => {
 
 .page-title-green {
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 0 0 0 0;
   line-height: 1.2;

--- a/frontend/src/views/collection/CollectionSearch.vue
+++ b/frontend/src/views/collection/CollectionSearch.vue
@@ -92,7 +92,7 @@ function goBack() {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 4px 0;
   line-height: 1.2;

--- a/frontend/src/views/data/DataIndex.vue
+++ b/frontend/src/views/data/DataIndex.vue
@@ -42,7 +42,7 @@ const router = useRouter()
 }
 .page-title {
   text-align: center;
-  color: #09bb07;
+  color: var(--color-primary);
   padding: 10px 0;
   margin: 0;
   font-size: 34px;

--- a/frontend/src/views/data/ElectricityFees.vue
+++ b/frontend/src/views/data/ElectricityFees.vue
@@ -258,7 +258,7 @@ const resetQuery = () => {
 }
 .page-title {
   text-align: center;
-  color: #09bb07;
+  color: var(--color-primary);
   padding: 10px 0;
   margin: 0;
   font-size: 34px;

--- a/frontend/src/views/data/YellowPage.vue
+++ b/frontend/src/views/data/YellowPage.vue
@@ -89,7 +89,7 @@ onMounted(() => {
 }
 .page-title {
   text-align: center;
-  color: #09bb07;
+  color: var(--color-primary);
   padding: 10px 0;
   margin: 0;
   font-size: 34px;
@@ -103,7 +103,7 @@ onMounted(() => {
   display: inline-block;
   width: 20px;
   height: 20px;
-  border: 2px solid #09bb07;
+  border: 2px solid var(--color-primary);
   border-top-color: transparent;
   border-radius: 50%;
   animation: weui-loading 1s linear infinite;

--- a/frontend/src/views/evaluate/Evaluate.vue
+++ b/frontend/src/views/evaluate/Evaluate.vue
@@ -130,7 +130,7 @@ function confirmEvaluate() {
 
 .page-title-green {
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 0;
   line-height: 1.2;
@@ -188,8 +188,8 @@ function confirmEvaluate() {
   transition: transform 0.3s;
 }
 .weui-switch:checked {
-  border-color: #09bb07;
-  background-color: #09bb07;
+  border-color: var(--color-primary);
+  background-color: var(--color-primary);
 }
 .weui-switch:checked::after {
   transform: translateX(20px);
@@ -263,6 +263,6 @@ function confirmEvaluate() {
 }
 
 .weui-dialog--confirm .weui-dialog__btn_primary {
-  color: #09bb07;
+  color: var(--color-primary);
 }
 </style>

--- a/frontend/src/views/grade/Grade.vue
+++ b/frontend/src/views/grade/Grade.vue
@@ -246,7 +246,7 @@ onMounted(() => {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 20px 0;
   line-height: 1.2;
@@ -283,7 +283,7 @@ onMounted(() => {
   right: 0;
   bottom: 0;
   height: 3px;
-  background-color: #09bb07;
+  background-color: var(--color-primary);
 }
 
 /* 学期与绩点摘要：居中，第一行绿色，第二行灰色 */
@@ -294,7 +294,7 @@ onMounted(() => {
 .term {
   padding-top: 15px;
   font-size: 16px;
-  color: #09bb07;
+  color: var(--color-primary);
   text-align: center;
   margin-bottom: 4px;
 }

--- a/frontend/src/views/graduateExam/GraduateExamResult.vue
+++ b/frontend/src/views/graduateExam/GraduateExamResult.vue
@@ -149,7 +149,7 @@ onMounted(() => {
 
 .page-title-green {
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 0 0 20px 0;
   line-height: 1.2;
@@ -158,7 +158,7 @@ onMounted(() => {
 .kaoyan-total {
   text-align: center;
   font-size: 16px;
-  color: #09bb07;
+  color: var(--color-primary);
   margin-bottom: 4px;
 }
 
@@ -166,7 +166,7 @@ onMounted(() => {
   text-align: center;
   font-size: 28px;
   font-weight: 500;
-  color: #09bb07;
+  color: var(--color-primary);
   margin-bottom: 24px;
 }
 

--- a/frontend/src/views/graduateExam/GraduateExamSearch.vue
+++ b/frontend/src/views/graduateExam/GraduateExamSearch.vue
@@ -142,7 +142,7 @@ function doQuery() {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 20px 0;
   line-height: 1.2;

--- a/frontend/src/views/news/NewsList.vue
+++ b/frontend/src/views/news/NewsList.vue
@@ -176,7 +176,7 @@ onMounted(() => {
   font-size: 22px;
   font-weight: 500;
   text-align: center;
-  color: #09bb07;
+  color: var(--color-primary);
 }
 .weui-tab__panel {
   flex: 1;
@@ -210,9 +210,9 @@ onMounted(() => {
   border-top: 1px solid #e5e5e5;
 }
 .news-tabbar .weui-bar__item_on .weui-tabbar__label {
-  color: #09bb07;
+  color: var(--color-primary);
 }
-/* 原版无 _active 图时，用滤镜高亮为绿色 #09bb07 */
+/* 原版无 _active 图时，用滤镜高亮为绿色 var(--color-primary) */
 .news-tabbar .weui-bar__item_on .weui-tabbar__icon {
   filter: brightness(0) saturate(100%) invert(48%) sepia(79%) saturate(2476%) hue-rotate(86deg);
 }

--- a/frontend/src/views/schedule/Schedule.vue
+++ b/frontend/src/views/schedule/Schedule.vue
@@ -609,7 +609,7 @@ onMounted(() => {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 20px 0;
   line-height: 1.2;
@@ -719,11 +719,11 @@ onMounted(() => {
   width: 3px;
   height: 3px;
   border-radius: 50%;
-  background-color: #09bb07;
+  background-color: var(--color-primary);
 }
 
 .schedule-grid__cell--head.today-highlight {
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 500;
   background: rgba(9, 187, 7, 0.08) !important;
 }
@@ -854,7 +854,7 @@ onMounted(() => {
 
 .schedule-detail-dialog__close {
   font-size: 16px;
-  color: #09bb07;
+  color: var(--color-primary);
   cursor: pointer;
 }
 
@@ -938,7 +938,7 @@ onMounted(() => {
 }
 
 .week-picker__item--active {
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 500;
 }
 </style>

--- a/frontend/src/views/spare/SpareList.vue
+++ b/frontend/src/views/spare/SpareList.vue
@@ -110,7 +110,7 @@ onMounted(() => {
 
 .page-title-green {
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 0 0 20px 0;
   line-height: 1.2;

--- a/frontend/src/views/spare/SpareSearch.vue
+++ b/frontend/src/views/spare/SpareSearch.vue
@@ -279,7 +279,7 @@ function doSearch() {
 .page-title-green {
   text-align: center;
   font-size: 34px;
-  color: #09bb07;
+  color: var(--color-primary);
   font-weight: 400;
   margin: 10px 0 20px 0;
   line-height: 1.2;

--- a/frontend/src/views/user/LoginRecord.vue
+++ b/frontend/src/views/user/LoginRecord.vue
@@ -150,7 +150,7 @@ onMounted(() => {
   vertical-align: middle;
   animation: weuiLoading 1s linear infinite;
   border: 2px solid #e5e5e5;
-  border-top-color: #09bb07;
+  border-top-color: var(--color-primary);
   border-radius: 50%;
 }
 


### PR DESCRIPTION
## Summary
- Add theme.js for system/light/dark theme management with FOUC prevention
- Extend community-theme.css with full dark mode CSS variable set
- Replace #09bb07 across 36 Vue files with var(--color-primary)
- Fix community component hardcoded colors (Header, Tabbar, skeleton)
- New AppearancePage.vue with theme, font scale, language
- 6-language i18n support

## Test plan
- [ ] Verify dark mode toggle in Appearance page
- [ ] Verify no FOUC on page reload in dark mode
- [ ] Verify community module colors adapt to dark mode
- [ ] Tests pass: `npx vitest run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)