### PR TITLE
Add i18n headers and Chinese-only notice to legal/security pages

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -153,7 +153,12 @@
     "menuSmartPartyBuilding": "Smart Party Building",
     "menuOpen": "Open menu",
     "menuClose": "Close menu",
-    "closeCookie": "Close"
+    "closeCookie": "Close",
+    "back": "Back",
+    "securityTitle": "Security Specifications",
+    "privacyPolicyTitle": "Privacy Policy",
+    "userAgreementTitle": "User Agreement",
+    "chineseOnlyNotice": "This page is currently available in Chinese only."
   },
   "appearance": {
     "title": "Interface & Appearance",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -153,7 +153,12 @@
     "menuSmartPartyBuilding": "スマート党建",
     "menuOpen": "メニューを開く",
     "menuClose": "メニューを閉じる",
-    "closeCookie": "閉じる"
+    "closeCookie": "閉じる",
+    "back": "戻る",
+    "securityTitle": "セキュリティ技術仕様",
+    "privacyPolicyTitle": "プライバシーポリシー",
+    "userAgreementTitle": "利用規約",
+    "chineseOnlyNotice": "このページは現在中国語版のみ提供されています。"
   },
   "appearance": {
     "title": "インターフェースと外観",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -153,7 +153,12 @@
     "menuSmartPartyBuilding": "스마트 당건설",
     "menuOpen": "메뉴 열기",
     "menuClose": "메뉴 닫기",
-    "closeCookie": "닫기"
+    "closeCookie": "닫기",
+    "back": "뒤로",
+    "securityTitle": "보안 기술 사양",
+    "privacyPolicyTitle": "개인정보 처리방침",
+    "userAgreementTitle": "이용 약관",
+    "chineseOnlyNotice": "이 페이지는 현재 중국어로만 제공됩니다."
   },
   "appearance": {
     "title": "인터페이스 및 외관",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -153,7 +153,12 @@
     "menuSmartPartyBuilding": "智慧党建",
     "menuOpen": "打开菜单",
     "menuClose": "关闭菜单",
-    "closeCookie": "关闭"
+    "closeCookie": "关闭",
+    "back": "返回",
+    "securityTitle": "安全技术规格说明",
+    "privacyPolicyTitle": "隐私政策",
+    "userAgreementTitle": "用户协议",
+    "chineseOnlyNotice": "本页面目前仅提供中文版本。"
   },
   "appearance": {
     "title": "界面和外观",

--- a/frontend/src/locales/zh-HK.json
+++ b/frontend/src/locales/zh-HK.json
@@ -153,7 +153,12 @@
     "menuSmartPartyBuilding": "智慧黨建",
     "menuOpen": "打開菜單",
     "menuClose": "關閉菜單",
-    "closeCookie": "關閉"
+    "closeCookie": "關閉",
+    "back": "返回",
+    "securityTitle": "安全技術規格說明",
+    "privacyPolicyTitle": "隱私政策",
+    "userAgreementTitle": "用戶協議",
+    "chineseOnlyNotice": "本頁面目前僅提供中文版本。"
   },
   "appearance": {
     "title": "介面和外觀",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -153,7 +153,12 @@
     "menuSmartPartyBuilding": "智慧黨建",
     "menuOpen": "開啟選單",
     "menuClose": "關閉選單",
-    "closeCookie": "關閉"
+    "closeCookie": "關閉",
+    "back": "返回",
+    "securityTitle": "安全技術規格說明",
+    "privacyPolicyTitle": "隱私政策",
+    "userAgreementTitle": "使用者協議",
+    "chineseOnlyNotice": "本頁面目前僅提供中文版本。"
   },
   "appearance": {
     "title": "介面和外觀",

--- a/frontend/src/views/about/PrivacyPolicy.vue
+++ b/frontend/src/views/about/PrivacyPolicy.vue
@@ -1,16 +1,24 @@
 <script setup>
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 const router = useRouter()
+const { t, locale } = useI18n()
+
+const isNonChinese = computed(() => !locale.value.startsWith('zh'))
 </script>
 
 <template>
   <div class="article-page">
     <div class="article-header">
-      <span class="back-btn" @click="router.back()">返回</span>
-      <h2 class="article-title">隐私政策</h2>
+      <span class="back-btn" @click="router.back()">{{ t('about.back') }}</span>
+      <h2 class="article-title">{{ t('about.privacyPolicyTitle') }}</h2>
     </div>
     <div class="weui-article">
+      <div v-if="isNonChinese" class="lang-notice">
+        {{ t('about.chineseOnlyNotice') }}
+      </div>
       <p id="policy-common" style="text-align:center">《广东二师助手隐私政策》</p>
       <p style="text-align:center">更新日期：2022年11月15日</p>
       <p style="text-align:right"><br></p>
@@ -223,5 +231,16 @@ const router = useRouter()
 
 .weui-article strong {
   font-weight: 600;
+}
+
+.lang-notice {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffc107;
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  line-height: 1.6;
 }
 </style>

--- a/frontend/src/views/about/Security.vue
+++ b/frontend/src/views/about/Security.vue
@@ -1,16 +1,24 @@
 <script setup>
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 const router = useRouter()
+const { t, locale } = useI18n()
+
+const isNonChinese = computed(() => !locale.value.startsWith('zh'))
 </script>
 
 <template>
   <div class="article-page">
     <div class="article-header">
-      <span class="back-btn" @click="router.back()">返回</span>
-      <h2 class="article-title">安全技术规格说明</h2>
+      <span class="back-btn" @click="router.back()">{{ t('about.back') }}</span>
+      <h2 class="article-title">{{ t('about.securityTitle') }}</h2>
     </div>
     <div class="weui-article">
+      <div v-if="isNonChinese" class="lang-notice">
+        {{ t('about.chineseOnlyNotice') }}
+      </div>
       <p style="text-align:center">《广东二师助手安全技术规格说明》</p>
       <p style="text-align:center">更新日期：2019年2月18日</p>
       <p style="text-align:right"><br/></p>
@@ -198,5 +206,16 @@ const router = useRouter()
 
 .weui-article strong {
   font-weight: 600;
+}
+
+.lang-notice {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffc107;
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  line-height: 1.6;
 }
 </style>

--- a/frontend/src/views/about/UserAgreement.vue
+++ b/frontend/src/views/about/UserAgreement.vue
@@ -1,16 +1,24 @@
 <script setup>
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 const router = useRouter()
+const { t, locale } = useI18n()
+
+const isNonChinese = computed(() => !locale.value.startsWith('zh'))
 </script>
 
 <template>
   <div class="article-page">
     <div class="article-header">
-      <span class="back-btn" @click="router.back()">返回</span>
-      <h2 class="article-title">用户协议</h2>
+      <span class="back-btn" @click="router.back()">{{ t('about.back') }}</span>
+      <h2 class="article-title">{{ t('about.userAgreementTitle') }}</h2>
     </div>
     <div class="weui-article">
+      <div v-if="isNonChinese" class="lang-notice">
+        {{ t('about.chineseOnlyNotice') }}
+      </div>
       <h3>《广东二师助手用户协议》</h3>
       <p style="text-align:center">更新日期：2022年11月10日</p>
       <p><strong>第一条 特别提示</strong></p>
@@ -272,5 +280,16 @@ const router = useRouter()
 
 .weui-article strong {
   font-weight: 600;
+}
+
+.lang-notice {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffc107;
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  line-height: 1.6;
 }
 </style>


### PR DESCRIPTION
## Summary
- Security, PrivacyPolicy, UserAgreement: localized headers + Chinese-only notice for non-zh locales

## Test plan
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)