### PR TITLE
Fix sensitive data leaks, media atomicity, delivery UI, and photograph validation

### DIFF
--- a/frontend/src/views/delivery/Detail.vue
+++ b/frontend/src/views/delivery/Detail.vue
@@ -101,7 +101,9 @@ onMounted(async () => {
         pickupAddress: o.company ? `${o.company} 取件` : '取件',
         deliveryAddress: o.address || '',
         remarks: o.remarks,
-        description: o.remarks
+        description: o.remarks,
+        pickupCode: o.number || null,
+        contactPhone: o.phone || null
       }
       detailType.value = data.detailType
       trade.value = data.trade || null
@@ -134,7 +136,7 @@ onMounted(async () => {
             <span class="route-icon route-icon--pickup">取</span>
             <div class="route-content">
               <div class="route-text">{{ item.pickupAddress }}</div>
-              <div v-if="item.pickupCode && (isOwner() || isRunner() || item.status !== 0)" class="route-code">
+              <div v-if="item.pickupCode && (detailType === 0 || detailType === 3)" class="route-code">
                 取件码：{{ item.pickupCode }}
               </div>
               <div v-else-if="item.pickupCode" class="route-code">
@@ -146,7 +148,7 @@ onMounted(async () => {
             <span class="route-icon route-icon--delivery">送</span>
             <div class="route-content">
               <div class="route-text">{{ item.deliveryAddress }}</div>
-              <div v-if="item.contactPhone && (isOwner() || isRunner() || item.status !== 0)" class="route-phone">
+              <div v-if="item.contactPhone && (detailType === 0 || detailType === 3)" class="route-phone">
                 联系电话：{{ item.contactPhone }}
               </div>
               <div v-else-if="item.contactPhone" class="route-phone">

--- a/frontend/src/views/delivery/Home.vue
+++ b/frontend/src/views/delivery/Home.vue
@@ -6,7 +6,6 @@ import { useScrollLoad } from '../../composables/useScrollLoad'
 import CommunityHeader from '../../components/community/CommunityHeader.vue'
 
 const router = useRouter()
-const activeStatus = ref('all') // all, pending, delivering, completed
 const scrollContainer = ref({ get scrollTop() { return window.pageYOffset || document.documentElement.scrollTop } })
 
 const PAGE_SIZE = 10
@@ -29,12 +28,7 @@ const fetchDeliveryData = async (page) => {
 
 const { items: list, loading, finished, refreshing, pullY, loadData, handleTouchStart, handleTouchMove, handleTouchEnd } = useScrollLoad(fetchDeliveryData)
 
-function switchStatus(status) {
-  activeStatus.value = status
-  list.value = []
-  loadData(true)
-}
-// 后端列表接口暂无状态筛选，前端保留 Tab 切换 UI，数据仍为全部
+// 后端仅返回 state=0（待接单）订单，无需状态筛选
 
 function goDetail(id) {
   router.push(`/delivery/detail/${id}`)
@@ -85,34 +79,6 @@ onUnmounted(() => {
       <span v-if="refreshing" class="community-pull-refresh__text"><i class="community-loading-spinner"></i> 正在刷新...</span>
       <span v-else-if="pullY > 50" class="community-pull-refresh__text">释放立即刷新</span>
       <span v-else-if="pullY > 0" class="community-pull-refresh__text">下拉刷新</span>
-    </div>
-
-    <!-- 状态筛选 Tab -->
-    <div class="delivery-status-tabs">
-      <div
-        :class="['status-tab', { active: activeStatus === 'all' }]"
-        @click="switchStatus('all')"
-      >
-        全部
-      </div>
-      <div
-        :class="['status-tab', { active: activeStatus === 'pending' }]"
-        @click="switchStatus('pending')"
-      >
-        待接单
-      </div>
-      <div
-        :class="['status-tab', { active: activeStatus === 'delivering' }]"
-        @click="switchStatus('delivering')"
-      >
-        配送中
-      </div>
-      <div
-        :class="['status-tab', { active: activeStatus === 'completed' }]"
-        @click="switchStatus('completed')"
-      >
-        已完成
-      </div>
     </div>
 
     <!-- 任务卡片列表 -->
@@ -171,37 +137,6 @@ onUnmounted(() => {
   background: var(--c-bg);
   min-height: 100vh;
   --module-color: #f59e0b;
-}
-
-.delivery-status-tabs {
-  display: flex;
-  background: var(--c-card);
-  border-bottom: 1px solid var(--c-divider);
-  padding: 0 var(--space-lg);
-}
-.status-tab {
-  flex: 1;
-  text-align: center;
-  padding: var(--space-md) 0;
-  font-size: var(--font-md);
-  color: var(--c-text-2);
-  cursor: pointer;
-  position: relative;
-  transition: all 0.3s;
-}
-.status-tab.active {
-  color: var(--c-delivery);
-  font-weight: 500;
-}
-.status-tab.active::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: var(--c-delivery);
-  border-radius: 3px 3px 0 0;
 }
 
 .delivery-list {

--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -49,6 +49,10 @@ public class DatingController {
             isPickNotAvailable = datingService.checkIsPickPageHidden(sessionId, pick.getPickId());
             isContactVisible = isPickNotAvailable;
         }
+        if (!isContactVisible) {
+            profile.setQq(null);
+            profile.setWechat(null);
+        }
         Map<String, Object> data = new HashMap<>();
         data.put("profile", profile);
         data.put("pictureURL", pictureURL);

--- a/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
@@ -234,6 +234,11 @@ public class DatingService {
             DatingPickVO vo = pickEntityToVO(e);
             if (e.getRoommateProfile() != null && e.getRoommateProfile().getProfileId() != null)
                 vo.getRoommateProfile().setPictureURL(getRoommateProfilePictureURL(e.getRoommateProfile().getProfileId()));
+            // Only expose target's contact info if the pick has been accepted (state == 1)
+            if (!Integer.valueOf(1).equals(e.getState()) && vo.getRoommateProfile() != null) {
+                vo.getRoommateProfile().setQq(null);
+                vo.getRoommateProfile().setWechat(null);
+            }
             return vo;
         }).collect(Collectors.toList());
     }

--- a/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
@@ -37,11 +37,19 @@ public class DeliveryController {
         DeliveryOrderVO order = deliveryService.queryDeliveryOrderByOrderId(id);
         int detailType = deliveryService.queryDeliveryOrderDetailType(sessionId, id);
         Map<String, Object> data = new HashMap<>();
-        data.put("order", order);
         data.put("detailType", detailType);
-        if (order.getState() != null && !order.getState().equals(0)) {
-            DeliveryTradeVO trade = deliveryService.queryDeliveryTradeByOrderId(order.getOrderId());
-            data.put("trade", trade);
+        if (detailType == 1 || detailType == 2) {
+            // Unauthorized viewers: strip sensitive fields and omit trade info
+            order.setNumber(null);
+            order.setPhone(null);
+            data.put("order", order);
+        } else {
+            // Owner (0) or runner (3): return full data including trade
+            data.put("order", order);
+            if (order.getState() != null && !order.getState().equals(0)) {
+                DeliveryTradeVO trade = deliveryService.queryDeliveryTradeByOrderId(order.getOrderId());
+                data.put("trade", trade);
+            }
         }
         return new DataJsonResult<>(true, data);
     }

--- a/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
@@ -85,7 +85,7 @@ public class PhotographController {
     @RequestMapping(value = "/api/photograph/id/{id}/comment", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addPhotographComment(HttpServletRequest request, @PathVariable("id") Integer id
-            , @Validated @NotBlank @Length(min = 1, max = 50) String comment) {
+            , @Validated @NotBlank @Length(min = 1, max = 50) String comment) throws DataNotExistException {
         photographService.addPhotographComment(id, comment, (String) request.getAttribute("sessionId"));
         return new JsonResult(true);
     }
@@ -144,23 +144,28 @@ public class PhotographController {
         actual.setCount(count);
         actual.setType(dto.getType());
         int id = photographService.addPhotograph(actual, sessionId);
-        if (uploadedFileCount > 0) {
-            int imageIndex = 1;
-            for (MultipartFile image : images) {
-                if (image != null && !image.isEmpty() && image.getSize() > 0 && image.getSize() < ValueConstantUtils.MAX_IMAGE_SIZE) {
-                    photographService.uploadPhotographItemPicture(id, imageIndex++, image.getInputStream());
+        try {
+            if (uploadedFileCount > 0) {
+                int imageIndex = 1;
+                for (MultipartFile image : images) {
+                    if (image != null && !image.isEmpty() && image.getSize() > 0 && image.getSize() < ValueConstantUtils.MAX_IMAGE_SIZE) {
+                        photographService.uploadPhotographItemPicture(id, imageIndex++, image.getInputStream());
+                    }
+                }
+            } else if (uploadedKeyCount > 0) {
+                for (int i = 1; i <= imageKeys.length; i++) {
+                    photographService.movePhotographItemPictureFromTempObject(id, i, imageKeys[i - 1]);
                 }
             }
-        } else if (uploadedKeyCount > 0) {
-            for (int i = 1; i <= imageKeys.length; i++) {
-                photographService.movePhotographItemPictureFromTempObject(id, i, imageKeys[i - 1]);
-            }
+        } catch (Exception e) {
+            photographService.deletePhotograph(id);
+            return new JsonResult(false, "拍好校园图片上传失败");
         }
         return new JsonResult(true);
     }
 
     @RequestMapping(value = "/api/photograph/id/{id}/like", method = RequestMethod.POST)
-    public JsonResult LikePhotograph(HttpServletRequest request, @PathVariable("id") int id) {
+    public JsonResult LikePhotograph(HttpServletRequest request, @PathVariable("id") int id) throws DataNotExistException {
         photographService.LikePhotograph(id, (String) request.getAttribute("sessionId"));
         return new JsonResult(true);
     }

--- a/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
@@ -158,6 +158,7 @@ public class PhotographController {
                 }
             }
         } catch (Exception e) {
+            photographService.deletePhotographImages(id, count);
             photographService.deletePhotograph(id);
             return new JsonResult(false, "拍好校园图片上传失败");
         }

--- a/src/main/java/cn/gdeiassistant/core/photograph/mapper/PhotographMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/mapper/PhotographMapper.java
@@ -121,4 +121,11 @@ public interface PhotographMapper {
 
     @Insert("insert into photograph_like (photo_id,username,create_time) values(#{id},#{username},now())")
     void insertPhotographLike(@Param("id") int id, @Param("username") String username);
+
+    @Select("select count(id) from photograph where id=#{id}")
+    @ResultType(Integer.class)
+    Integer selectPhotographCountById(@Param("id") int id);
+
+    @Delete("delete from photograph where id=#{id}")
+    void deletePhotograph(@Param("id") int id);
 }

--- a/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
@@ -176,6 +176,14 @@ public class PhotographService {
         photographMapper.deletePhotograph(id);
     }
 
+    public void deletePhotographImages(int id, int count) {
+        for (int i = 1; i <= count; i++) {
+            try {
+                r2StorageService.deleteObject("gdeiassistant-userdata", "photograph/" + id + "_" + i + ".jpg");
+            } catch (Exception ignored) {}
+        }
+    }
+
     public String getPhotographItemPictureURL(int id, int index) {
         return r2StorageService.generatePresignedUrl("gdeiassistant-userdata", "photograph/" + id + "_" + index + ".jpg", 30, TimeUnit.MINUTES);
     }

--- a/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
@@ -127,9 +127,13 @@ public class PhotographService {
     }
 
     @Transactional("appTransactionManager")
-    public void addPhotographComment(int id, String comment, String sessionId) {
+    public void addPhotographComment(int id, String comment, String sessionId) throws DataNotExistException {
         if (comment == null || comment.trim().isEmpty() || comment.length() > 50) {
             throw new IllegalArgumentException("评论内容不能为空且不能超过 50 字");
+        }
+        Integer photographCount = photographMapper.selectPhotographCountById(id);
+        if (photographCount == null || photographCount == 0) {
+            throw new DataNotExistException("照片信息不存在");
         }
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         PhotographCommentEntity entity = new PhotographCommentEntity();
@@ -156,6 +160,7 @@ public class PhotographService {
             r2StorageService.uploadObject("gdeiassistant-userdata", "photograph/" + id + "_" + index + ".jpg", inputStream);
         } catch (Exception e) {
             logger.error("上传拍好校园图片失败，id={}, index={}", id, index, e);
+            throw new RuntimeException("拍好校园图片上传失败", e);
         } finally {
             if (inputStream != null) {
                 try { inputStream.close(); } catch (IOException ignored) {}
@@ -167,12 +172,20 @@ public class PhotographService {
         r2StorageService.moveObject("gdeiassistant-userdata", objectKey, "photograph/" + id + "_" + index + ".jpg");
     }
 
+    public void deletePhotograph(int id) {
+        photographMapper.deletePhotograph(id);
+    }
+
     public String getPhotographItemPictureURL(int id, int index) {
         return r2StorageService.generatePresignedUrl("gdeiassistant-userdata", "photograph/" + id + "_" + index + ".jpg", 30, TimeUnit.MINUTES);
     }
 
     @Transactional("appTransactionManager")
-    public void LikePhotograph(int id, String sessionId) {
+    public void LikePhotograph(int id, String sessionId) throws DataNotExistException {
+        Integer photographCount = photographMapper.selectPhotographCountById(id);
+        if (photographCount == null || photographCount == 0) {
+            throw new DataNotExistException("照片信息不存在");
+        }
         User user = userCertificateService.getUserLoginCertificate(sessionId);
         Integer count = photographMapper.selectPhotographLikeCountByPhotoIdAndUsername(id, user.getUsername());
         if (count == null || count == 0) {

--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -79,10 +79,15 @@ public class SecretController {
                 return new JsonResult(false, "语音文件大小过大");
             } else {
                 Integer id = secretService.addSecretInfo(sessionId, dto);
-                if (file != null && !file.isEmpty() && file.getSize() > 0) {
-                    secretService.uploadVoiceSecret(id, file.getInputStream());
-                } else {
-                    secretService.moveVoiceSecretFromTempObject(id, voiceKey);
+                try {
+                    if (file != null && !file.isEmpty() && file.getSize() > 0) {
+                        secretService.uploadVoiceSecret(id, file.getInputStream());
+                    } else {
+                        secretService.moveVoiceSecretFromTempObject(id, voiceKey);
+                    }
+                } catch (Exception e) {
+                    secretService.deleteSecretById(id);
+                    return new JsonResult(false, "语音上传失败");
                 }
                 return new JsonResult(true);
             }

--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -86,6 +86,7 @@ public class SecretController {
                         secretService.moveVoiceSecretFromTempObject(id, voiceKey);
                     }
                 } catch (Exception e) {
+                    secretService.deleteSecretVoice(id);
                     secretService.deleteSecretById(id);
                     return new JsonResult(false, "语音上传失败");
                 }

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -155,6 +155,10 @@ public class SecretService {
         return entity.getId();
     }
 
+    public void deleteSecretById(int id) {
+        secretMapper.deleteSecret(id);
+    }
+
     @Transactional("appTransactionManager")
     public void addSecretComment(int id, String sessionId, String comment) throws Exception {
         if (comment == null || comment.trim().isEmpty() || comment.length() > 50) {

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -159,6 +159,12 @@ public class SecretService {
         secretMapper.deleteSecret(id);
     }
 
+    public void deleteSecretVoice(int id) {
+        try {
+            r2StorageService.deleteObject("gdeiassistant-userdata", "secret/voice/" + id + ".mp3");
+        } catch (Exception ignored) {}
+    }
+
     @Transactional("appTransactionManager")
     public void addSecretComment(int id, String sessionId, String comment) throws Exception {
         if (comment == null || comment.trim().isEmpty() || comment.length() > 50) {

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -160,9 +160,12 @@ public class SecretService {
     }
 
     public void deleteSecretVoice(int id) {
-        try {
-            r2StorageService.deleteObject("gdeiassistant-userdata", "secret/voice/" + id + ".mp3");
-        } catch (Exception ignored) {}
+        String[] extensions = new String[]{".mp3", ".webm", ".ogg", ".wav", ".m4a", ".mp4"};
+        for (String ext : extensions) {
+            try {
+                r2StorageService.deleteObject("gdeiassistant-userdata", "secret/voice/" + id + ext);
+            } catch (Exception ignored) {}
+        }
     }
 
     @Transactional("appTransactionManager")

--- a/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
@@ -82,14 +82,19 @@ public class TopicController {
         String sessionId = (String) request.getAttribute("sessionId");
         dto.setCount(actualImageCount);
         TopicVO vo = topicService.addTopic(dto, sessionId);
-        if (images != null && images.length > 0) {
-            for (int i = 1; i <= images.length; i++) {
-                topicService.uploadTopicItemPicture(vo.getId(), i, images[i - 1].getInputStream());
+        try {
+            if (images != null && images.length > 0) {
+                for (int i = 1; i <= images.length; i++) {
+                    topicService.uploadTopicItemPicture(vo.getId(), i, images[i - 1].getInputStream());
+                }
+            } else if (imageKeys != null && imageKeys.length > 0) {
+                for (int i = 1; i <= imageKeys.length; i++) {
+                    topicService.moveTopicItemPictureFromTempObject(vo.getId(), i, imageKeys[i - 1]);
+                }
             }
-        } else if (imageKeys != null && imageKeys.length > 0) {
-            for (int i = 1; i <= imageKeys.length; i++) {
-                topicService.moveTopicItemPictureFromTempObject(vo.getId(), i, imageKeys[i - 1]);
-            }
+        } catch (Exception e) {
+            topicService.deleteTopic(vo.getId());
+            return new JsonResult(false, "话题图片上传失败");
         }
         return new JsonResult(true);
     }

--- a/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
@@ -93,6 +93,7 @@ public class TopicController {
                 }
             }
         } catch (Exception e) {
+            topicService.deleteTopicImages(vo.getId(), dto.getCount());
             topicService.deleteTopic(vo.getId());
             return new JsonResult(false, "话题图片上传失败");
         }

--- a/src/main/java/cn/gdeiassistant/core/topic/mapper/TopicMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/mapper/TopicMapper.java
@@ -69,6 +69,9 @@ public interface TopicMapper {
     @Insert("insert into topic_like (topic_id,username,create_time) values(#{topicId},#{username},now())")
     void insertTopicLike(@Param("topicId") int id, @Param("username") String username);
 
+    @Delete("delete from topic where id=#{id}")
+    void deleteTopic(@Param("id") int id);
+
     @Select("select tl.id,tl.topic_id,tl.username,tl.create_time from topic_like tl " +
             "inner join topic t on tl.topic_id=t.id where t.username=#{username} and tl.username!=#{username} " +
             "order by tl.create_time desc, tl.id desc limit #{start},#{size}")

--- a/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
@@ -156,4 +156,12 @@ public class TopicService {
     public void deleteTopic(int id) {
         topicMapper.deleteTopic(id);
     }
+
+    public void deleteTopicImages(int id, int count) {
+        for (int i = 1; i <= count; i++) {
+            try {
+                r2StorageService.deleteObject("gdeiassistant-userdata", "topic/" + id + "_" + i + ".jpg");
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
@@ -14,7 +14,6 @@ import cn.gdeiassistant.common.tools.SpringUtils.R2StorageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -137,12 +136,12 @@ public class TopicService {
         return r2StorageService.generatePresignedUrl("gdeiassistant-userdata", "topic/" + id + "_" + index + ".jpg", 90, TimeUnit.MINUTES);
     }
 
-    @Async
     public void uploadTopicItemPicture(int id, int index, InputStream inputStream) {
         try {
             r2StorageService.uploadObject("gdeiassistant-userdata", "topic/" + id + "_" + index + ".jpg", inputStream);
         } catch (Exception e) {
             logger.error("上传话题图片失败，id={}，index={}", id, index, e);
+            throw new RuntimeException("话题图片上传失败", e);
         } finally {
             if (inputStream != null) {
                 try { inputStream.close(); } catch (IOException ignored) {}
@@ -152,5 +151,9 @@ public class TopicService {
 
     public void moveTopicItemPictureFromTempObject(int id, int index, String objectKey) {
         r2StorageService.moveObject("gdeiassistant-userdata", objectKey, "topic/" + id + "_" + index + ".jpg");
+    }
+
+    public void deleteTopic(int id) {
+        topicMapper.deleteTopic(id);
     }
 }

--- a/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
@@ -52,7 +52,26 @@ class DeliveryContractTest {
     }
 
     @Test
-    void detailEndpointReturnsExpectedFields() throws Exception {
+    void detailEndpointReturnsFullFieldsForOwner() throws Exception {
+        DeliveryOrderVO order = mockDeliveryOrderVO();
+        order.setState(0);
+
+        when(deliveryService.queryDeliveryOrderByOrderId(1)).thenReturn(order);
+        when(deliveryService.queryDeliveryOrderDetailType("test-session", 1)).thenReturn(0);
+
+        mockMvc.perform(get("/api/delivery/order/id/1")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.order.orderId").exists())
+                .andExpect(jsonPath("$.data.order.number").value("SF123456"))
+                .andExpect(jsonPath("$.data.order.phone").value("13800138000"))
+                .andExpect(jsonPath("$.data.order.price").exists())
+                .andExpect(jsonPath("$.data.detailType").value(0));
+    }
+
+    @Test
+    void detailEndpointStripsSensitiveFieldsForThirdParty() throws Exception {
         DeliveryOrderVO order = mockDeliveryOrderVO();
         order.setState(0);
 
@@ -63,16 +82,10 @@ class DeliveryContractTest {
                         .requestAttr("sessionId", "test-session"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.order").exists())
                 .andExpect(jsonPath("$.data.order.orderId").exists())
-                .andExpect(jsonPath("$.data.order.name").exists())
-                .andExpect(jsonPath("$.data.order.number").exists())
-                .andExpect(jsonPath("$.data.order.phone").exists())
-                .andExpect(jsonPath("$.data.order.price").exists())
-                .andExpect(jsonPath("$.data.order.company").exists())
-                .andExpect(jsonPath("$.data.order.address").exists())
-                .andExpect(jsonPath("$.data.order.state").exists())
-                .andExpect(jsonPath("$.data.detailType").isNumber());
+                .andExpect(jsonPath("$.data.order.number").doesNotExist())
+                .andExpect(jsonPath("$.data.order.phone").doesNotExist())
+                .andExpect(jsonPath("$.data.detailType").value(1));
     }
 
     private static DeliveryOrderVO mockDeliveryOrderVO() {

--- a/src/test/java/cn/gdeiassistant/core/photograph/service/PhotographServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/photograph/service/PhotographServiceTest.java
@@ -71,8 +71,9 @@ class PhotographServiceTest {
     }
 
     @Test
-    void addPhotographComment_succeedsWithValidComment() {
+    void addPhotographComment_succeedsWithValidComment() throws DataNotExistException {
         User user = new User("testuser");
+        when(photographMapper.selectPhotographCountById(1)).thenReturn(1);
         when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
         when(photographMapper.selectPhotographByIdAndUsername(eq(1), eq("testuser")))
                 .thenReturn(null);
@@ -86,12 +87,33 @@ class PhotographServiceTest {
     }
 
     @Test
-    void uploadPhotographItemPicture_logsErrorButDoesNotThrowOnR2Failure() {
+    void addPhotographComment_throwsDataNotExistExceptionForNonExistentPhotograph() {
+        when(photographMapper.selectPhotographCountById(999)).thenReturn(0);
+
+        assertThrows(DataNotExistException.class,
+                () -> photographService.addPhotographComment(999, "nice photo", "session1"));
+
+        verify(photographMapper, never()).insertPhotographComment(any());
+    }
+
+    @Test
+    void likePhotograph_throwsDataNotExistExceptionForNonExistentPhotograph() {
+        when(photographMapper.selectPhotographCountById(999)).thenReturn(0);
+
+        assertThrows(DataNotExistException.class,
+                () -> photographService.LikePhotograph(999, "session1"));
+
+        verify(photographMapper, never()).insertPhotographLike(anyInt(), anyString());
+    }
+
+    @Test
+    void uploadPhotographItemPicture_throwsRuntimeExceptionOnR2Failure() {
         InputStream stream = new ByteArrayInputStream("fake".getBytes());
         doThrow(new RuntimeException("R2 unavailable"))
                 .when(r2StorageService).uploadObject(anyString(), anyString(), any(InputStream.class));
 
-        assertDoesNotThrow(() -> photographService.uploadPhotographItemPicture(1, 1, stream));
+        assertThrows(RuntimeException.class,
+                () -> photographService.uploadPhotographItemPicture(1, 1, stream));
     }
 
     @Test
@@ -106,8 +128,9 @@ class PhotographServiceTest {
     }
 
     @Test
-    void likePhotograph_insertsLikeForFirstTimeLiker() {
+    void likePhotograph_insertsLikeForFirstTimeLiker() throws DataNotExistException {
         User user = new User("testuser");
+        when(photographMapper.selectPhotographCountById(1)).thenReturn(1);
         when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
         when(photographMapper.selectPhotographLikeCountByPhotoIdAndUsername(1, "testuser"))
                 .thenReturn(0);


### PR DESCRIPTION
## Summary
- Strip phone/number/trade from delivery detail for unauthorized users
- Strip qq/wechat from dating profiles when not authorized; strip from sent picks unless accepted
- Fix Web delivery detail page (map number/phone, replace isOwner/isRunner with detailType)
- Remove misleading delivery hall status filter tabs (Web)
- Make topic/photograph/secret media publish atomic: clean up both R2 objects and DB records on failure
- Add photograph existence check before comment/like with tests
- Fix secret voice cleanup to cover all 6 supported audio formats

## Test plan
- [x] `./gradlew test` — 134 tests passed, 0 failures
- [ ] Delivery detail strips sensitive data for third-party viewers
- [ ] Dating contact info only visible when authorized
- [ ] Media upload failure cleans up both R2 and DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)