### PR TITLE
fix(frontend): migrate hardcoded colors for dark mode

### DIFF
--- a/frontend/src/components/info/HistoryBlock.vue
+++ b/frontend/src/components/info/HistoryBlock.vue
@@ -31,7 +31,7 @@ defineProps({
 
 <style scoped>
 .modern-card {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 12px;
   padding: 16px;
   margin-bottom: 16px;
@@ -40,7 +40,7 @@ defineProps({
 .card-title {
   font-size: 17px;
   font-weight: 600;
-  color: #333333;
+  color: var(--color-text-primary);
   margin-bottom: 12px;
   display: flex;
   align-items: center;
@@ -56,7 +56,7 @@ defineProps({
 }
 .history-lead {
   font-size: 15px;
-  color: #333;
+  color: var(--color-text-primary);
   margin: 0 0 12px;
   line-height: 1.5;
 }
@@ -66,7 +66,7 @@ defineProps({
 }
 .history-desc {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.6;
   margin: 0 0 8px;
 }

--- a/frontend/src/components/info/InteractionBlock.vue
+++ b/frontend/src/components/info/InteractionBlock.vue
@@ -91,7 +91,7 @@ function getActionLabel(item) {
 
 <style scoped>
 .modern-card {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 12px;
   padding: 16px;
   margin-bottom: 16px;
@@ -109,7 +109,7 @@ function getActionLabel(item) {
 .card-title {
   font-size: 17px;
   font-weight: 600;
-  color: #333333;
+  color: var(--color-text-primary);
   margin-bottom: 0;
   display: flex;
   align-items: center;
@@ -153,7 +153,7 @@ function getActionLabel(item) {
 .interaction-empty {
   padding: 12px 0 4px;
   font-size: 14px;
-  color: #999999;
+  color: var(--color-text-tertiary);
   text-align: center;
 }
 
@@ -165,9 +165,9 @@ function getActionLabel(item) {
 
 .interaction-item {
   width: 100%;
-  border: 1px solid #f0f0f0;
+  border: 1px solid var(--color-divider);
   border-radius: 10px;
-  background: #fafafa;
+  background: var(--color-bg-secondary);
   padding: 12px;
   text-align: left;
   cursor: pointer;
@@ -188,20 +188,20 @@ function getActionLabel(item) {
   min-width: 0;
   font-size: 15px;
   font-weight: 600;
-  color: #333333;
+  color: var(--color-text-primary);
 }
 
 .interaction-item__time {
   flex-shrink: 0;
   font-size: 12px;
-  color: #999999;
+  color: var(--color-text-tertiary);
 }
 
 .interaction-item__content {
   margin-top: 8px;
   font-size: 13px;
   line-height: 1.6;
-  color: #666666;
+  color: var(--color-text-secondary);
 }
 
 .interaction-item__footer {
@@ -249,7 +249,7 @@ function getActionLabel(item) {
 }
 
 .interaction-item__state.is-read {
-  color: #999999;
+  color: var(--color-text-tertiary);
 }
 
 .interaction-item__state.is-unread {

--- a/frontend/src/components/info/NoticeBlock.vue
+++ b/frontend/src/components/info/NoticeBlock.vue
@@ -48,7 +48,7 @@ const visibleNotices = computed(() => {
 
 <style scoped>
 .modern-card {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 12px;
   padding: 16px;
   margin-bottom: 16px;
@@ -63,7 +63,7 @@ const visibleNotices = computed(() => {
 .card-title {
   font-size: 17px;
   font-weight: 600;
-  color: #333333;
+  color: var(--color-text-primary);
   margin-bottom: 12px;
   display: flex;
   align-items: center;
@@ -94,23 +94,23 @@ const visibleNotices = computed(() => {
   margin-top: 12px;
 }
 .notice-content + .notice-content {
-  border-top: 1px solid #f2f2f2;
+  border-top: 1px solid var(--color-divider);
   padding-top: 14px;
 }
 .notice-title {
   font-size: 16px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 6px;
 }
 .notice-date {
   font-size: 13px;
-  color: #999;
+  color: var(--color-text-tertiary);
   margin-bottom: 10px;
 }
 .notice-body {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.6;
 }
 </style>

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -231,7 +231,7 @@ onMounted(() => {
 
 <style scoped>
 .about-page {
-  background-color: #fff;
+  background-color: var(--color-surface);
   min-height: 100vh;
   padding: 0 0 80px 0;
   display: flex;
@@ -247,7 +247,7 @@ onMounted(() => {
   left: 0;
   right: 0;
   height: 50px;
-  background-color: #fff;
+  background-color: var(--color-surface);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   z-index: 1000;
 }
@@ -263,7 +263,7 @@ onMounted(() => {
 .navbar-title {
   font-size: 18px;
   font-weight: bold;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .hamburger-btn {
@@ -282,7 +282,7 @@ onMounted(() => {
 .hamburger-btn span {
   width: 24px;
   height: 2px;
-  background-color: #333;
+  background-color: var(--color-text-primary);
   transition: all 0.3s;
 }
 
@@ -303,7 +303,7 @@ onMounted(() => {
   right: -300px;
   width: 300px;
   height: 100vh;
-  background-color: #fff;
+  background-color: var(--color-surface);
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
   z-index: 1002;
   transition: right 0.3s ease;
@@ -319,13 +319,13 @@ onMounted(() => {
   justify-content: space-between;
   align-items: center;
   padding: 16px;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--color-divider);
 }
 
 .menu-title {
   font-size: 18px;
   font-weight: bold;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .menu-close {
@@ -334,7 +334,7 @@ onMounted(() => {
   border: none;
   background: transparent;
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -346,7 +346,7 @@ onMounted(() => {
 }
 
 .menu-item {
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--color-divider);
 }
 
 .menu-item-header {
@@ -355,17 +355,17 @@ onMounted(() => {
   align-items: center;
   padding: 16px;
   cursor: pointer;
-  color: #333;
+  color: var(--color-text-primary);
   font-size: 15px;
 }
 
 .menu-item-header:hover {
-  background-color: #f5f5f5;
+  background-color: var(--color-bg-secondary);
 }
 
 .menu-arrow {
   font-size: 12px;
-  color: #999;
+  color: var(--color-text-tertiary);
   transition: transform 0.3s;
 }
 
@@ -374,20 +374,20 @@ onMounted(() => {
 }
 
 .menu-subitems {
-  background-color: #f9f9f9;
+  background-color: var(--color-bg-secondary);
 }
 
 .menu-subitem {
   display: block;
   padding: 12px 16px 12px 32px;
-  color: #666;
+  color: var(--color-text-secondary);
   text-decoration: none;
   font-size: 14px;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--color-divider);
 }
 
 .menu-subitem:hover {
-  background-color: #f0f0f0;
+  background-color: var(--color-divider);
   color: var(--color-primary);
 }
 
@@ -431,7 +431,7 @@ onMounted(() => {
 .about-title {
   font-size: 18px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
   margin: 0 0 16px 0;
   text-align: center;
   position: relative;
@@ -451,7 +451,7 @@ onMounted(() => {
 
 .about-description {
   line-height: 1.8;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 14px;
 }
 
@@ -513,7 +513,7 @@ onMounted(() => {
   text-align: center;
   margin-top: auto;
   padding-top: 40px;
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--color-divider);
   padding-left: 16px;
   padding-right: 16px;
 }
@@ -540,7 +540,7 @@ onMounted(() => {
 
 .footer-copyright {
   font-size: 12px;
-  color: #999;
+  color: var(--color-text-tertiary);
   margin: 8px 0;
 }
 
@@ -554,7 +554,7 @@ onMounted(() => {
 }
 
 .footer-beian a {
-  color: #999;
+  color: var(--color-text-tertiary);
   text-decoration: none;
 }
 

--- a/frontend/src/views/Info.vue
+++ b/frontend/src/views/Info.vue
@@ -266,7 +266,7 @@ onMounted(() => {
   overflow: hidden !important;
   display: flex;
   flex-direction: column;
-  background-color: #f6fbf6;
+  background-color: var(--color-bg-secondary);
 }
 .weui-tab__panel.info-container {
   flex: 1;
@@ -275,7 +275,7 @@ onMounted(() => {
   box-sizing: border-box;
   padding: 12px;
   padding-bottom: 60px;
-  background-color: #f6fbf6;
+  background-color: var(--color-bg-secondary);
   min-height: 100vh;
 }
 
@@ -286,12 +286,12 @@ onMounted(() => {
 .section-title {
   font-size: 18px;
   font-weight: 700;
-  color: #2f3b52;
+  color: var(--color-text-primary);
   margin: 4px 4px 12px;
 }
 
 .modern-card {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 12px;
   padding: 16px;
   margin-bottom: 16px;
@@ -310,7 +310,7 @@ onMounted(() => {
   gap: 12px;
   padding: 12px 0;
   border: none;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--color-divider);
   background: transparent;
   text-align: left;
   cursor: pointer;
@@ -342,13 +342,13 @@ onMounted(() => {
 .entry-link__title {
   font-size: 15px;
   font-weight: 600;
-  color: #333333;
+  color: var(--color-text-primary);
 }
 
 .entry-link__desc {
   margin-top: 4px;
   font-size: 13px;
-  color: #999999;
+  color: var(--color-text-tertiary);
 }
 
 .entry-link__ft {
@@ -362,7 +362,7 @@ onMounted(() => {
 
 .empty-card {
   font-size: 14px;
-  color: #999999;
+  color: var(--color-text-tertiary);
   text-align: center;
 }
 </style>

--- a/frontend/src/views/card/CardInfo.vue
+++ b/frontend/src/views/card/CardInfo.vue
@@ -184,7 +184,7 @@ onMounted(() => {
 
 <style scoped>
 .card-info-page {
-  background-color: #fff;
+  background-color: var(--color-surface);
   min-height: 100vh;
   padding-bottom: 32px;
 }
@@ -195,21 +195,21 @@ onMounted(() => {
   align-items: center;
   min-height: 44px;
   padding: 10px 15px;
-  background-color: #fff;
+  background-color: var(--color-surface);
   box-sizing: border-box;
 }
 
 .nav-btn-back {
   font-size: 16px;
   line-height: 24px;
-  color: #888;
+  color: var(--color-text-tertiary);
   cursor: pointer;
 }
 
 .page-header {
   text-align: center;
   padding: 0 0 6px;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .page-title-green {
@@ -223,7 +223,7 @@ onMounted(() => {
 .card-info-page .weui-cells__title {
   padding: 12px 15px 8px;
   font-size: 14px;
-  color: #888;
+  color: var(--color-text-tertiary);
 }
 
 .card-info-page .info-cells {
@@ -243,7 +243,7 @@ onMounted(() => {
   right: 15px;
   bottom: 0;
   height: 1px;
-  border-bottom: 1px solid #E5E5E5;
+  border-bottom: 1px solid var(--color-border);
   transform-origin: 0 100%;
   transform: scaleY(0.5);
 }
@@ -253,21 +253,21 @@ onMounted(() => {
 }
 
 .info-cell .weui-cell__bd {
-  color: #888;
+  color: var(--color-text-tertiary);
 }
 
 .info-label {
-  color: #888;
+  color: var(--color-text-tertiary);
 }
 
 .info-cell .weui-cell__ft {
-  color: #000;
+  color: var(--color-text-primary);
   text-align: right;
   flex-shrink: 0;
 }
 
 .info-value {
-  color: #000;
+  color: var(--color-text-primary);
 }
 
 .weui-toast__wrp--text {
@@ -282,7 +282,7 @@ onMounted(() => {
   margin-top: 32px;
   padding: 0 15px;
   font-size: 14px;
-  color: #888;
+  color: var(--color-text-tertiary);
   text-align: center;
 }
 
@@ -307,7 +307,7 @@ onMounted(() => {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 12px;
   width: 320px;
   overflow: hidden;
@@ -320,7 +320,7 @@ onMounted(() => {
 
 .weui-dialog__title {
   font-size: 17px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .weui-dialog__bd {
@@ -330,7 +330,7 @@ onMounted(() => {
 .weui-dialog__tip {
   margin: 0 0 12px;
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -338,31 +338,31 @@ onMounted(() => {
   width: 100%;
   padding: 12px;
   font-size: 15px;
-  border: 1px solid #e5e5e5;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   box-sizing: border-box;
 }
 
 .weui-dialog__ft {
   display: flex;
-  border-top: 1px solid #e5e5e5;
+  border-top: 1px solid var(--color-border);
 }
 
 .weui-dialog__btn {
   flex: 1;
   padding: 14px;
   text-align: center;
-  color: #333;
+  color: var(--color-text-primary);
   text-decoration: none;
   font-size: 17px;
 }
 
 .weui-dialog__btn_primary {
   color: var(--color-primary);
-  border-left: 1px solid #e5e5e5;
+  border-left: 1px solid var(--color-border);
 }
 
 .weui-dialog__btn_default {
-  color: #888;
+  color: var(--color-text-tertiary);
 }
 </style>

--- a/frontend/src/views/cet/Cet.vue
+++ b/frontend/src/views/cet/Cet.vue
@@ -266,7 +266,7 @@ onMounted(() => {
 
 <style scoped>
 .cet-page {
-  background-color: #fff;
+  background-color: var(--color-surface);
   min-height: 100vh;
   padding-bottom: 24px;
 }
@@ -277,14 +277,14 @@ onMounted(() => {
   align-items: center;
   min-height: 44px;
   padding: 10px 15px;
-  background-color: #fff;
+  background-color: var(--color-surface);
   box-sizing: border-box;
 }
 
 .nav-btn-back {
   font-size: 16px;
   line-height: 24px;
-  color: #888;
+  color: var(--color-text-tertiary);
   cursor: pointer;
 }
 
@@ -314,7 +314,7 @@ onMounted(() => {
   margin-top: 25px;
   text-align: center;
   font-size: 14px;
-  color: #888;
+  color: var(--color-text-tertiary);
 }
 
 .cet-page-desc__link {
@@ -327,7 +327,7 @@ onMounted(() => {
   height: 50px;
   display: block;
   cursor: pointer;
-  background: #f5f5f5;
+  background: var(--color-bg-secondary);
 }
 
 .weui-vcode-placeholder {
@@ -343,7 +343,7 @@ onMounted(() => {
 .cet-result-desc {
   text-align: center;
   font-size: 14px;
-  color: #888;
+  color: var(--color-text-tertiary);
   margin: 0 0 20px 0;
 }
 

--- a/frontend/src/views/grade/Grade.vue
+++ b/frontend/src/views/grade/Grade.vue
@@ -218,7 +218,7 @@ onMounted(() => {
 
 <style scoped>
 .grade-page {
-  background-color: #fff;
+  background-color: var(--color-surface);
   min-height: 100vh;
   padding-bottom: 24px;
 }
@@ -230,7 +230,7 @@ onMounted(() => {
   align-items: center;
   min-height: 44px;
   padding: 10px 15px;
-  background-color: #fff;
+  background-color: var(--color-surface);
   box-sizing: border-box;
 }
 
@@ -238,7 +238,7 @@ onMounted(() => {
 .nav-btn-more {
   font-size: 16px;
   line-height: 24px;
-  color: #888;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   flex-shrink: 0;
 }
@@ -256,8 +256,8 @@ onMounted(() => {
 .grade-navbar {
   display: flex;
   position: relative;
-  background-color: #fff;
-  border-bottom: 1px solid #e5e5e5;
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .grade-navbar__item {
@@ -265,14 +265,14 @@ onMounted(() => {
   padding: 16px 0;
   text-align: center;
   font-size: 17px;
-  color: #999;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   position: relative;
   -webkit-tap-highlight-color: transparent;
 }
 
 .grade-navbar__item_on {
-  color: #000;
+  color: var(--color-text-primary);
   font-weight: 600;
 }
 
@@ -306,7 +306,7 @@ onMounted(() => {
 .page_desc {
   margin: 0 0 8px;
   font-size: 14px;
-  color: #999;
+  color: var(--color-text-tertiary);
   text-align: center;
 }
 
@@ -323,9 +323,9 @@ onMounted(() => {
 
 .table thead th {
   font-weight: 600;
-  color: #000;
+  color: var(--color-text-primary);
   padding: 12px 8px;
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .table .col-course {
@@ -345,9 +345,9 @@ onMounted(() => {
 
 .table tbody td {
   padding: 12px 8px;
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid var(--color-border);
   font-size: 14px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .table tbody .col-course {

--- a/frontend/src/views/news/NewsList.vue
+++ b/frontend/src/views/news/NewsList.vue
@@ -160,14 +160,14 @@ onMounted(() => {
   overflow: hidden !important; /* 关键：锁死外层 */
   display: flex;
   flex-direction: column;
-  background-color: #f8f8f8; /* WEUI 默认底色 */
+  background-color: var(--color-bg-secondary); /* WEUI 默认底色 */
 }
 .page-header {
   flex-shrink: 0;
   padding: 12px 16px 16px;
 }
 .news-back {
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 15px;
   text-decoration: none;
 }
@@ -195,19 +195,19 @@ onMounted(() => {
   flex-shrink: 0;
   margin-left: 8px;
   font-size: 13px;
-  color: #999;
+  color: var(--color-text-tertiary);
 }
 .weui-loadmore {
   padding: 16px 0;
   text-align: center;
 }
 .weui-loadmore_line .weui-loadmore__tips {
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 .news-tabbar {
   flex-shrink: 0;
-  background: #f7f7fa;
-  border-top: 1px solid #e5e5e5;
+  background: var(--color-bg-secondary);
+  border-top: 1px solid var(--color-border);
 }
 .news-tabbar .weui-bar__item_on .weui-tabbar__label {
   color: var(--color-primary);

--- a/frontend/src/views/schedule/Schedule.vue
+++ b/frontend/src/views/schedule/Schedule.vue
@@ -334,7 +334,7 @@ onMounted(() => {
         :style="{
           gridColumn: idx + 2,
           gridRow: 1,
-          backgroundColor: idx === todayIndex ? 'rgba(9, 187, 7, 0.08)' : '#fff'
+          backgroundColor: idx === todayIndex ? 'rgba(9, 187, 7, 0.08)' : undefined
         }"
       >
         <span class="schedule-grid__head-label">{{ label }}</span>
@@ -358,7 +358,7 @@ onMounted(() => {
         :style="{
           gridColumn: (index % 7) + 2,
           gridRow: Math.floor(index / 7) + 2,
-          backgroundColor: (index % 7) === todayIndex ? 'rgba(9, 187, 7, 0.08)' : '#fcfdfe'
+          backgroundColor: (index % 7) === todayIndex ? 'rgba(9, 187, 7, 0.08)' : undefined
         }"
       ></div>
       <!-- 空状态：无课周时作为“超级格子”占据右侧全部区域，与节次列同级 -->
@@ -580,7 +580,7 @@ onMounted(() => {
 
 <style scoped>
 .schedule-page {
-  background-color: #fff;
+  background-color: var(--color-surface);
   min-height: 100vh;
   padding-bottom: 24px;
   width: 100%;
@@ -593,7 +593,7 @@ onMounted(() => {
   align-items: center;
   min-height: 44px;
   padding: 10px 15px;
-  background-color: #fff;
+  background-color: var(--color-surface);
   box-sizing: border-box;
 }
 
@@ -601,7 +601,7 @@ onMounted(() => {
 .nav-btn-more {
   font-size: 16px;
   line-height: 24px;
-  color: #888;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   flex-shrink: 0;
 }
@@ -635,7 +635,7 @@ onMounted(() => {
   padding: 8px 16px;
   border: 1px solid #fa5151;
   border-radius: 4px;
-  background: #fff;
+  background: var(--color-surface);
   color: #fa5151;
   font-size: 14px;
   text-align: center;
@@ -651,7 +651,7 @@ onMounted(() => {
   line-height: 1.2;
   text-align: center;
   margin-bottom: 10px;
-  color: #979797;
+  color: var(--color-text-tertiary);
   font-size: 14px;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
@@ -671,7 +671,7 @@ onMounted(() => {
   position: relative;
   width: 100%;
   min-height: 500px;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 /* 课表网格：纸质底色 #fcfdfe，极细网格线 */
@@ -682,30 +682,30 @@ onMounted(() => {
   width: 100%;
   min-height: 500px;
   position: relative;
-  background-color: #fcfdfe;
+  background-color: var(--color-bg-secondary);
 }
 
 .schedule-grid__cell {
-  border: 0.5px solid #f0f0f0;
+  border: 0.5px solid var(--color-divider);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 12px;
-  color: #5a5a5a;
-  background: #fcfdfe;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
   box-sizing: border-box;
 }
 
 .schedule-grid__cell--corner {
-  background: #fcfdfe;
+  background: var(--color-bg-secondary);
 }
 
 .schedule-grid__cell--head {
   padding: 8px 4px;
   font-size: 12px;
-  color: #333;
-  background: #fff;
-  border: 0.5px solid #f0f0f0;
+  color: var(--color-text-primary);
+  background: var(--color-surface);
+  border: 0.5px solid var(--color-divider);
   flex-direction: column;
   gap: 4px;
 }
@@ -730,17 +730,17 @@ onMounted(() => {
 
 /* 节次列：纯白背景、灰色文字，始终无高亮 */
 .schedule-grid__cell--index {
-  color: #5a5a5a;
+  color: var(--color-text-secondary);
   font-weight: 500;
-  background: #fff;
-  border: 0.5px solid #f0f0f0;
-  border-right: 1px solid #f2f2f2;
+  background: var(--color-surface);
+  border: 0.5px solid var(--color-divider);
+  border-right: 1px solid var(--color-divider);
   min-width: 30px;
 }
 
 .schedule-grid__cell--slot {
-  background: #fcfdfe;
-  border: 0.5px solid #f0f0f0;
+  background: var(--color-bg-secondary);
+  border: 0.5px solid var(--color-divider);
 }
 
 /* 今日整列：与内联 backgroundColor 双保险，任意星期今日列从第一行起全部显绿 */
@@ -793,7 +793,7 @@ onMounted(() => {
 .empty-state__text {
   margin: 20px 0 0 0;
   font-size: 16px;
-  color: #b0b0b0;
+  color: var(--color-text-tertiary);
   line-height: 1.4;
 }
 
@@ -831,7 +831,7 @@ onMounted(() => {
   transform: translate(-50%, -50%);
   width: calc(100% - 32px);
   max-width: 340px;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 8px;
   z-index: 5001;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
@@ -842,14 +842,14 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .schedule-detail-dialog__title {
   margin: 0;
   font-size: 17px;
   font-weight: 500;
-  color: #000;
+  color: var(--color-text-primary);
 }
 
 .schedule-detail-dialog__close {
@@ -871,12 +871,12 @@ onMounted(() => {
 }
 
 .schedule-detail-dialog__bd .weui-form-preview__label {
-  color: #999;
+  color: var(--color-text-tertiary);
   margin-right: 8px;
 }
 
 .schedule-detail-dialog__bd .weui-form-preview__value {
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 /* 周次选择器（WEUI Picker 风格：底部弹出） */
@@ -885,7 +885,7 @@ onMounted(() => {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 12px 12px 0 0;
   z-index: 5001;
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.1);
@@ -899,20 +899,20 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
 }
 
 .week-picker__cancel {
   font-size: 16px;
-  color: #888;
+  color: var(--color-text-tertiary);
   cursor: pointer;
 }
 
 .week-picker__title {
   font-size: 17px;
   font-weight: 500;
-  color: #000;
+  color: var(--color-text-primary);
 }
 
 .week-picker__placeholder {
@@ -928,13 +928,13 @@ onMounted(() => {
 .week-picker__item {
   padding: 14px 16px;
   font-size: 17px;
-  color: #333;
+  color: var(--color-text-primary);
   text-align: center;
   cursor: pointer;
 }
 
 .week-picker__item:active {
-  background: #f5f5f5;
+  background: var(--color-bg-secondary);
 }
 
 .week-picker__item--active {

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
## Summary
- Fix invisible text in dark mode: InteractionBlock, HistoryBlock, NoticeBlock
- About.vue, NewsList, Info, Schedule, Grade, CardInfo, Cet: replace hardcoded colors
- 10 files, ~125 color replacements

🤖 Generated with [Claude Code](https://claude.com/claude-code)