### PR TITLE
Remove default cron secret, anonymize deleted accounts across all modules

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/tools/Utils/AnonymizeUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/Utils/AnonymizeUtils.java
@@ -1,0 +1,17 @@
+package cn.gdeiassistant.common.tools.Utils;
+
+/**
+ * Replaces internal deleted-account identifiers with a user-friendly label.
+ */
+public class AnonymizeUtils {
+
+    private static final String DELETED_PREFIX = "del_";
+    private static final String ANONYMOUS_LABEL = "已注销用户";
+
+    public static String sanitizeUsername(String username) {
+        if (username != null && username.startsWith(DELETED_PREFIX)) {
+            return ANONYMOUS_LABEL;
+        }
+        return username;
+    }
+}

--- a/src/main/java/cn/gdeiassistant/core/cron/controller/CronController.java
+++ b/src/main/java/cn/gdeiassistant/core/cron/controller/CronController.java
@@ -36,7 +36,7 @@ public class CronController {
      * Returns true if authentication passes, false if a 403 response was sent.
      */
     private boolean authenticateCron(String secret, HttpServletResponse response) throws IOException {
-        if (secret == null || !secret.equals(cronSecret)) {
+        if (cronSecret == null || cronSecret.isEmpty() || secret == null || !secret.equals(cronSecret)) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             response.setContentType("application/json");
             response.setCharacterEncoding("UTF-8");

--- a/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
+++ b/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
@@ -87,6 +87,9 @@ public class AccountDeletionService {
     @Autowired(required = false)
     private cn.gdeiassistant.core.photograph.mapper.PhotographMapper photographMapper;
 
+    @Autowired(required = false)
+    private cn.gdeiassistant.core.message.mapper.InteractionNotificationMapper interactionNotificationMapper;
+
     /**
      * 关闭待处理的社区功能信息
      */
@@ -229,6 +232,9 @@ public class AccountDeletionService {
         }
         if (photographMapper != null) {
             photographMapper.anonymizeUsername(user.getUsername(), deletedUsername);
+        }
+        if (interactionNotificationMapper != null) {
+            interactionNotificationMapper.anonymizeActorUsername(user.getUsername(), deletedUsername, "已注销用户");
         }
         userMapper.closeUser(deletedUsername, user.getUsername());
         //保存注销日志

--- a/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
+++ b/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
@@ -78,6 +78,15 @@ public class AccountDeletionService {
     @Autowired(required = false)
     private DatingMapper datingMapper;
 
+    @Autowired(required = false)
+    private cn.gdeiassistant.core.topic.mapper.TopicMapper topicMapper;
+
+    @Autowired(required = false)
+    private cn.gdeiassistant.core.secret.mapper.SecretMapper secretMapper;
+
+    @Autowired(required = false)
+    private cn.gdeiassistant.core.photograph.mapper.PhotographMapper photographMapper;
+
     /**
      * 关闭待处理的社区功能信息
      */
@@ -209,8 +218,19 @@ public class AccountDeletionService {
         Integer count = userMapper.selectDeletedUserCount("del_"
                 + StringEncryptUtils.sha1HexString(user.getUsername()).substring(0, 15));
         count = count == null ? 0 : count;
-        userMapper.closeUser("del_" + StringEncryptUtils.sha1HexString(user.getUsername())
-                .substring(0, 15) + "_" + count, user.getUsername());
+        String deletedUsername = "del_" + StringEncryptUtils.sha1HexString(user.getUsername())
+                .substring(0, 15) + "_" + count;
+        //匿名化社区内容的 username
+        if (topicMapper != null) {
+            topicMapper.anonymizeUsername(user.getUsername(), deletedUsername);
+        }
+        if (secretMapper != null) {
+            secretMapper.anonymizeUsername(user.getUsername(), deletedUsername);
+        }
+        if (photographMapper != null) {
+            photographMapper.anonymizeUsername(user.getUsername(), deletedUsername);
+        }
+        userMapper.closeUser(deletedUsername, user.getUsername());
         //保存注销日志
         SaveCloseLog(user.getUsername(), count);
     }

--- a/src/main/java/cn/gdeiassistant/core/message/mapper/InteractionNotificationMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/message/mapper/InteractionNotificationMapper.java
@@ -19,6 +19,13 @@ public interface InteractionNotificationMapper {
     @Options(useGeneratedKeys = true, keyProperty = "notificationId", keyColumn = "notification_id")
     void insertInteractionNotification(InteractionNotificationEntity entity);
 
+    @Update("update interaction_notification set actor_username=#{newUsername}, " +
+            "content=replace(content, #{oldUsername}, #{anonymousLabel}) " +
+            "where actor_username=#{oldUsername}")
+    void anonymizeActorUsername(@Param("oldUsername") String oldUsername,
+                                @Param("newUsername") String newUsername,
+                                @Param("anonymousLabel") String anonymousLabel);
+
     @Select("select notification_id,module,type,receiver_username,actor_username,target_id,target_sub_id,target_type,title,content,create_time,is_read " +
             "from interaction_notification where receiver_username=#{username} " +
             "order by create_time desc, notification_id desc limit #{start},#{size}")

--- a/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
+++ b/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
@@ -1,6 +1,7 @@
 package cn.gdeiassistant.core.message.service;
 
 import cn.gdeiassistant.common.pojo.Entity.User;
+import cn.gdeiassistant.common.tools.Utils.AnonymizeUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import cn.gdeiassistant.core.message.mapper.InteractionNotificationMapper;
 import cn.gdeiassistant.core.message.pojo.entity.InteractionNotificationEntity;
@@ -92,7 +93,7 @@ public class InteractionNotificationService {
         vo.setModule(normalizeModule(entity.getModule()));
         vo.setType(entity.getType());
         vo.setTitle(entity.getTitle());
-        vo.setContent(entity.getContent());
+        vo.setContent(anonymizeContent(entity.getContent(), entity.getActorUsername()));
         vo.setCreatedAt(formatDate(entity.getCreateTime()));
         vo.setIsRead(entity.getIsRead() != null && entity.getIsRead() != 0);
         vo.setTargetType(entity.getTargetType());
@@ -103,6 +104,13 @@ public class InteractionNotificationService {
 
     private String formatDate(java.util.Date value) {
         return value == null ? "" : value.toInstant().atZone(ZONE_ID).toLocalDateTime().format(DATETIME_FORMATTER);
+    }
+
+    private String anonymizeContent(String content, String actorUsername) {
+        if (content != null && actorUsername != null && actorUsername.startsWith("del_")) {
+            return content.replace(actorUsername, AnonymizeUtils.sanitizeUsername(actorUsername));
+        }
+        return content;
     }
 
     private String normalizeModule(String module) {

--- a/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
+++ b/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
@@ -81,7 +81,12 @@ public class InteractionNotificationService {
         }
         List<InteractionMessageVO> list = new ArrayList<>(entityList.size());
         for (InteractionNotificationEntity entity : entityList) {
-            if (deletedActors.contains(entity.getActorUsername())) {
+            String originalActor = entity.getActorUsername();
+            if (deletedActors.contains(originalActor)) {
+                // Replace original username in content, then mark actor as anonymous
+                if (entity.getContent() != null) {
+                    entity.setContent(entity.getContent().replace(originalActor, AnonymizeUtils.sanitizeUsername("del_")));
+                }
                 entity.setActorUsername("del_legacy");
             }
             list.add(toInteractionMessageVO(entity));

--- a/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
+++ b/src/main/java/cn/gdeiassistant/core/message/service/InteractionNotificationService.java
@@ -3,6 +3,7 @@ package cn.gdeiassistant.core.message.service;
 import cn.gdeiassistant.common.pojo.Entity.User;
 import cn.gdeiassistant.common.tools.Utils.AnonymizeUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
+import cn.gdeiassistant.core.user.mapper.UserMapper;
 import cn.gdeiassistant.core.message.mapper.InteractionNotificationMapper;
 import cn.gdeiassistant.core.message.pojo.entity.InteractionNotificationEntity;
 import cn.gdeiassistant.core.message.pojo.vo.InteractionMessageVO;
@@ -27,6 +28,9 @@ public class InteractionNotificationService {
 
     @Resource(name = "interactionNotificationMapper")
     private InteractionNotificationMapper interactionNotificationMapper;
+
+    @Autowired(required = false)
+    private UserMapper userMapper;
 
     public void createInteractionNotification(String module, String type, String receiverUsername, String actorUsername,
             String targetId, String targetSubId, String targetType, String title, String content) {
@@ -60,8 +64,26 @@ public class InteractionNotificationService {
         if (entityList == null || entityList.isEmpty()) {
             return new ArrayList<>();
         }
+        // Batch check which actor usernames are deleted (pre-fix historical data)
+        java.util.Set<String> deletedActors = new java.util.HashSet<>();
+        if (userMapper != null) {
+            java.util.Set<String> uniqueActors = new java.util.HashSet<>();
+            for (InteractionNotificationEntity e : entityList) {
+                if (e.getActorUsername() != null && !e.getActorUsername().startsWith("del_")) {
+                    uniqueActors.add(e.getActorUsername());
+                }
+            }
+            for (String actor : uniqueActors) {
+                if (userMapper.selectUser(actor) == null) {
+                    deletedActors.add(actor);
+                }
+            }
+        }
         List<InteractionMessageVO> list = new ArrayList<>(entityList.size());
         for (InteractionNotificationEntity entity : entityList) {
+            if (deletedActors.contains(entity.getActorUsername())) {
+                entity.setActorUsername("del_legacy");
+            }
             list.add(toInteractionMessageVO(entity));
         }
         return list;

--- a/src/main/java/cn/gdeiassistant/core/photograph/mapper/PhotographMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/mapper/PhotographMapper.java
@@ -128,4 +128,7 @@ public interface PhotographMapper {
 
     @Delete("delete from photograph where id=#{id}")
     void deletePhotograph(@Param("id") int id);
+
+    @Update("update photograph set username=#{newUsername} where username=#{oldUsername}")
+    void anonymizeUsername(@Param("oldUsername") String oldUsername, @Param("newUsername") String newUsername);
 }

--- a/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
@@ -13,6 +13,7 @@ import cn.gdeiassistant.core.photograph.pojo.vo.PhotographCommentVO;
 import cn.gdeiassistant.core.photograph.pojo.vo.PhotographVO;
 import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
 import cn.gdeiassistant.common.tools.SpringUtils.R2StorageService;
+import cn.gdeiassistant.common.tools.Utils.AnonymizeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,6 +71,7 @@ public class PhotographService {
         List<PhotographVO> result = new ArrayList<>();
         for (PhotographEntity e : list) {
             if (e.getId() == null) continue;
+            e.setUsername(AnonymizeUtils.sanitizeUsername(e.getUsername()));
             PhotographVO vo = photographConverter.toVO(e);
             vo.setFirstImageUrl(getPhotographItemPictureURL(e.getId(), 1));
             result.add(vo);
@@ -84,6 +86,7 @@ public class PhotographService {
         List<PhotographVO> result = new ArrayList<>();
         for (PhotographEntity e : list) {
             if (e.getId() == null) continue;
+            e.setUsername(AnonymizeUtils.sanitizeUsername(e.getUsername()));
             PhotographVO vo = photographConverter.toVO(e);
             if (e.getCount() != null && e.getCount() >= 1) {
                 vo.setFirstImageUrl(getPhotographItemPictureURL(e.getId(), 1));
@@ -100,6 +103,7 @@ public class PhotographService {
             throw new DataNotExistException("照片信息不存在");
         }
         PhotographEntity e = list.get(0);
+        e.setUsername(AnonymizeUtils.sanitizeUsername(e.getUsername()));
         PhotographVO vo = photographConverter.toVO(e);
         List<String> urls = new ArrayList<>();
         int count = e.getCount() != null ? e.getCount() : 0;
@@ -108,6 +112,7 @@ public class PhotographService {
         }
         vo.setImageUrls(urls);
         if (e.getPhotographCommentList() != null) {
+            e.getPhotographCommentList().forEach(c -> c.setUsername(AnonymizeUtils.sanitizeUsername(c.getUsername())));
             vo.setPhotographCommentList(photographCommentConverter.toVOList(e.getPhotographCommentList()));
         }
         return vo;
@@ -116,6 +121,7 @@ public class PhotographService {
     public List<PhotographCommentVO> queryPhotographCommentList(int id) {
         List<PhotographCommentEntity> list = photographMapper.selectPhotographCommentByPhotoId(id);
         if (list == null) return new ArrayList<>();
+        list.forEach(e -> e.setUsername(AnonymizeUtils.sanitizeUsername(e.getUsername())));
         return photographCommentConverter.toVOList(list);
     }
 

--- a/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
@@ -100,4 +100,7 @@ public interface SecretMapper {
 
     @Delete("delete from secret_like where content_id=#{content_id} and username=#{username}")
     void deleteSecretLike(@Param("content_id") int contentId, @Param("username") String username);
+
+    @Update("update secret_content set username=#{newUsername} where username=#{oldUsername}")
+    void anonymizeUsername(@Param("oldUsername") String oldUsername, @Param("newUsername") String newUsername);
 }

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -10,6 +10,7 @@ import cn.gdeiassistant.core.secret.pojo.entity.SecretCommentEntity;
 import cn.gdeiassistant.core.secret.pojo.entity.SecretContentEntity;
 import cn.gdeiassistant.core.secret.pojo.vo.SecretCommentVO;
 import cn.gdeiassistant.core.secret.pojo.vo.SecretVO;
+import cn.gdeiassistant.common.tools.Utils.AnonymizeUtils;
 import cn.gdeiassistant.core.message.service.InteractionNotificationService;
 import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
 import cn.gdeiassistant.common.tools.SpringUtils.R2StorageService;
@@ -59,6 +60,7 @@ public class SecretService {
         }
         List<SecretVO> result = new ArrayList<>();
         for (SecretContentEntity entity : list) {
+            entity.setUsername(AnonymizeUtils.sanitizeUsername(entity.getUsername()));
             SecretVO vo = secretConverter.toVO(entity);
             vo.setCommentCount(secretMapper.selectSecretCommentCount(entity.getId()));
             vo.setLikeCount(secretMapper.selectSecretLikeCount(entity.getId()));
@@ -74,12 +76,14 @@ public class SecretService {
         if (list == null || list.isEmpty()) {
             return new ArrayList<>();
         }
+        list.forEach(e -> e.setUsername(AnonymizeUtils.sanitizeUsername(e.getUsername())));
         return secretConverter.toVOList(list);
     }
 
     public List<SecretCommentVO> getSecretComments(int contentId) throws Exception {
         List<SecretCommentEntity> list = secretMapper.selectSecretCommentsByContentId(contentId);
         if (list == null) return new ArrayList<>();
+        list.forEach(e -> e.setUsername(AnonymizeUtils.sanitizeUsername(e.getUsername())));
         return secretCommentConverter.toVOList(list);
     }
 
@@ -138,6 +142,7 @@ public class SecretService {
         if (entity == null) {
             throw new DataNotExistException("查询的树洞消息不存在");
         }
+        entity.setUsername(AnonymizeUtils.sanitizeUsername(entity.getUsername()));
         SecretVO vo = secretConverter.toVO(entity);
         if (entity.getType() != null && entity.getType() == 1) {
             vo.setVoiceURL(getSecretVoiceURL(entity.getId()));

--- a/src/main/java/cn/gdeiassistant/core/topic/mapper/TopicMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/mapper/TopicMapper.java
@@ -72,6 +72,9 @@ public interface TopicMapper {
     @Delete("delete from topic where id=#{id}")
     void deleteTopic(@Param("id") int id);
 
+    @Update("update topic set username=#{newUsername} where username=#{oldUsername}")
+    void anonymizeUsername(@Param("oldUsername") String oldUsername, @Param("newUsername") String newUsername);
+
     @Select("select tl.id,tl.topic_id,tl.username,tl.create_time from topic_like tl " +
             "inner join topic t on tl.topic_id=t.id where t.username=#{username} and tl.username!=#{username} " +
             "order by tl.create_time desc, tl.id desc limit #{start},#{size}")

--- a/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
@@ -11,6 +11,7 @@ import cn.gdeiassistant.core.topic.pojo.entity.TopicLikeEntity;
 import cn.gdeiassistant.core.topic.pojo.vo.TopicVO;
 import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
 import cn.gdeiassistant.common.tools.SpringUtils.R2StorageService;
+import cn.gdeiassistant.common.tools.Utils.AnonymizeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +53,7 @@ public class TopicService {
             if (e.getCount() != null && e.getCount() >= 1) {
                 e.setFirstImageUrl(downloadTopicItemPicture(e.getId(), 1));
             }
+            sanitizeEntity(e);
             voList.add(topicConverter.toVO(e));
         }
         return voList;
@@ -66,6 +68,7 @@ public class TopicService {
             if (e.getCount() != null && e.getCount() >= 1) {
                 e.setFirstImageUrl(downloadTopicItemPicture(e.getId(), 1));
             }
+            sanitizeEntity(e);
             voList.add(topicConverter.toVO(e));
         }
         return voList;
@@ -80,6 +83,7 @@ public class TopicService {
             if (e.getCount() != null && e.getCount() >= 1) {
                 e.setFirstImageUrl(downloadTopicItemPicture(e.getId(), 1));
             }
+            sanitizeEntity(e);
             voList.add(topicConverter.toVO(e));
         }
         return voList;
@@ -96,6 +100,7 @@ public class TopicService {
             }
             entity.setImageUrls(urls);
         }
+        sanitizeEntity(entity);
         return topicConverter.toVO(entity);
     }
 
@@ -129,6 +134,7 @@ public class TopicService {
         entity.setContent(dto.getContent());
         entity.setCount(dto.getCount());
         topicMapper.insertTopic(entity);
+        sanitizeEntity(entity);
         return topicConverter.toVO(entity);
     }
 
@@ -155,6 +161,10 @@ public class TopicService {
 
     public void deleteTopic(int id) {
         topicMapper.deleteTopic(id);
+    }
+
+    private void sanitizeEntity(TopicEntity e) {
+        e.setUsername(AnonymizeUtils.sanitizeUsername(e.getUsername()));
     }
 
     public void deleteTopicImages(int id, int count) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -187,7 +187,7 @@ trial:
 app:
   test-accounts: gdeiassistant
   cron:
-    secret: ${CRON_SECRET:changeme-generate-a-real-secret}
+    secret: ${CRON_SECRET:}
   cors:
     allowed-origin-patterns: ${CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:5173,http://127.0.0.1:5173,http://localhost:4173,http://127.0.0.1:4173}
 


### PR DESCRIPTION
## Summary
- Remove hardcoded default from `CRON_SECRET` — empty value blocks all cron requests
- Anonymize deleted-account usernames in topic/secret/photograph API responses via `AnonymizeUtils.sanitizeUsername()`
- Update `AccountDeletionService` to anonymize usernames in topic, secret, photograph, and interaction_notification tables
- Handle historical pre-fix deleted accounts in notification read path: batch-check user existence, replace original username in content before marking actor
- Total: 141 backend tests passing

## Test plan
- [x] `./gradlew test` — 141 tests passed
- [ ] Cron endpoints reject requests when `CRON_SECRET` env var is not set
- [ ] Deleted account content shows "已注销用户" instead of internal `del_*` identifier
- [ ] Historical notifications from pre-fix deleted accounts also show "已注销用户"

🤖 Generated with [Claude Code](https://claude.com/claude-code)