### PR TITLE
feat: Track 1 — request correlation, slow query watchlist, unbounded endpoint inventory

### DIFF
--- a/docs/ops/unbounded-endpoints-inventory-2026-03-23.md
+++ b/docs/ops/unbounded-endpoints-inventory-2026-03-23.md
@@ -1,0 +1,127 @@
+# Unbounded / Unpaged Endpoints Inventory
+
+**Date:** 2026-03-23
+**Purpose:** Catalog all REST endpoints that return lists without server-side pagination or size caps, classify risk, and recommend action.
+
+## Legend
+
+| Classification | Meaning |
+|---|---|
+| **acceptable** | Bounded by nature (per-user data unlikely to grow large) or already paginated |
+| **needs-pagination** | Should add `start`/`size` path params and SQL `LIMIT` |
+| **needs-server-side-cap** | Add a hard `LIMIT` in SQL even without client-side paging params |
+| **needs-lazy-fetch** | Currently eager-loads nested data; should defer to a separate call |
+
+| Risk | Meaning |
+|---|---|
+| **low** | Bounded by user behavior; unlikely to exceed tens of rows |
+| **medium** | Could reach hundreds of rows for active users |
+| **high** | Could reach thousands of rows; may cause OOM or slow response |
+
+---
+
+## Inventory
+
+### 1. Secret (tree-hole)
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 1a | `/api/secret/profile` | GET | All personal secret posts | Unbounded `SELECT ... WHERE username=? AND state=0 ORDER BY id DESC` via `selectSecretByUsernameLight` | needs-pagination | medium |
+| 1b | `/api/secret/id/{id}/comments` | GET | All comments for one secret post | Unbounded `SELECT ... WHERE content_id=? ORDER BY id` via `selectSecretCommentsByContentId` | needs-server-side-cap | low |
+
+**Notes:** The public feed (`/api/secret/info/start/{start}/size/{size}`) is already paginated. The `selectSecretByUsername` (heavy variant with eager comment loading) is only used indirectly through the profile endpoint and compounds the problem since each row triggers an N+1 comment query. The light variant (`selectSecretByUsernameLight`) avoids N+1 but is still unbounded.
+
+---
+
+### 2. Marketplace (second-hand)
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 2a | `/api/ershou/profile` | GET | All personal marketplace items, grouped by state (doing/sold/off) | Unbounded `SELECT ... WHERE username=? ORDER BY id DESC` via `selectItemsByUsername`, then in-memory grouping into three lists | needs-pagination | medium |
+
+**Notes:** Public feeds (`/api/ershou/item/start/{start}`, `/api/ershou/keyword/...`, `/api/ershou/item/type/...`) all use `LIMIT`. The profile endpoint fetches all items regardless of state and groups them in Java. For heavy sellers this could return hundreds of rows.
+
+---
+
+### 3. Lost and Found
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 3a | `/api/lostandfound/profile` | GET | All personal lost-and-found items, grouped by state (lost/found/didfound) | Unbounded `SELECT ... WHERE username=? ORDER BY id DESC` via `selectItemByUsername`, then in-memory grouping into three lists | needs-pagination | medium |
+
+**Notes:** Public feeds use `LIMIT`. Same pattern as marketplace -- unbounded personal profile with in-memory grouping.
+
+---
+
+### 4. Delivery (express pickup)
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 4a | `/api/delivery/mine` | GET | Two unbounded arrays: user's published orders + user's accepted orders | `selectDeliveryOrderByUsername` (no LIMIT) and `selectAcceptedDeliveryOrderByUsername` (no LIMIT), returned as `published` + `accepted` | needs-pagination | medium |
+| 4b | (mapper only) | -- | `selectDeliveryTradeByUsername` | Unbounded `SELECT ... WHERE username=?` -- not exposed via controller but available in mapper | acceptable | low |
+
+**Notes:** The public order list (`/api/delivery/order/start/{start}/size/{size}`) is paginated. The personal endpoint returns two separate unbounded lists.
+
+---
+
+### 5. Dating (roommate)
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 5a | `/api/dating/profile/my` | GET | All personal roommate profiles | Unbounded `SELECT ... WHERE username=?` via `selectDatingProfileByUsername` | acceptable | low |
+| 5b | `/api/dating/pick/my/sent` | GET | All picks sent by user | Unbounded `SELECT ... WHERE p.username=? ORDER BY pick_id DESC` via `selectDatingPickListByUsername` (includes JOIN to dating_profile) | needs-server-side-cap | medium |
+| 5c | `/api/dating/pick/my/received` | GET | All picks received by user | Unbounded `SELECT ... WHERE d.username=? ORDER BY pick_id DESC` via `selectReceivedRoommatePickListByProfileOwner` | needs-server-side-cap | medium |
+
+**Notes:** User profiles (5a) are naturally bounded (users create few profiles). Picks (5b, 5c) can grow if a profile is popular or a user is very active.
+
+---
+
+### 6. Photograph (campus photos)
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 6a | `/api/photograph/id/{id}/comment` | GET | All comments for one photograph | Unbounded `SELECT ... WHERE photo_id=?` via `selectPhotographCommentByPhotoId` | needs-server-side-cap | low |
+
+**Notes:** Main lists and profile list are already paginated. Only the per-item comment list is unbounded.
+
+---
+
+### 7. Express (confessions)
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 7a | `/api/express/id/{id}/comment` | GET | All comments for one confession | Unbounded `SELECT ... WHERE express_id=?` via `selectExpressComment` | needs-server-side-cap | low |
+
+**Notes:** Main feeds, profile list, and keyword search are all paginated. Only per-item comments are unbounded.
+
+---
+
+### 8. Topic
+
+No unbounded endpoints found. All list endpoints use `start`/`size` pagination.
+
+---
+
+### 9. Profile
+
+| # | Path | Method | Description | Current behavior | Classification | Risk |
+|---|---|---|---|---|---|---|
+| 9a | `/api/profile/locations` | GET | Full region list (static dictionary) | Loads all regions from `LocationUtils.getRegionMap()`, sorts in-memory | acceptable | low |
+
+**Notes:** Region data is a static dictionary, not user-generated. Size is fixed and small.
+
+---
+
+## Summary by Classification
+
+| Classification | Count | Endpoints |
+|---|---|---|
+| **needs-pagination** | 3 | 1a, 2a, 3a |
+| **needs-server-side-cap** | 5 | 1b, 5b, 5c, 6a, 7a |
+| **acceptable** | 3 | 4b, 5a, 9a |
+
+## Recommended Priority
+
+1. **High priority** (needs-pagination, medium risk): `/api/secret/profile`, `/api/ershou/profile`, `/api/lostandfound/profile`, `/api/delivery/mine` -- these return full user histories without any limit.
+2. **Medium priority** (needs-server-side-cap): `/api/dating/pick/my/sent`, `/api/dating/pick/my/received` -- picks can accumulate over time.
+3. **Low priority** (needs-server-side-cap, low risk): Comment endpoints (`/api/secret/id/{id}/comments`, `/api/photograph/id/{id}/comment`, `/api/express/id/{id}/comment`) -- individual items rarely accumulate huge comment counts but should still have a safety cap.

