### PR TITLE
Fix upload path traversal, marketplace bucketing, topic search, and dating visibility

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/tools/SpringUtils/R2StorageService.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/SpringUtils/R2StorageService.java
@@ -116,6 +116,25 @@ public class R2StorageService {
         }
     }
 
+    private static final String TEMP_UPLOAD_PREFIX = "upload/";
+
+    /**
+     * 校验 sourceKey 是否为合法的临时上传路径。
+     * 仅允许以 "upload/" 开头且不含路径穿越字符的 key，防止攻击者通过
+     * 客户端提交任意 objectKey 来移动或删除其他用户的对象。
+     */
+    private void validateSourceKey(String sourceKey) {
+        if (sourceKey == null || sourceKey.isEmpty()) {
+            throw new IllegalArgumentException("sourceKey 不能为空");
+        }
+        if (sourceKey.contains("..")) {
+            throw new IllegalArgumentException("sourceKey 包含非法路径穿越字符: " + sourceKey);
+        }
+        if (!sourceKey.startsWith(TEMP_UPLOAD_PREFIX)) {
+            throw new IllegalArgumentException("sourceKey 必须位于临时上传目录 (upload/): " + sourceKey);
+        }
+    }
+
     /**
      * 复制对象并删除源对象，适用于前端先上传临时对象、后端再归档到业务路径。
      */
