### PR TITLE
Web shell accessibility: semantic buttons, focus-visible, aria-labels

### DIFF
--- a/frontend/src/components/community/CommunityTabbar.vue
+++ b/frontend/src/components/community/CommunityTabbar.vue
@@ -29,17 +29,17 @@ function goTo(path) {
 
 <template>
   <div class="community-tabbar" :style="{ '--module-color': moduleColor }">
-    <a
+    <button
       v-for="tab in tabs"
       :key="tab.key"
-      href="javascript:;"
+      type="button"
       class="community-tabbar__item"
       :class="{ active: activeTab === tab.key }"
-      @click.prevent="goTo(tab.path)"
+      @click="goTo(tab.path)"
     >
       <i class="community-tabbar__icon" v-html="tab.icon"></i>
       <p class="community-tabbar__label">{{ tab.label }}</p>
-    </a>
+    </button>
   </div>
 </template>
 
@@ -70,6 +70,15 @@ function goTo(path) {
   padding: 6px 0;
   transition: color 0.25s ease;
   -webkit-tap-highlight-color: transparent;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}
+
+.community-tabbar__item:focus-visible {
+  outline: 2px solid var(--module-color, #6366f1);
+  outline-offset: -2px;
 }
 
 .community-tabbar__item.active {

--- a/frontend/src/layout/MainLayout.vue
+++ b/frontend/src/layout/MainLayout.vue
@@ -36,9 +36,10 @@ watch(
       <router-view />
     </div>
     <div class="weui-tabbar" role="tablist">
-      <div
+      <button
         v-for="(tab, index) in tabs"
         :key="tab.path"
+        type="button"
         role="tab"
         :aria-label="$t(tab.labelKey)"
         :aria-selected="activeIndex === index"
@@ -48,7 +49,7 @@ watch(
       >
         <img :src="tab.icon" alt="" class="weui-tabbar__icon" />
         <p class="weui-tabbar__label">{{ $t(tab.labelKey) }}</p>
-      </div>
+      </button>
     </div>
   </div>
 </template>
@@ -87,5 +88,17 @@ watch(
 .weui-tabbar {
   background: var(--color-surface);
   border-top: 1px solid var(--color-divider);
+}
+.weui-tabbar__item {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  padding: 0;
+}
+.weui-tabbar__item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 </style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -150,7 +150,10 @@
     "menuCookiePolicy": "Cookie Policy",
     "menuIPDeclaration": "Intellectual Property Notice",
     "menuFriendlyLinks": "Friendly Links",
-    "menuSmartPartyBuilding": "Smart Party Building"
+    "menuSmartPartyBuilding": "Smart Party Building",
+    "menuOpen": "Open menu",
+    "menuClose": "Close menu",
+    "closeCookie": "Close"
   },
   "appearance": {
     "title": "Interface & Appearance",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -150,7 +150,10 @@
     "menuCookiePolicy": "Cookieポリシー",
     "menuIPDeclaration": "知的財産権宣言",
     "menuFriendlyLinks": "リンク集",
-    "menuSmartPartyBuilding": "スマート党建"
+    "menuSmartPartyBuilding": "スマート党建",
+    "menuOpen": "メニューを開く",
+    "menuClose": "メニューを閉じる",
+    "closeCookie": "閉じる"
   },
   "appearance": {
     "title": "インターフェースと外観",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -150,7 +150,10 @@
     "menuCookiePolicy": "쿠키 정책",
     "menuIPDeclaration": "지식재산권 선언",
     "menuFriendlyLinks": "링크 모음",
-    "menuSmartPartyBuilding": "스마트 당건설"
+    "menuSmartPartyBuilding": "스마트 당건설",
+    "menuOpen": "메뉴 열기",
+    "menuClose": "메뉴 닫기",
+    "closeCookie": "닫기"
   },
   "appearance": {
     "title": "인터페이스 및 외관",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -150,7 +150,10 @@
     "menuCookiePolicy": "Cookie政策",
     "menuIPDeclaration": "知识产权声明",
     "menuFriendlyLinks": "友情链接",
-    "menuSmartPartyBuilding": "智慧党建"
+    "menuSmartPartyBuilding": "智慧党建",
+    "menuOpen": "打开菜单",
+    "menuClose": "关闭菜单",
+    "closeCookie": "关闭"
   },
   "appearance": {
     "title": "界面和外观",

--- a/frontend/src/locales/zh-HK.json
+++ b/frontend/src/locales/zh-HK.json
@@ -150,7 +150,10 @@
     "menuCookiePolicy": "Cookie政策",
     "menuIPDeclaration": "知識產權聲明",
     "menuFriendlyLinks": "友情鏈接",
-    "menuSmartPartyBuilding": "智慧黨建"
+    "menuSmartPartyBuilding": "智慧黨建",
+    "menuOpen": "打開菜單",
+    "menuClose": "關閉菜單",
+    "closeCookie": "關閉"
   },
   "appearance": {
     "title": "介面和外觀",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -150,7 +150,10 @@
     "menuCookiePolicy": "Cookie政策",
     "menuIPDeclaration": "智慧財產權聲明",
     "menuFriendlyLinks": "友情連結",
-    "menuSmartPartyBuilding": "智慧黨建"
+    "menuSmartPartyBuilding": "智慧黨建",
+    "menuOpen": "開啟選單",
+    "menuClose": "關閉選單",
+    "closeCookie": "關閉"
   },
   "appearance": {
     "title": "介面和外觀",

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -112,7 +112,7 @@ onMounted(() => {
     <div class="top-navbar">
       <div class="navbar-content">
         <span class="navbar-title">{{ t('about.appName') }}</span>
-        <button class="hamburger-btn" @click="toggleMenu">
+        <button class="hamburger-btn" :aria-label="t('about.menuOpen')" @click="toggleMenu">
           <span></span>
           <span></span>
           <span></span>
@@ -125,7 +125,7 @@ onMounted(() => {
     <div class="side-menu" :class="{ 'menu-open': showMenu }">
       <div class="menu-header">
         <span class="menu-title">{{ t('about.appName') }}</span>
-        <button class="menu-close" @click="toggleMenu">×</button>
+        <button class="menu-close" :aria-label="t('about.menuClose')" @click="toggleMenu">×</button>
       </div>
       <div class="menu-list">
         <div
@@ -227,7 +227,7 @@ onMounted(() => {
             </template>
           </i18n-t>
         </div>
-        <button class="cookie-close" @click="closeCookieBanner">×</button>
+        <button class="cookie-close" :aria-label="t('about.closeCookie')" @click="closeCookieBanner">×</button>
       </div>
     </div>
   </div>

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -133,20 +133,20 @@ onMounted(() => {
           :key="menu.title"
           class="menu-item"
         >
-          <div class="menu-item-header" @click="toggleSubMenu(menu.title)">
+          <button type="button" class="menu-item-header" @click="toggleSubMenu(menu.title)">
             <span>{{ menu.title }}</span>
             <span class="menu-arrow" :class="{ 'arrow-down': expandedMenu === menu.title }">▼</span>
-          </div>
+          </button>
           <div class="menu-subitems" v-if="expandedMenu === menu.title">
-            <a
+            <button
               v-for="item in menu.items"
               :key="item.text"
-              href="javascript:;"
+              type="button"
               class="menu-subitem"
               @click="handleMenuClick(item)"
             >
               {{ item.text }}
-            </a>
+            </button>
           </div>
         </div>
       </div>
@@ -159,9 +159,9 @@ onMounted(() => {
 
     <!-- 进入系统按钮 -->
     <div class="weui-btn_area">
-      <a href="javascript:;" class="weui-btn weui-btn_primary" @click.prevent="goToLogin">
+      <button type="button" class="weui-btn weui-btn_primary" @click="goToLogin">
         {{ t('about.enterSystem') }}
-      </a>
+      </button>
     </div>
 
     <!-- 应用介绍 -->
@@ -361,10 +361,20 @@ onMounted(() => {
   cursor: pointer;
   color: var(--color-text-primary);
   font-size: 15px;
+  width: 100%;
+  border: none;
+  background: transparent;
+  font: inherit;
+  text-align: left;
 }
 
 .menu-item-header:hover {
   background-color: var(--color-bg-secondary);
+}
+
+.menu-item-header:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 
 .menu-arrow {
@@ -383,16 +393,27 @@ onMounted(() => {
 
 .menu-subitem {
   display: block;
+  width: 100%;
   padding: 12px 16px 12px 32px;
   color: var(--color-text-secondary);
   text-decoration: none;
   font-size: 14px;
+  border: none;
   border-bottom: 1px solid var(--color-divider);
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 .menu-subitem:hover {
   background-color: var(--color-divider);
   color: var(--color-primary);
+}
+
+.menu-subitem:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 
 .menu-subitem:last-child {
@@ -423,6 +444,14 @@ onMounted(() => {
 .weui-btn_primary {
   width: 100%;
   background-color: var(--color-primary);
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: #fff;
+}
+.weui-btn_primary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .about-content {

--- a/frontend/src/views/AppearancePage.vue
+++ b/frontend/src/views/AppearancePage.vue
@@ -54,22 +54,23 @@ function onLocaleChange(code) {
 <template>
   <div class="appearance-page">
     <div class="appearance-header">
-      <a class="back-link" @click="$router.back()">←</a>
+      <button type="button" class="back-link" @click="$router.back()">←</button>
       <h2>{{ t('appearance.title') }}</h2>
     </div>
 
     <div class="appearance-section">
       <h3 class="section-title">{{ t('appearance.theme.label') }}</h3>
       <div class="option-list">
-        <div
+        <button
           v-for="opt in themeOptions"
           :key="opt.value"
+          type="button"
           class="option-item"
           @click="onThemeChange(opt.value)"
         >
           <span>{{ t(opt.labelKey) }}</span>
           <span v-if="theme === opt.value" class="check-icon">✓</span>
-        </div>
+        </button>
       </div>
     </div>
 
@@ -97,15 +98,16 @@ function onLocaleChange(code) {
     <div class="appearance-section">
       <h3 class="section-title">{{ t('appearance.language.label') }}</h3>
       <div class="option-list">
-        <div
+        <button
           v-for="loc in locales"
           :key="loc.code"
+          type="button"
           class="option-item"
           @click="onLocaleChange(loc.code)"
         >
           <span>{{ loc.label }}</span>
           <span v-if="selectedLocale === loc.code" class="check-icon">✓</span>
-        </div>
+        </button>
       </div>
     </div>
   </div>
@@ -131,6 +133,14 @@ function onLocaleChange(code) {
   cursor: pointer;
   color: var(--color-primary);
   text-decoration: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+}
+.back-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 .section-title {
   font-size: 0.85rem;
@@ -142,12 +152,22 @@ function onLocaleChange(code) {
   background: var(--color-surface);
 }
 .option-item {
+  width: 100%;
   padding: 12px 16px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   cursor: pointer;
+  border: none;
   border-bottom: 1px solid var(--color-divider);
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+.option-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 .option-item:hover {
   background: var(--color-bg-tertiary);


### PR DESCRIPTION
## Summary
- Replace interactive divs and `href="javascript:;"` with semantic `<button>` elements
- Add focus-visible outline styles to shell controls
- Add i18n aria-labels to icon-only buttons in About page
- Files: MainLayout, CommunityTabbar, AppearancePage, About

## Test plan
- [x] `npm run build` passes
- [ ] Keyboard navigation reaches tab bars and settings actions
- [ ] No `href="javascript:;"` remains in shell components

🤖 Generated with [Claude Code](https://claude.com/claude-code)