### PR TITLE
Security hardening: JWT secret, encryption fail-fast, Redis password encryption, request log redaction, express anonymization

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/aspect/RequestLogAspect.java
+++ b/src/main/java/cn/gdeiassistant/common/aspect/RequestLogAspect.java
@@ -1,5 +1,7 @@
 package cn.gdeiassistant.common.aspect;
 
+import cn.gdeiassistant.common.pojo.Entity.RequestSecurity;
+import cn.gdeiassistant.common.pojo.Entity.RequestValidation;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import com.alibaba.fastjson2.JSON;
 import org.aspectj.lang.JoinPoint;
@@ -50,8 +52,12 @@ public class RequestLogAspect {
                 if (i != 1) {
                     stringBuilder.append(" , ");
                 }
-                stringBuilder.append(parameterName[i])
-                        .append(":").append(JSON.toJSONString(args[i]));
+                if (args[i] instanceof RequestValidation || args[i] instanceof RequestSecurity) {
+                    stringBuilder.append(parameterName[i]).append(":[REDACTED]");
+                } else {
+                    stringBuilder.append(parameterName[i])
+                            .append(":").append(JSON.toJSONString(args[i]));
+                }
             }
         }
         stringBuilder.append(" . ");

--- a/src/main/java/cn/gdeiassistant/common/config/Encryption/StringEncryptionConfig.java
+++ b/src/main/java/cn/gdeiassistant/common/config/Encryption/StringEncryptionConfig.java
@@ -71,6 +71,14 @@ public class StringEncryptionConfig implements EnvironmentAware {
             }
         }
         //安全加密功能模块未启用
+        //生产环境下拒绝启动，防止敏感字段静默落成明文
+        for (String profile : environment.getActiveProfiles()) {
+            if ("production".equalsIgnoreCase(profile) || "prod".equalsIgnoreCase(profile)) {
+                throw new IllegalStateException(
+                        "Field encryption must be enabled in production. " +
+                        "Set ENCRYPT_ENABLE=true and ENCRYPT_PRIVATE_KEY in environment.");
+            }
+        }
         return null;
     }
 

