### PR TITLE
Secure cron endpoints and clean up dating profiles on account deletion

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/config/Application/ApplicationWebMvcConfig.java
+++ b/src/main/java/cn/gdeiassistant/common/config/Application/ApplicationWebMvcConfig.java
@@ -69,7 +69,7 @@ public class ApplicationWebMvcConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
                 .allowedOriginPatterns(resolveAllowedOriginPatterns())
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
-                .allowedHeaders("Authorization", "X-Client-Type", "Content-Type")
+                .allowedHeaders("Authorization", "X-Client-Type", "X-Cron-Secret", "Content-Type")
                 .allowCredentials(false)
                 .maxAge(3600);
     }

--- a/src/main/java/cn/gdeiassistant/common/constant/SettingConstantUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/constant/SettingConstantUtils.java
@@ -6,7 +6,7 @@ public class SettingConstantUtils {
     public static final String[] LOGIN_INTERCEPTOR_EXCEPTION_LIST = {
             "/login",
             "/logout",
-            "/cron",
+            // "/cron" — removed: cron endpoints now require X-Cron-Secret header authentication
             "/api/auth",
             "/api/module",
             "/download",

--- a/src/main/java/cn/gdeiassistant/core/cron/controller/CronController.java
+++ b/src/main/java/cn/gdeiassistant/core/cron/controller/CronController.java
@@ -1,14 +1,18 @@
 package cn.gdeiassistant.core.cron.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
 import cn.gdeiassistant.core.gradequery.service.GradeCronService;
 import cn.gdeiassistant.core.schedulequery.service.ScheduleCronService;
 import cn.gdeiassistant.core.information.service.SchoolNews.SchoolNewsCornService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
@@ -24,8 +28,36 @@ public class CronController {
     @Autowired(required = false)
     private SchoolNewsCornService schoolNewsCornService;
 
+    @Value("${app.cron.secret}")
+    private String cronSecret;
+
+    /**
+     * Validate the X-Cron-Secret header against the configured secret.
+     * Returns true if authentication passes, false if a 403 response was sent.
+     */
+    private boolean authenticateCron(String secret, HttpServletResponse response) throws IOException {
+        if (secret == null || !secret.equals(cronSecret)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().print("{\"code\":403,\"message\":\"Forbidden: invalid or missing X-Cron-Secret\"}");
+            response.getWriter().flush();
+            return false;
+        }
+        return true;
+    }
+
+    // TODO: These cron endpoints are fire-and-forget — they return success immediately
+    // while the underlying service methods may execute asynchronously. The response
+    // does not reflect whether the task actually completed successfully.
+
+    @RateLimit(maxRequests = 2, windowSeconds = 60)
     @RequestMapping(value = "/cron/grade", method = RequestMethod.GET)
-    public JsonResult cacheGradeData() {
+    public JsonResult cacheGradeData(@RequestHeader(value = "X-Cron-Secret", required = false) String secret,
+                                     HttpServletResponse response) throws IOException {
+        if (!authenticateCron(secret, response)) {
+            return null;
+        }
         if (gradeCronService != null) {
             gradeCronService.synchronizeGradeData();
             return new JsonResult(true);
@@ -33,8 +65,13 @@ public class CronController {
         return new JsonResult(false);
     }
 
+    @RateLimit(maxRequests = 2, windowSeconds = 60)
     @RequestMapping(value = "/cron/schedule", method = RequestMethod.GET)
-    public JsonResult cacheScheduleData() {
+    public JsonResult cacheScheduleData(@RequestHeader(value = "X-Cron-Secret", required = false) String secret,
+                                        HttpServletResponse response) throws IOException {
+        if (!authenticateCron(secret, response)) {
+            return null;
+        }
         if (scheduleCronService != null) {
             scheduleCronService.synchronizeScheduleData();
             return new JsonResult(true);
@@ -42,8 +79,13 @@ public class CronController {
         return new JsonResult(false);
     }
 
+    @RateLimit(maxRequests = 2, windowSeconds = 60)
     @RequestMapping(value = "/cron/news", method = RequestMethod.GET)
-    public JsonResult collectNews() throws InterruptedException, ExecutionException, IOException {
+    public JsonResult collectNews(@RequestHeader(value = "X-Cron-Secret", required = false) String secret,
+                                  HttpServletResponse response) throws InterruptedException, ExecutionException, IOException {
+        if (!authenticateCron(secret, response)) {
+            return null;
+        }
         if (schoolNewsCornService != null) {
             schoolNewsCornService.collectNews();
             return new JsonResult(true);

--- a/src/main/java/cn/gdeiassistant/core/dating/mapper/DatingMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/mapper/DatingMapper.java
@@ -127,4 +127,11 @@ public interface DatingMapper {
 
     @Delete("delete from dating_profile where profile_id=#{profileId}")
     void deleteRoommateProfile(@Param("profileId") int profileId);
+
+    /**
+     * Hide all dating profiles for a given user by setting state=0.
+     * Used during account deletion to clean up dating data.
+     */
+    @Update("update dating_profile set state=0 where username=#{username} and state=1")
+    void hideDatingProfilesByUsername(@Param("username") String username);
 }

--- a/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
+++ b/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
@@ -21,6 +21,7 @@ import cn.gdeiassistant.core.profile.mapper.ProfileMapper;
 import cn.gdeiassistant.core.user.mapper.UserMapper;
 import cn.gdeiassistant.core.user.pojo.entity.UserEntity;
 import cn.gdeiassistant.core.close.mapper.CloseMapper;
+import cn.gdeiassistant.core.dating.mapper.DatingMapper;
 import cn.gdeiassistant.core.profile.service.UserProfileService;
 import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
 import cn.gdeiassistant.common.tools.Utils.StringEncryptUtils;
@@ -74,6 +75,9 @@ public class AccountDeletionService {
     @Autowired
     private CloseMapper closeMapper;
 
+    @Autowired(required = false)
+    private DatingMapper datingMapper;
+
     /**
      * 关闭待处理的社区功能信息
      */
@@ -104,6 +108,10 @@ public class AccountDeletionService {
                     deliveryMapper.updateTradeState(deliveryTrade.getTradeId(), 0, 2);
                 }
             }
+        }
+        //隐藏用户的交友资料
+        if (datingMapper != null) {
+            datingMapper.hideDatingProfilesByUsername(username);
         }
     }
 
@@ -186,6 +194,10 @@ public class AccountDeletionService {
         //删除教务缓存信息
         gradeDao.removeGrade(user.getUsername());
         scheduleDao.removeSchedule(user.getUsername());
+        //隐藏用户的交友资料
+        if (datingMapper != null) {
+            datingMapper.hideDatingProfilesByUsername(user.getUsername());
+        }
         //删除用户资料信息
         profileMapper.resetUserProfile(user.getUsername(), "已注销");
         profileMapper.resetUserIntroduction(user.getUsername());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -186,6 +186,8 @@ trial:
 
 app:
   test-accounts: gdeiassistant
+  cron:
+    secret: ${CRON_SECRET:changeme-generate-a-real-secret}
   cors:
     allowed-origin-patterns: ${CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173}
 


### PR DESCRIPTION
## Summary
- Add `X-Cron-Secret` header authentication to all cron endpoints (grade/schedule/news sync), configured via `CRON_SECRET` env var
- Add `@RateLimit(maxRequests=2, windowSeconds=60)` to cron endpoints
- Remove `/cron` from auth interceptor exception list
- Hide dating profiles (`state=0`) during account deletion
- 141 backend tests passing

## Test plan
- [x] `./gradlew test` — 141 tests passed
- [ ] Cron endpoints return 403 without valid `X-Cron-Secret` header
- [ ] Account deletion hides user's dating profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)