--- a/src/main/java/cn/gdeiassistant/common/aspect/QueryLogAspect.java
+++ b/src/main/java/cn/gdeiassistant/common/aspect/QueryLogAspect.java
@@ -1,8 +1,9 @@
 package cn.gdeiassistant.common.aspect;
 
+import cn.gdeiassistant.common.constant.ObservabilityConstants;
 import cn.gdeiassistant.common.pojo.Entity.User;
-import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.slf4j.Logger;
@@ -38,8 +39,24 @@ public class QueryLogAspect {
 
     }
 
-    @AfterReturning("RestQueryAction()")
-    public void RestSaveQueryLog(JoinPoint joinPoint) {
+    @Pointcut("execution(* cn.gdeiassistant.core.secret.controller.SecretController.*(..)) || "
+            + "execution(* cn.gdeiassistant.core.topic.controller.TopicController.*(..)) || "
+            + "execution(* cn.gdeiassistant.core.express.controller.ExpressController.*(..)) || "
+            + "execution(* cn.gdeiassistant.core.marketplace.controller.MarketplaceController.*(..)) || "
+            + "execution(* cn.gdeiassistant.core.lostandfound.controller.LostAndFoundController.*(..)) || "
+            + "execution(* cn.gdeiassistant.core.delivery.controller.DeliveryController.*(..)) || "
+            + "execution(* cn.gdeiassistant.core.dating.controller.DatingController.*(..)) || "
+            + "execution(* cn.gdeiassistant.core.photograph.controller.PhotographController.*(..))")
+    public void CommunityQueryAction() {
+
+    }
+
+    @Around("RestQueryAction()")
+    public Object RestSaveQueryLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long elapsed = System.currentTimeMillis() - start;
+
         Object[] args = joinPoint.getArgs();
         HttpServletRequest request = (HttpServletRequest) args[0];
         String username = (Optional.ofNullable((User) request.getAttribute("user"))
@@ -62,10 +79,21 @@ public class QueryLogAspect {
                 logger.info("用户{}于{}查询了消费记录信息", username, dateTime);
                 break;
         }
+
+        if (elapsed > ObservabilityConstants.QUERY_SLOW_THRESHOLD_MS) {
+            logger.warn("Slow REST query detected: {} took {}ms (threshold {}ms), user={}",
+                    functionName, elapsed, ObservabilityConstants.QUERY_SLOW_THRESHOLD_MS, username);
+        }
+
+        return result;
     }
 
-    @AfterReturning("QueryAction()")
-    public void SaveQueryLog(JoinPoint joinPoint) {
+    @Around("QueryAction()")
+    public Object SaveQueryLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long elapsed = System.currentTimeMillis() - start;
+
         Object[] args = joinPoint.getArgs();
         String username = Optional.ofNullable((String) WebUtils.getSessionAttribute((HttpServletRequest) args[0]
                 , "username")).orElse("unknown");
@@ -102,5 +130,29 @@ public class QueryLogAspect {
                 logger.info("用户{}于{}查询了空课室信息", username, dateTime);
                 break;
         }
+
+        if (elapsed > ObservabilityConstants.QUERY_SLOW_THRESHOLD_MS) {
+            logger.warn("Slow query detected: {} took {}ms (threshold {}ms), user={}",
+                    functionName, elapsed, ObservabilityConstants.QUERY_SLOW_THRESHOLD_MS, username);
+        }
+
+        return result;
+    }
+
+    @Around("CommunityQueryAction()")
+    public Object CommunityQueryLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long elapsed = System.currentTimeMillis() - start;
+
+        String methodName = joinPoint.getSignature().toShortString();
+        logger.info("Community query executed: {} in {}ms", methodName, elapsed);
+
+        if (elapsed > ObservabilityConstants.QUERY_SLOW_THRESHOLD_MS) {
+            logger.warn("Slow community query detected: {} took {}ms (threshold {}ms)",
+                    methodName, elapsed, ObservabilityConstants.QUERY_SLOW_THRESHOLD_MS);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/cn/gdeiassistant/common/aspect/RequestLogAspect.java
+++ b/src/main/java/cn/gdeiassistant/common/aspect/RequestLogAspect.java
@@ -5,7 +5,9 @@ import cn.gdeiassistant.common.pojo.Entity.RequestValidation;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import com.alibaba.fastjson2.JSON;
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.CodeSignature;
@@ -13,10 +15,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Set;
 
 @Aspect
 @Component
@@ -24,6 +31,15 @@ import java.util.Date;
 public class RequestLogAspect {
 
     private final Logger logger = LoggerFactory.getLogger(RequestLogAspect.class);
+
+    /** Sensitive parameter names that must never be logged. */
+    private static final Set<String> SENSITIVE_PARAMS = Set.of(
+            "password", "token", "secret", "credential", "accesskey"
+    );
+
+    // ----------------------------------------------------------------
+    // Existing @RequestLogPersistence behaviour (unchanged)
+    // ----------------------------------------------------------------
 
     @Pointcut("@annotation(cn.gdeiassistant.common.annotation.RequestLogPersistence)")
     public void RequestAction() {
@@ -63,5 +79,167 @@ public class RequestLogAspect {
         stringBuilder.append(" . ");
         //保存请求信息到日志
         logger.info(stringBuilder.toString());
+    }
+
+    // ----------------------------------------------------------------
+    // Broad correlation / latency logging for ALL controller methods
+    // ----------------------------------------------------------------
+
+    @Pointcut("execution(* cn.gdeiassistant..controller..*(..))")
+    public void allControllerMethods() {
+    }
+
+    /**
+     * Logs request correlation ID, HTTP method, path, client IP, parameters
+     * (with sensitive redaction), elapsed time and success/failure for every
+     * controller method invocation.
+     */
+    @Around("allControllerMethods()")
+    public Object logRequestCorrelation(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request = resolveRequest(joinPoint);
+
+        String requestId = "?";
+        String method = "?";
+        String path = "?";
+        String clientIp = "?";
+
+        if (request != null) {
+            Object idAttr = request.getAttribute("requestId");
+            if (idAttr != null) {
+                requestId = idAttr.toString();
+            }
+            method = request.getMethod();
+            path = request.getRequestURI();
+            clientIp = resolveClientIp(request);
+        }
+
+        long start = System.currentTimeMillis();
+        boolean success = true;
+        try {
+            Object result = joinPoint.proceed();
+            return result;
+        } catch (Throwable t) {
+            success = false;
+            throw t;
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+
+            // Build log line
+            StringBuilder sb = new StringBuilder("CorrelationLog - ");
+            sb.append("rid:").append(requestId);
+            sb.append(" | ").append(method).append(' ').append(path);
+            sb.append(" | ip:").append(clientIp);
+            sb.append(" | handler:").append(joinPoint.getSignature().getDeclaringType().getSimpleName())
+              .append('.').append(joinPoint.getSignature().getName());
+
+            // Log non-sensitive parameters (skip file/upload args and servlet types)
+            appendSafeParameters(sb, joinPoint);
+
+            sb.append(" | status:").append(success ? "OK" : "FAIL");
+            sb.append(" | elapsed:").append(elapsed).append("ms");
+
+            logger.info(sb.toString());
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------
+
+    /**
+     * Resolves the current {@link HttpServletRequest} either from the join-point
+     * arguments or from the {@link RequestContextHolder}.
+     */
+    private HttpServletRequest resolveRequest(ProceedingJoinPoint joinPoint) {
+        for (Object arg : joinPoint.getArgs()) {
+            if (arg instanceof HttpServletRequest) {
+                return (HttpServletRequest) arg;
+            }
+        }
+        // Fallback to RequestContextHolder
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        return attrs != null ? attrs.getRequest() : null;
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip != null && !ip.isBlank()) {
+            // Take the first IP in the chain (original client)
+            return ip.split(",")[0].trim();
+        }
+        ip = request.getHeader("X-Real-IP");
+        if (ip != null && !ip.isBlank()) {
+            return ip.trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * Appends non-sensitive, non-binary parameters to the log line.
+     * Skips {@link MultipartFile}, {@link HttpServletRequest},
+     * {@link HttpServletResponse}, and parameters whose name suggests
+     * they contain secrets.
+     */
+    private void appendSafeParameters(StringBuilder sb, ProceedingJoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        String[] names;
+        try {
+            names = ((CodeSignature) joinPoint.getSignature()).getParameterNames();
+        } catch (Exception e) {
+            // Parameter names not available at runtime
+            return;
+        }
+        if (names == null || names.length == 0) {
+            return;
+        }
+
+        sb.append(" | params:{");
+        boolean first = true;
+        for (int i = 0; i < args.length; i++) {
+            Object arg = args[i];
+            String name = names[i];
+
+            // Skip servlet infrastructure types and file uploads
+            if (arg instanceof HttpServletRequest
+                    || arg instanceof HttpServletResponse
+                    || arg instanceof MultipartFile
+                    || arg instanceof MultipartFile[]) {
+                continue;
+            }
+
+            // Redact sensitive parameters
+            if (isSensitive(name)) {
+                if (!first) sb.append(", ");
+                sb.append(name).append(":[REDACTED]");
+                first = false;
+                continue;
+            }
+
+            // Redact RequestValidation / RequestSecurity
+            if (arg instanceof RequestValidation || arg instanceof RequestSecurity) {
+                if (!first) sb.append(", ");
+                sb.append(name).append(":[REDACTED]");
+                first = false;
+                continue;
+            }
+
+            if (arg != null) {
+                if (!first) sb.append(", ");
+                try {
+                    sb.append(name).append(':').append(JSON.toJSONString(arg));
+                } catch (Exception e) {
+                    sb.append(name).append(":[serialization-error]");
+                }
+                first = false;
+            }
+        }
+        sb.append('}');
+    }
+
+    private boolean isSensitive(String paramName) {
+        if (paramName == null) return false;
+        String lower = paramName.toLowerCase();
+        return SENSITIVE_PARAMS.stream().anyMatch(lower::contains);
     }
 }

--- a/src/main/java/cn/gdeiassistant/common/config/Application/ApplicationWebMvcConfig.java
+++ b/src/main/java/cn/gdeiassistant/common/config/Application/ApplicationWebMvcConfig.java
@@ -69,7 +69,7 @@ public class ApplicationWebMvcConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
                 .allowedOriginPatterns(resolveAllowedOriginPatterns())
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
-                .allowedHeaders("Authorization", "X-Client-Type", "X-Cron-Secret", "Content-Type")
+                .allowedHeaders("Authorization", "X-Client-Type", "X-Cron-Secret", "X-Request-ID", "Content-Type")
                 .allowCredentials(false)
                 .maxAge(3600);
     }

--- a/src/main/java/cn/gdeiassistant/common/constant/ObservabilityConstants.java
+++ b/src/main/java/cn/gdeiassistant/common/constant/ObservabilityConstants.java
@@ -1,0 +1,6 @@
+package cn.gdeiassistant.common.constant;
+
+public class ObservabilityConstants {
+    public static final long REST_SLOW_THRESHOLD_MS = 800;
+    public static final long QUERY_SLOW_THRESHOLD_MS = 1500;
+}

--- a/src/main/java/cn/gdeiassistant/common/filter/RequestCorrelationFilter.java
+++ b/src/main/java/cn/gdeiassistant/common/filter/RequestCorrelationFilter.java
@@ -1,0 +1,51 @@
+package cn.gdeiassistant.common.filter;
+
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Assigns a unique request correlation ID to every inbound HTTP request and measures
+ * wall-clock latency. The ID is propagated via:
+ * <ul>
+ *   <li>Request attribute {@code requestId}</li>
+ *   <li>Response header {@code X-Request-ID}</li>
+ *   <li>SLF4J MDC key {@code requestId}</li>
+ * </ul>
+ * If the caller already supplies an {@code X-Request-ID} header it is reused.
+ */
+@Component
+public class RequestCorrelationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+
+        String requestId = request.getHeader("X-Request-ID");
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString().substring(0, 8);
+        }
+
+        request.setAttribute("requestId", requestId);
+        response.setHeader("X-Request-ID", requestId);
+        MDC.put("requestId", requestId);
+
+        long start = System.currentTimeMillis();
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            request.setAttribute("requestElapsedMs", elapsed);
+            MDC.remove("requestId");
+        }
+    }
+}

--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -82,12 +82,14 @@ public class DatingController {
         return new DataJsonResult<>(true, datingService.queryMyRoommateProfiles(sessionId));
     }
 
+    // TODO(perf): unpaged — see docs/ops/unbounded-endpoints-inventory
     @RequestMapping(value = "/api/dating/pick/my/sent", method = RequestMethod.GET)
     public DataJsonResult<List<DatingPickVO>> getMySentPicks(HttpServletRequest request) {
         String sessionId = (String) request.getAttribute("sessionId");
         return new DataJsonResult<>(true, datingService.queryMySentPicks(sessionId));
     }
 
+    // TODO(perf): unpaged — see docs/ops/unbounded-endpoints-inventory
     @RequestMapping(value = "/api/dating/pick/my/received", method = RequestMethod.GET)
     public DataJsonResult<List<DatingPickVO>> getMyReceivedPicks(HttpServletRequest request) {
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
@@ -57,6 +57,7 @@ public class DeliveryController {
     /**
      * 我的跑腿：我发布的 + 我接的单。GET /api/delivery/mine
      */
+    // TODO(perf): unpaged — see docs/ops/unbounded-endpoints-inventory
     @RequestMapping(value = "/api/delivery/mine", method = RequestMethod.GET)
     public DataJsonResult<Map<String, Object>> getMyDelivery(HttpServletRequest request) {
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
+++ b/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
@@ -38,6 +38,7 @@ public class LostAndFoundController {
         return new DataJsonResult<>(true, list);
     }
 
+    // TODO(perf): unpaged — see docs/ops/unbounded-endpoints-inventory
     @RequestMapping(value = "/api/lostandfound/profile", method = RequestMethod.GET)
     public DataJsonResult<Map<String, Object>> getMyLostAndFoundItems(HttpServletRequest request) throws Exception {
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
@@ -40,6 +40,7 @@ public class MarketplaceController {
         return new DataJsonResult<>(true, list);
     }
 
+    // TODO(perf): unpaged — see docs/ops/unbounded-endpoints-inventory
     @RequestMapping(value = "/api/ershou/profile", method = RequestMethod.GET)
     public DataJsonResult<Map<String, Object>> getMySecondhandItems(HttpServletRequest request) throws Exception {
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -53,6 +53,7 @@ public class SecretController {
         return new DataJsonResult<>(true, list);
     }
 
+    // TODO(perf): unpaged — see docs/ops/unbounded-endpoints-inventory
     @RequestMapping(value = "/api/secret/profile", method = RequestMethod.GET)
     public DataJsonResult<List<SecretVO>> getMySecrets(HttpServletRequest request) throws Exception {
         String sessionId = (String) request.getAttribute("sessionId");


### PR DESCRIPTION
## Summary
- 1A: RequestCorrelationFilter (X-Request-ID, MDC, latency) + expanded RequestLogAspect
- 1B: ObservabilityConstants + expanded QueryLogAspect (8 community modules, slow threshold warnings)
- 1C: Unbounded endpoints inventory (11 endpoints classified) + TODO markers

## Test plan
- [x] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)