--- a/src/main/java/cn/gdeiassistant/common/pojo/Config/JWTConfig.java
+++ b/src/main/java/cn/gdeiassistant/common/pojo/Config/JWTConfig.java
@@ -17,9 +17,11 @@ public class JWTConfig {
     @Autowired
     private ModuleUtils moduleUtils;
 
+    private static final String INSECURE_PLACEHOLDER = "YOUR_SECURE_JWT_SECRET_AT_LEAST_32_CHARS";
+
     @Value("${jwt.secret:}")
     public void setSecret(String secret) {
-        if (StringUtils.isNotBlank(secret)) {
+        if (StringUtils.isNotBlank(secret) && !INSECURE_PLACEHOLDER.equals(secret)) {
             this.secret = secret;
         } else {
             moduleUtils.DisableModule(ModuleEnum.JWT);

--- a/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
+++ b/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
@@ -45,7 +45,11 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
             Map<String, String> map = objectMapper.readValue(json, MAP_STRING_STRING);
             User user = new User();
             user.setUsername(map.get("username"));
-            user.setPassword(map.get("password"));
+            try {
+                user.setPassword(StringEncryptUtils.decryptString(map.get("password")));
+            } catch (Exception e2) {
+                user.setPassword(map.get("password"));
+            }
             return user;
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Redis 登录凭证反序列化失败", e);
@@ -56,7 +60,11 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
     public void saveUserCookieCertificate(String cookieId, String username, String password) {
         Map<String, String> map = new HashMap<>();
         map.put("username", username);
-        map.put("password", password);
+        try {
+            map.put("password", StringEncryptUtils.encryptString(password));
+        } catch (Exception e) {
+            map.put("password", password);
+        }
         String key = StringEncryptUtils.sha256HexString(COOKIE_PREFIX + cookieId);
         try {
             redisDaoUtils.set(key, objectMapper.writeValueAsString(map));
@@ -81,7 +89,11 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
                     Map<String, String> map = objectMapper.readValue(json, MAP_STRING_STRING);
                     User user = new User();
                     user.setUsername(map.get("username"));
-                    user.setPassword(map.get("password"));
+                    try {
+                        user.setPassword(StringEncryptUtils.decryptString(map.get("password")));
+                    } catch (Exception e2) {
+                        user.setPassword(map.get("password"));
+                    }
                     return user;
                 }
             } catch (Exception e) {
@@ -111,7 +123,11 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
         if (redisTemplate == null) return;
         Map<String, String> map = new HashMap<>();
         map.put("username", username);
-        map.put("password", password);
+        try {
+            map.put("password", StringEncryptUtils.encryptString(password));
+        } catch (Exception e) {
+            map.put("password", password);
+        }
         String finalKey = StringEncryptUtils.sha256HexString(LOGIN_PREFIX + sessionId);
         try {
             redisTemplate.opsForValue().set(finalKey, objectMapper.writeValueAsString(map));
@@ -131,7 +147,11 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
             UserCertificateEntity entity = new UserCertificateEntity();
             User user = new User();
             user.setUsername(map.get("username"));
-            user.setPassword(map.get("password"));
+            try {
+                user.setPassword(StringEncryptUtils.decryptString(map.get("password")));
+            } catch (Exception e2) {
+                user.setPassword(map.get("password"));
+            }
             entity.setUser(user);
             entity.setKeycode(map.get("keycode"));
             entity.setNumber(map.get("number"));
@@ -146,7 +166,11 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
     public void saveUserSessionCertificate(String sessionId, UserCertificateEntity userCertificate) {
         Map<String, String> map = new HashMap<>();
         map.put("username", userCertificate.getUser().getUsername());
-        map.put("password", userCertificate.getUser().getPassword());
+        try {
+            map.put("password", StringEncryptUtils.encryptString(userCertificate.getUser().getPassword()));
+        } catch (Exception e) {
+            map.put("password", userCertificate.getUser().getPassword());
+        }
         map.put("keycode", userCertificate.getKeycode());
         map.put("number", userCertificate.getNumber());
         map.put("timestamp", String.valueOf(userCertificate.getTimestamp()));

--- a/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
+++ b/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -28,6 +29,37 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
     private final String SESSION_PREFIX = "USER_SESSION_CERTIFICATE_";
 
     @Autowired
+    private Environment environment;
+
+    private boolean isProduction() {
+        for (String profile : environment.getActiveProfiles()) {
+            if ("production".equalsIgnoreCase(profile) || "prod".equalsIgnoreCase(profile)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String encryptPassword(String password) {
+        try {
+            return StringEncryptUtils.encryptString(password);
+        } catch (Exception e) {
+            if (isProduction()) {
+                throw new RuntimeException("Password encryption failed in production", e);
+            }
+            return password;
+        }
+    }
+
+    private String decryptPassword(String encrypted) {
+        try {
+            return StringEncryptUtils.decryptString(encrypted);
+        } catch (Exception e) {
+            return encrypted;
+        }
+    }
+
+    @Autowired
     private RedisDaoUtils redisDaoUtils;
 
     @Autowired
@@ -45,11 +77,7 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
             Map<String, String> map = objectMapper.readValue(json, MAP_STRING_STRING);
             User user = new User();
             user.setUsername(map.get("username"));
-            try {
-                user.setPassword(StringEncryptUtils.decryptString(map.get("password")));
-            } catch (Exception e2) {
-                user.setPassword(map.get("password"));
-            }
+            user.setPassword(decryptPassword(map.get("password")));
             return user;
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Redis 登录凭证反序列化失败", e);
@@ -60,11 +88,7 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
     public void saveUserCookieCertificate(String cookieId, String username, String password) {
         Map<String, String> map = new HashMap<>();
         map.put("username", username);
-        try {
-            map.put("password", StringEncryptUtils.encryptString(password));
-        } catch (Exception e) {
-            map.put("password", password);
-        }
+        map.put("password", encryptPassword(password));
         String key = StringEncryptUtils.sha256HexString(COOKIE_PREFIX + cookieId);
         try {
             redisDaoUtils.set(key, objectMapper.writeValueAsString(map));
@@ -123,11 +147,7 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
         if (redisTemplate == null) return;
         Map<String, String> map = new HashMap<>();
         map.put("username", username);
-        try {
-            map.put("password", StringEncryptUtils.encryptString(password));
-        } catch (Exception e) {
-            map.put("password", password);
-        }
+        map.put("password", encryptPassword(password));
         String finalKey = StringEncryptUtils.sha256HexString(LOGIN_PREFIX + sessionId);
         try {
             redisTemplate.opsForValue().set(finalKey, objectMapper.writeValueAsString(map));
@@ -147,11 +167,7 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
             UserCertificateEntity entity = new UserCertificateEntity();
             User user = new User();
             user.setUsername(map.get("username"));
-            try {
-                user.setPassword(StringEncryptUtils.decryptString(map.get("password")));
-            } catch (Exception e2) {
-                user.setPassword(map.get("password"));
-            }
+            user.setPassword(decryptPassword(map.get("password")));
             entity.setUser(user);
             entity.setKeycode(map.get("keycode"));
             entity.setNumber(map.get("number"));
@@ -166,11 +182,7 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
     public void saveUserSessionCertificate(String sessionId, UserCertificateEntity userCertificate) {
         Map<String, String> map = new HashMap<>();
         map.put("username", userCertificate.getUser().getUsername());
-        try {
-            map.put("password", StringEncryptUtils.encryptString(userCertificate.getUser().getPassword()));
-        } catch (Exception e) {
-            map.put("password", userCertificate.getUser().getPassword());
-        }
+        map.put("password", encryptPassword(userCertificate.getUser().getPassword()));
         map.put("keycode", userCertificate.getKeycode());
         map.put("number", userCertificate.getNumber());
         map.put("timestamp", String.valueOf(userCertificate.getTimestamp()));

--- a/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
+++ b/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
@@ -113,11 +113,7 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
                     Map<String, String> map = objectMapper.readValue(json, MAP_STRING_STRING);
                     User user = new User();
                     user.setUsername(map.get("username"));
-                    try {
-                        user.setPassword(StringEncryptUtils.decryptString(map.get("password")));
-                    } catch (Exception e2) {
-                        user.setPassword(map.get("password"));
-                    }
+                    user.setPassword(decryptPassword(map.get("password")));
                     return user;
                 }
             } catch (Exception e) {

--- a/src/main/java/cn/gdeiassistant/common/tools/Utils/JwtUtil.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/Utils/JwtUtil.java
@@ -34,7 +34,15 @@ public class JwtUtil {
      * @param username  用户唯一标识（学号/校园网账号）
      * @return JWT 字符串
      */
+    private void ensureSecretConfigured() {
+        String secret = jwtConfig.getSecret();
+        if (secret == null || secret.isEmpty()) {
+            throw new IllegalStateException("JWT secret is not configured. Set the JWT_SECRET environment variable.");
+        }
+    }
+
     public String createToken(String sessionId, String username) {
+        ensureSecretConfigured();
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expireTime = now.plusDays(EXPIRE_DAYS);
         return JWT.create()
@@ -54,6 +62,7 @@ public class JwtUtil {
      * @throws JWTVerificationException 签名无效或已过期
      */
     public Map<String, Claim> verifyAndParse(String token) throws JWTVerificationException {
+        ensureSecretConfigured();
         JWTVerifier verifier = JWT.require(Algorithm.HMAC256(jwtConfig.getSecret()))
                 .withIssuer(ISSUER)
                 .build();

--- a/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
+++ b/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
@@ -241,6 +241,7 @@ public class AccountDeletionService {
         }
         if (expressMapper != null) {
             expressMapper.anonymizeByUsername(user.getUsername(), deletedUsername);
+            expressMapper.anonymizeCommentsByUsername(user.getUsername(), deletedUsername);
         }
         userMapper.closeUser(deletedUsername, user.getUsername());
         //保存注销日志

--- a/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
+++ b/src/main/java/cn/gdeiassistant/core/deletion/service/AccountDeletionService.java
@@ -90,6 +90,9 @@ public class AccountDeletionService {
     @Autowired(required = false)
     private cn.gdeiassistant.core.message.mapper.InteractionNotificationMapper interactionNotificationMapper;
 
+    @Autowired(required = false)
+    private cn.gdeiassistant.core.express.mapper.ExpressMapper expressMapper;
+
     /**
      * 关闭待处理的社区功能信息
      */
@@ -235,6 +238,9 @@ public class AccountDeletionService {
         }
         if (interactionNotificationMapper != null) {
             interactionNotificationMapper.anonymizeActorUsername(user.getUsername(), deletedUsername, "已注销用户");
+        }
+        if (expressMapper != null) {
+            expressMapper.anonymizeByUsername(user.getUsername(), deletedUsername);
         }
         userMapper.closeUser(deletedUsername, user.getUsername());
         //保存注销日志

--- a/src/main/java/cn/gdeiassistant/core/express/mapper/ExpressMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/express/mapper/ExpressMapper.java
@@ -155,4 +155,7 @@ public interface ExpressMapper {
 
     @Update("update express set username=#{newUsername}, nickname='已注销用户', realname=null where username=#{oldUsername}")
     void anonymizeByUsername(@Param("oldUsername") String oldUsername, @Param("newUsername") String newUsername);
+
+    @Update("update express_comment set username=#{newUsername} where username=#{oldUsername}")
+    void anonymizeCommentsByUsername(@Param("oldUsername") String oldUsername, @Param("newUsername") String newUsername);
 }

--- a/src/main/java/cn/gdeiassistant/core/express/mapper/ExpressMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/express/mapper/ExpressMapper.java
@@ -152,4 +152,7 @@ public interface ExpressMapper {
     @ResultMap("expressComment")
     List<ExpressComment> selectReceivedExpressCommentPage(@Param("username") String username,
             @Param("start") int start, @Param("size") int size);
+
+    @Update("update express set username=#{newUsername}, nickname='已注销用户', realname=null where username=#{oldUsername}")
+    void anonymizeByUsername(@Param("oldUsername") String oldUsername, @Param("newUsername") String newUsername);
 }

--- a/src/main/java/cn/gdeiassistant/core/express/service/ExpressService.java
+++ b/src/main/java/cn/gdeiassistant/core/express/service/ExpressService.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.express.service;
 
+import cn.gdeiassistant.common.tools.Utils.AnonymizeUtils;
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import cn.gdeiassistant.common.exception.ExpressException.CorrectRecordException;
 import cn.gdeiassistant.common.exception.ExpressException.NoRealNameException;
@@ -67,7 +68,15 @@ public class ExpressService {
 
     public List<ExpressComment> queryExpressComment(int expressId) {
         List<ExpressComment> list = expressMapper.selectExpressComment(expressId);
-        return list == null || list.isEmpty() ? new ArrayList<>() : list;
+        if (list == null || list.isEmpty()) return new ArrayList<>();
+        for (ExpressComment c : list) {
+            String sanitized = AnonymizeUtils.sanitizeUsername(c.getUsername());
+            if (c.getNickname() == null || c.getNickname().isEmpty()) {
+                c.setNickname(sanitized);
+            }
+            c.setUsername(sanitized);
+        }
+        return list;
     }
 
     @Transactional("appTransactionManager")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,7 +72,7 @@ server:
     context-path: /
 
 jwt:
-  secret: ${JWT_SECRET:YOUR_SECURE_JWT_SECRET_AT_LEAST_32_CHARS}
+  secret: ${JWT_SECRET:}
 
 email:
   smtp:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,7 +109,7 @@ wechat:
     secret: ${WECHAT_APP_SECRET:}
 
 encrypt:
-  enable: false
+  enable: ${ENCRYPT_ENABLE:false}
   type: aes
   private:
     key: ${ENCRYPT_PRIVATE_KEY:}


### PR DESCRIPTION
## Summary
- Remove default JWT secret placeholder — empty/old values disable JWT with fail-fast guard
- Redact `RequestValidation`/`RequestSecurity` parameters in request logs
- Production profile fail-fast: refuse startup if field encryption not enabled
- Encrypt passwords in Redis (cookie/login/session) using AES via unified `encryptPassword()`/`decryptPassword()` helpers; production throws on failure, dev falls back gracefully
- Anonymize express posts and comments on account deletion
- Sanitize express comment authors at read time via `AnonymizeUtils`
- 141 backend tests passing

## Test plan
- [x] `./gradlew clean test` — 141 tests passed, 0 failures
- [ ] JWT endpoints reject requests when `JWT_SECRET` env var is not set
- [ ] Production startup fails if `ENCRYPT_ENABLE` is not true
- [ ] Redis stores encrypted passwords (not plaintext) when encryption enabled
- [ ] Express comments from deleted accounts show "已注销用户"

🤖 Generated with [Claude Code](https://claude.com/claude-code)