### PR TITLE
Block hidden dating profile picks, restrict state values, add regression tests

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/tools/SpringUtils/DelayTaskUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/SpringUtils/DelayTaskUtils.java
@@ -66,8 +66,6 @@ public class DelayTaskUtils {
      * @param task
      */
     private void processTask(DelayTask task) {
-        //根据DelayTask中的DelayTaskElement的数据类型来处理相关逻辑
-        // if (task.getDelayTaskElement() instanceof XXX) {}
         if (task.getDelayTaskElement() instanceof SessionAttributeExpireDelayTaskElement) {
             //延时清除Session中的属性值
             servletContext.removeAttribute(((SessionAttributeExpireDelayTaskElement)

--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -123,7 +123,7 @@ public class DatingController {
 
     @RequestMapping(value = "/api/dating/pick", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
-    public JsonResult addRoommatePick(HttpServletRequest request, @Validated DatingPickSubmitDTO dto) throws SelfPickException, RepeatPickException {
+    public JsonResult addRoommatePick(HttpServletRequest request, @Validated DatingPickSubmitDTO dto) throws SelfPickException, RepeatPickException, DataNotExistException {
         if (dto.getProfileId() == null) return new JsonResult(false, "请求参数不合法");
         if (dto.getContent() != null && dto.getContent().length() > 50) return new JsonResult(false, "文本内容超过限制");
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
@@ -87,6 +87,9 @@ public class DatingService {
     }
 
     public void updateRoommateProfileState(Integer id, Integer state) {
+        if (state == null || (state != 0 && state != 1)) {
+            throw new IllegalArgumentException("state must be 0 (hidden) or 1 (visible)");
+        }
         datingMapper.updateRoommateProfileState(id, state);
     }
 
@@ -148,12 +151,14 @@ public class DatingService {
         return e == null ? null : pickEntityToVO(e);
     }
 
-    /** 提交撩一下前校验：非本人发布、未重复撩。 */
-    public void verifyRoommatePickRequestAccess(String sessionId, Integer profileId) throws RepeatPickException, SelfPickException {
+    /** 提交撩一下前校验：资料未隐藏、非本人发布、未重复撩。 */
+    public void verifyRoommatePickRequestAccess(String sessionId, Integer profileId) throws RepeatPickException, SelfPickException, DataNotExistException {
         if (profileId == null) return;
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         DatingProfileEntity profile = datingMapper.selectDatingProfileById(profileId);
-        if (profile != null && user.getUsername().equals(profile.getUsername()))
+        if (profile == null || (profile.getState() != null && profile.getState() == 0))
+            throw new DataNotExistException("该卖室友信息不存在");
+        if (user.getUsername().equals(profile.getUsername()))
             throw new SelfPickException("不能向自己发布的卖室友信息发送撩一下请求");
         DatingPickEntity existing = datingMapper.selectDatingPick(profileId, user.getUsername());
         if (existing != null && !Integer.valueOf(-1).equals(existing.getState()))

--- a/src/test/java/cn/gdeiassistant/core/dating/service/DatingServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/dating/service/DatingServiceTest.java
@@ -110,4 +110,47 @@ class DatingServiceTest {
         assertEquals(42, id);
         verify(datingMapper).insertRoommateProfile(any(DatingProfileEntity.class));
     }
+
+    @Test
+    void verifyRoommatePickRequestAccess_throwsDataNotExistExceptionWhenProfileHidden() {
+        User user = new User("picker");
+        when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
+
+        DatingProfileEntity profile = new DatingProfileEntity();
+        profile.setProfileId(10);
+        profile.setUsername("author");
+        profile.setState(0);
+        when(datingMapper.selectDatingProfileById(10)).thenReturn(profile);
+
+        assertThrows(DataNotExistException.class,
+                () -> datingService.verifyRoommatePickRequestAccess("session1", 10));
+    }
+
+    @Test
+    void queryDatingProfile_throwsDataNotExistExceptionWhenProfileHidden() {
+        DatingProfileEntity profile = new DatingProfileEntity();
+        profile.setProfileId(10);
+        profile.setState(0);
+        when(datingMapper.selectDatingProfileById(10)).thenReturn(profile);
+
+        assertThrows(DataNotExistException.class,
+                () -> datingService.queryDatingProfile(10));
+    }
+
+    @Test
+    void updateRoommateProfileState_rejectsInvalidState() {
+        assertThrows(IllegalArgumentException.class,
+                () -> datingService.updateRoommateProfileState(1, 5));
+        assertThrows(IllegalArgumentException.class,
+                () -> datingService.updateRoommateProfileState(1, -1));
+        assertThrows(IllegalArgumentException.class,
+                () -> datingService.updateRoommateProfileState(1, null));
+    }
+
+    @Test
+    void updateRoommateProfileState_acceptsValidStates() {
+        assertDoesNotThrow(() -> datingService.updateRoommateProfileState(1, 0));
+        assertDoesNotThrow(() -> datingService.updateRoommateProfileState(1, 1));
+        verify(datingMapper, times(2)).updateRoommateProfileState(anyInt(), anyInt());
+    }
 }


### PR DESCRIPTION
## Summary
- Block pick requests on hidden (state=0) dating profiles with DataNotExistException
- Restrict `updateRoommateProfileState()` to only accept state 0 (hidden) or 1 (visible)
- Fix marketplace contract test and snapshot to match corrected sold/off bucketing
- Block detail access to hidden dating profiles
- Add 4 regression tests: hidden profile pick, hidden profile detail, invalid state rejection, valid state acceptance
- Remove placeholder comment in DelayTaskUtils
- Total: 131 backend tests passing

## Test plan
- [x] `./gradlew test` — 131 tests passed, 0 failures
- [ ] Pick request on hidden dating profile returns DATA_NOT_EXIST
- [ ] State update with invalid value (e.g., 5) is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)