@@ -127,6 +146,7 @@ public class R2StorageService {
         if (!isEnabled()) {
             throw new FeatureNotEnabledException("对象存储未开启，无法归档上传文件");
         }
+        validateSourceKey(sourceKey);
         String resolvedBucket = resolveBucket(bucket);
         s3Client.copyObject(CopyObjectRequest.builder()
                 .sourceBucket(resolvedBucket)

--- a/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
@@ -49,6 +49,9 @@ public class DatingService {
     public DatingProfileVO queryDatingProfile(Integer id) throws DataNotExistException {
         DatingProfileEntity entity = datingMapper.selectDatingProfileById(id);
         if (entity == null) throw new DataNotExistException("该卖室友信息不存在");
+        if (entity.getState() != null && entity.getState() == 0) {
+            throw new DataNotExistException("该卖室友信息不存在");
+        }
         return profileEntityToVO(entity);
     }
 

--- a/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
@@ -67,11 +67,13 @@ public class DatingService {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         List<DatingProfileEntity> list = datingMapper.selectDatingProfileByUsername(user.getUsername());
         if (list == null) return new ArrayList<>();
-        return list.stream().map(e -> {
-            DatingProfileVO vo = profileEntityToVO(e);
-            vo.setPictureURL(getRoommateProfilePictureURL(e.getProfileId()));
-            return vo;
-        }).collect(Collectors.toList());
+        return list.stream()
+                .filter(e -> e.getState() == null || e.getState() != 0)
+                .map(e -> {
+                    DatingProfileVO vo = profileEntityToVO(e);
+                    vo.setPictureURL(getRoommateProfilePictureURL(e.getProfileId()));
+                    return vo;
+                }).collect(Collectors.toList());
     }
 
     public void updateRoommateProfile(DatingPublishDTO dto, Integer profileId) {

--- a/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
@@ -51,9 +51,9 @@ public class MarketplaceController {
             if (Integer.valueOf(1).equals(item.getState())) {
                 doing.add(item);
             } else if (Integer.valueOf(0).equals(item.getState())) {
-                sold.add(item);
-            } else if (Integer.valueOf(2).equals(item.getState())) {
                 off.add(item);
+            } else if (Integer.valueOf(2).equals(item.getState())) {
+                sold.add(item);
             }
         }
         Map<String, Object> data = new HashMap<>();

--- a/src/main/java/cn/gdeiassistant/core/topic/mapper/TopicMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/mapper/TopicMapper.java
@@ -40,7 +40,7 @@ public interface TopicMapper {
             "count(distinct tl.topic_id) as like_count " +
             "from topic t " +
             "left join topic_like tl on t.id=tl.topic_id " +
-            "where t.topic like concat(concat('%',#{keyword}),'%') group by t.id order by t.id limit #{start},#{size}")
+            "where (t.topic like concat(concat('%',#{keyword}),'%') or t.content like concat(concat('%',#{keyword}),'%')) group by t.id order by t.id limit #{start},#{size}")
     @ResultMap("Topic")
     List<TopicEntity> selectTopicPageByKeyword(@Param("start") int start, @Param("size") int size, @Param("username") String username, @Param("keyword") String keyword);
 

--- a/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
@@ -61,7 +61,15 @@ public class TopicService {
     public List<TopicVO> queryTopicByKeyword(String sessionId, int start, int size, String keyword) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         List<TopicEntity> list = topicMapper.selectTopicPageByKeyword(start, size, user.getUsername(), keyword);
-        return list == null || list.isEmpty() ? new ArrayList<>() : topicConverter.toVOList(list);
+        if (list == null || list.isEmpty()) return new ArrayList<>();
+        List<TopicVO> voList = new ArrayList<>();
+        for (TopicEntity e : list) {
+            if (e.getCount() != null && e.getCount() >= 1) {
+                e.setFirstImageUrl(downloadTopicItemPicture(e.getId(), 1));
+            }
+            voList.add(topicConverter.toVO(e));
+        }
+        return voList;
     }
 
     public List<TopicVO> queryMyTopicList(String sessionId, int start, int size) {

--- a/src/test/java/cn/gdeiassistant/contract/CommunitySummaryContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/CommunitySummaryContractTest.java
@@ -55,31 +55,31 @@ class CommunitySummaryContractTest {
         doingItem.setState(1);
         doingItem.setPictureURL(List.of("https://cdn.gdeiassistant.cn/ershou/101_1.jpg"));
 
-        MarketplaceItemEntity soldItem = new MarketplaceItemEntity();
-        soldItem.setId(102);
-        soldItem.setUsername("20231234");
-        soldItem.setName("二手风扇");
-        soldItem.setDescription("宿舍清仓");
-        soldItem.setPrice(25.0f);
-        soldItem.setLocation("白云校区");
-        soldItem.setType(5);
-        soldItem.setQq("654321");
-        soldItem.setPhone("13900139000");
-        soldItem.setState(0);
-        soldItem.setPictureURL(List.of("https://cdn.gdeiassistant.cn/ershou/102_1.jpg"));
-
         MarketplaceItemEntity offItem = new MarketplaceItemEntity();
-        offItem.setId(103);
+        offItem.setId(102);
         offItem.setUsername("20231234");
-        offItem.setName("旧教材");
-        offItem.setDescription("已停止出售");
-        offItem.setPrice(12.0f);
-        offItem.setLocation("花都校区");
-        offItem.setType(8);
-        offItem.setQq("777888");
-        offItem.setPhone("13700137000");
-        offItem.setState(2);
-        offItem.setPictureURL(List.of("https://cdn.gdeiassistant.cn/ershou/103_1.jpg"));
+        offItem.setName("二手风扇");
+        offItem.setDescription("宿舍清仓");
+        offItem.setPrice(25.0f);
+        offItem.setLocation("白云校区");
+        offItem.setType(5);
+        offItem.setQq("654321");
+        offItem.setPhone("13900139000");
+        offItem.setState(0);
+        offItem.setPictureURL(List.of("https://cdn.gdeiassistant.cn/ershou/102_1.jpg"));
+
+        MarketplaceItemEntity soldItem = new MarketplaceItemEntity();
+        soldItem.setId(103);
+        soldItem.setUsername("20231234");
+        soldItem.setName("旧教材");
+        soldItem.setDescription("已停止出售");
+        soldItem.setPrice(12.0f);
+        soldItem.setLocation("花都校区");
+        soldItem.setType(8);
+        soldItem.setQq("777888");
+        soldItem.setPhone("13700137000");
+        soldItem.setState(2);
+        soldItem.setPictureURL(List.of("https://cdn.gdeiassistant.cn/ershou/103_1.jpg"));
 
         when(marketplaceService.queryPersonalItems("session-1"))
                 .thenReturn(List.of(doingItem, soldItem, offItem));

--- a/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
@@ -94,6 +94,7 @@ class DatingContractTest {
 
         mockMvc.perform(get("/api/dating/profile/id/99"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(false));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(40401));
     }
 }

--- a/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
@@ -1,9 +1,11 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.dating.controller.DatingController;
 import cn.gdeiassistant.core.dating.pojo.vo.DatingPickVO;
 import cn.gdeiassistant.core.dating.pojo.vo.DatingProfileVO;
 import cn.gdeiassistant.core.dating.service.DatingService;
+import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +36,9 @@ class DatingContractTest {
     void setUp() {
         DatingController controller = new DatingController();
         ReflectionTestUtils.setField(controller, "datingService", datingService);
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -81,5 +85,15 @@ class DatingContractTest {
                 .andExpect(jsonPath("$.data.pictureURL").exists())
                 .andExpect(jsonPath("$.data.isContactVisible").value(false))
                 .andExpect(jsonPath("$.data.isPickNotAvailable").value(false));
+    }
+
+    @Test
+    void getProfileById_hiddenProfileReturnsDataNotExistError() throws Exception {
+        when(datingService.queryDatingProfile(Integer.valueOf(99)))
+                .thenThrow(new DataNotExistException("该卖室友信息不存在"));
+
+        mockMvc.perform(get("/api/dating/profile/id/99"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
     }
 }

--- a/src/test/resources/contracts/community-ershou-summary.success.json
+++ b/src/test/resources/contracts/community-ershou-summary.success.json
@@ -23,24 +23,6 @@
     ],
     "sold": [
       {
-        "id": 102,
-        "username": "20231234",
-        "name": "二手风扇",
-        "description": "宿舍清仓",
-        "price": 25.0,
-        "location": "白云校区",
-        "type": 5,
-        "qq": "654321",
-        "phone": "13900139000",
-        "state": 0,
-        "publishTime": null,
-        "pictureURL": [
-          "https://cdn.gdeiassistant.cn/ershou/102_1.jpg"
-        ]
-      }
-    ],
-    "off": [
-      {
         "id": 103,
         "username": "20231234",
         "name": "旧教材",
@@ -54,6 +36,24 @@
         "publishTime": null,
         "pictureURL": [
           "https://cdn.gdeiassistant.cn/ershou/103_1.jpg"
+        ]
+      }
+    ],
+    "off": [
+      {
+        "id": 102,
+        "username": "20231234",
+        "name": "二手风扇",
+        "description": "宿舍清仓",
+        "price": 25.0,
+        "location": "白云校区",
+        "type": 5,
+        "qq": "654321",
+        "phone": "13900139000",
+        "state": 0,
+        "publishTime": null,
+        "pictureURL": [
+          "https://cdn.gdeiassistant.cn/ershou/102_1.jpg"
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- **Security**: Validate objectKey in `R2StorageService.moveObject()` — only allow keys under `upload/` prefix, block path traversal (`..`), preventing arbitrary object move/delete
- **Marketplace**: Fix sold/off profile bucketing (`state=0` → off, `state=2` → sold), update contract test and snapshot
- **Topic search**: SQL now matches both title and content; search results populate `firstImageUrl` for Web thumbnails
- **Dating**: Filter hidden posts (`state=0`) at service layer for all clients; block detail access to hidden profiles with `DATA_NOT_EXIST` error; add regression test with `code=40401` assertion

## Test plan
- [x] `./gradlew test` — 127 tests passed, 0 failures
- [ ] Upload with non-`upload/` prefix objectKey is rejected
- [ ] Marketplace profile sold/off tabs show correct items
- [ ] Topic search matches content, results show thumbnails
- [ ] Hidden dating posts don't reappear on refresh or via detail API

🤖 Generated with [Claude Code](https://claude.com/claude-code)