### PR TITLE
security: harden educational system access module

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
+++ b/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
@@ -172,6 +172,6 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
         } catch (JsonProcessingException e) {
             throw new RuntimeException("会话凭证序列化失败", e);
         }
-        redisDaoUtils.expire(key, 30, TimeUnit.MINUTES);
+        redisDaoUtils.expire(key, 10, TimeUnit.MINUTES);
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/userlogin/service/UserCertificateService.java
+++ b/src/main/java/cn/gdeiassistant/core/userlogin/service/UserCertificateService.java
@@ -20,6 +20,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -188,8 +189,13 @@ public class UserCertificateService {
                         basicNameValuePairs.add(new BasicNameValuePair("service", "http://portal.gdei.edu.cn:8001/Login"));
                         basicNameValuePairs.add(new BasicNameValuePair("imageField.x", "0"));
                         basicNameValuePairs.add(new BasicNameValuePair("imageField.y", "0"));
-                        basicNameValuePairs.add(new BasicNameValuePair("tokens", document.getElementById("tokens").val()));
-                        basicNameValuePairs.add(new BasicNameValuePair("stamp", document.getElementById("stamp").val()));
+                        Element tokensEl = document.getElementById("tokens");
+                        Element stampEl = document.getElementById("stamp");
+                        if (tokensEl == null || stampEl == null) {
+                            throw new ServerErrorException("CAS 登录页面结构异常，未找到 tokens 或 stamp");
+                        }
+                        basicNameValuePairs.add(new BasicNameValuePair("tokens", tokensEl.val()));
+                        basicNameValuePairs.add(new BasicNameValuePair("stamp", stampEl.val()));
                         //绑定表单参数
                         httpPost.setEntity(new UrlEncodedFormEntity(basicNameValuePairs, StandardCharsets.UTF_8));
                         httpResponse = httpClient.execute(httpPost);
@@ -198,11 +204,30 @@ public class UserCertificateService {
                             //服务器异常
                             throw new ServerErrorException("教务系统异常");
                         }
-                        if (!document.select("body").get(0).hasAttr("bgcolor")) {
+                        Element bodyElement = document.select("body").first();
+                        if (bodyElement == null || !bodyElement.hasAttr("bgcolor")) {
                             //认证失败,提示账号或密码错误
                             throw new PasswordIncorrectException("登录账号密码不正确");
                         }
-                        httpGet = new HttpGet(document.select("a").first().attr("href"));
+                        Element firstLink = document.select("a").first();
+                        if (firstLink == null) {
+                            throw new ServerErrorException("CAS 登录后未找到跳转链接");
+                        }
+                        String casRedirectUrl = firstLink.attr("href");
+                        if (casRedirectUrl == null || casRedirectUrl.isEmpty()) {
+                            throw new ServerErrorException("CAS login后跳转链接为空");
+                        }
+                        // Validate redirect URL stays within trusted school domains
+                        try {
+                            java.net.URI uri = java.net.URI.create(casRedirectUrl);
+                            String host = uri.getHost();
+                            if (host != null && !host.toLowerCase().endsWith(".gdei.edu.cn") && !host.toLowerCase().equals("gdei.edu.cn")) {
+                                throw new ServerErrorException("CAS重定向地址不在可信域名范围内");
+                            }
+                        } catch (IllegalArgumentException e) {
+                            throw new ServerErrorException("CAS重定向地址格式异常");
+                        }
+                        httpGet = new HttpGet(casRedirectUrl);
                         httpResponse = httpClient.execute(httpGet);
                         document = Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
                         if (httpResponse.getStatusLine().getStatusCode() == 302) {
@@ -271,18 +296,53 @@ public class UserCertificateService {
             httpGet = new HttpGet(httpResponse.getFirstHeader("Location").getValue());
             httpResponse = httpClient.execute(httpGet);
             Document document = Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
-            httpGet = new HttpGet(document.select("a").first().attr("href"));
+            Element loginLink1 = document.select("a").first();
+            if (loginLink1 == null) {
+                throw new ServerErrorException("CAS 登录后未找到跳转链接");
+            }
+            String loginRedirect1 = loginLink1.attr("href");
+            if (loginRedirect1 == null || loginRedirect1.isEmpty()) {
+                throw new ServerErrorException("CAS login后跳转链接为空");
+            }
+            // Validate redirect URL stays within trusted school domains
+            try {
+                java.net.URI uri1 = java.net.URI.create(loginRedirect1);
+                String host1 = uri1.getHost();
+                if (host1 != null && !host1.toLowerCase().endsWith(".gdei.edu.cn") && !host1.toLowerCase().equals("gdei.edu.cn")) {
+                    throw new ServerErrorException("CAS重定向地址不在可信域名范围内");
+                }
+            } catch (IllegalArgumentException e) {
+                throw new ServerErrorException("CAS重定向地址格式异常");
+            }
+            httpGet = new HttpGet(loginRedirect1);
             httpResponse = httpClient.execute(httpGet);
             document = Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
-            httpGet = new HttpGet("http://jwgl.gdei.edu.cn/" + document.select("a").attr("href"));
+            String loginRedirect2 = document.select("a").attr("href");
+            if (loginRedirect2 == null || loginRedirect2.isEmpty()) {
+                throw new ServerErrorException("CAS login后跳转链接为空");
+            }
+            httpGet = new HttpGet("http://jwgl.gdei.edu.cn/" + loginRedirect2);
             httpResponse = httpClient.execute(httpGet);
             document = Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
             //获取学生的教务系统信息
-            String script = document.select("script").first().data();
-            String keycode = (document.getElementById("Form1").attr("action")
+            Element scriptElement = document.select("script").first();
+            if (scriptElement == null) {
+                throw new ServerErrorException("教务系统页面结构异常，未找到脚本元素");
+            }
+            String script = scriptElement.data();
+            Element form1Element = document.getElementById("Form1");
+            if (form1Element == null) {
+                throw new ServerErrorException("教务系统页面结构异常，未找到 Form1");
+            }
+            String keycode = (form1Element.attr("action")
                     .split("&")[1]).split("=")[1];
-            String number = ((script.split("=")[1]).split("'")[0]).substring(0, 11);
-            Long timestamp = Long.valueOf(document.getElementById("Form1")
+            java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\\d{10,12}");
+            java.util.regex.Matcher matcher = pattern.matcher(script);
+            if (!matcher.find()) {
+                throw new ServerErrorException("无法从教务系统响应中提取学号");
+            }
+            String number = matcher.group();
+            Long timestamp = Long.valueOf(form1Element
                     .attr("action").split("&")[2].split("=")[1]);
             //进行教务系统身份校验
             CasVerify(sessionId, httpClient, username, password, keycode, number, timestamp);

--- a/src/main/java/cn/gdeiassistant/integration/cas/CasClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/cas/CasClient.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class CasClient {
 
     private static final String CAS_LOGIN_URL = "https://security.gdei.edu.cn/cas/login";
-    private static final int TIMEOUT_MS = 3000;
+    private static final int TIMEOUT_MS = 10000;
 
     public CasSessionCredential login(String username, String password, String serviceUrl)
             throws IOException, ServerErrorException {
@@ -52,6 +52,11 @@ public class CasClient {
             Document document = Jsoup.parse(EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8));
 
             // 2. 提交登录表单
+            Element tokensElement = document.getElementById("tokens");
+            Element stampElement = document.getElementById("stamp");
+            if (tokensElement == null || stampElement == null) {
+                throw new ServerErrorException("CAS 登录页面结构异常，未找到 tokens 或 stamp");
+            }
             HttpPost httpPost = new HttpPost(CAS_LOGIN_URL);
             List<BasicNameValuePair> form = new ArrayList<>();
             form.add(new BasicNameValuePair("service", serviceUrl));
@@ -59,8 +64,8 @@ public class CasClient {
             form.add(new BasicNameValuePair("password", password));
             form.add(new BasicNameValuePair("imageField.x", "0"));
             form.add(new BasicNameValuePair("imageField.y", "0"));
-            form.add(new BasicNameValuePair("tokens", document.getElementById("tokens").val()));
-            form.add(new BasicNameValuePair("stamp", document.getElementById("stamp").val()));
+            form.add(new BasicNameValuePair("tokens", tokensElement.val()));
+            form.add(new BasicNameValuePair("stamp", stampElement.val()));
             httpPost.setEntity(new UrlEncodedFormEntity(form, StandardCharsets.UTF_8));
             httpResponse = httpClient.execute(httpPost);
             if (httpResponse.getStatusLine().getStatusCode() != 200) {
@@ -75,7 +80,17 @@ public class CasClient {
             }
             String redirectUrl = firstLink.attr("href");
             if (redirectUrl == null || redirectUrl.isEmpty()) {
-                throw new ServerErrorException("CAS 登录后跳转链接为空");
+                throw new ServerErrorException("CAS login后跳转链接为空");
+            }
+            // Validate redirect URL stays within trusted school domains
+            try {
+                java.net.URI uri = java.net.URI.create(redirectUrl);
+                String host = uri.getHost();
+                if (host != null && !host.toLowerCase().endsWith(".gdei.edu.cn") && !host.toLowerCase().equals("gdei.edu.cn")) {
+                    throw new ServerErrorException("CAS重定向地址不在可信域名范围内");
+                }
+            } catch (IllegalArgumentException e) {
+                throw new ServerErrorException("CAS重定向地址格式异常");
             }
 
             CasSessionCredential credential = new CasSessionCredential();

--- a/src/main/java/cn/gdeiassistant/integration/edu/EduSystemClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/edu/EduSystemClient.java
@@ -158,7 +158,11 @@ public class EduSystemClient {
                 if (httpResponse.getStatusLine().getStatusCode() != 200) {
                     throw new ServerErrorException("教务系统异常");
                 }
-                Elements xqdOptions = document.getElementsByAttributeValue("name", "xqd").first().select("option");
+                Element xqdElement = document.getElementsByAttributeValue("name", "xqd").first();
+                if (xqdElement == null) {
+                    throw new ServerErrorException("教务系统页面结构异常，未找到学期下拉框");
+                }
+                Elements xqdOptions = xqdElement.select("option");
                 int defaultTerm = 0;
                 for (Element option : xqdOptions) {
                     if (option.hasAttr("selected")) {
@@ -166,7 +170,11 @@ public class EduSystemClient {
                         break;
                     }
                 }
-                Elements xndOptions = document.getElementsByAttributeValue("name", "xnd").first().select("option");
+                Element xndElement = document.getElementsByAttributeValue("name", "xnd").first();
+                if (xndElement == null) {
+                    throw new ServerErrorException("教务系统页面结构异常，未找到学年下拉框");
+                }
+                Elements xndOptions = xndElement.select("option");
                 int defaultYear = 0;
                 for (Element option : xndOptions) {
                     if (option.hasAttr("selected")) {
@@ -175,13 +183,34 @@ public class EduSystemClient {
                     }
                 }
                 if (defaultYear != WeekUtils.getCurrentYear() || defaultTerm != WeekUtils.getCurrentTerm()) {
+                    Element viewStateElement = document.getElementsByAttributeValue("name", "__VIEWSTATE").first();
+                    if (viewStateElement == null) {
+                        throw new ServerErrorException("教务系统页面结构异常，未找到 __VIEWSTATE");
+                    }
+                    Element xndFormElement = document.getElementsByAttributeValue("name", "xnd").first();
+                    if (xndFormElement == null) {
+                        throw new ServerErrorException("教务系统页面结构异常，未找到学年下拉框");
+                    }
+                    Element xndFirstOption = xndFormElement.select("option").first();
+                    if (xndFirstOption == null) {
+                        throw new ServerErrorException("教务系统页面结构异常，学年下拉框无选项");
+                    }
+                    Element xqdFormElement = document.getElementsByAttributeValue("name", "xqd").first();
+                    if (xqdFormElement == null) {
+                        throw new ServerErrorException("教务系统页面结构异常，未找到学期下拉框");
+                    }
+                    Elements xqdFormOptions = xqdFormElement.select("option");
+                    int termIndex = WeekUtils.getCurrentTerm() - 1;
+                    if (termIndex < 0 || termIndex >= xqdFormOptions.size()) {
+                        throw new ServerErrorException("教务系统页面结构异常，学期选项索引越界");
+                    }
                     HttpPost httpPost = new HttpPost(JWGL_BASE + "/xskbcx.aspx?xh=" + credential.getNumber());
                     List<BasicNameValuePair> form = new ArrayList<>();
                     form.add(new BasicNameValuePair("__EVENTTARGET", ""));
                     form.add(new BasicNameValuePair("__EVENTARGUMENT", ""));
-                    form.add(new BasicNameValuePair("__VIEWSTATE", document.getElementsByAttributeValue("name", "__VIEWSTATE").first().val()));
-                    form.add(new BasicNameValuePair("xnd", document.getElementsByAttributeValue("name", "xnd").first().select("option").first().attr("value")));
-                    form.add(new BasicNameValuePair("xqd", document.getElementsByAttributeValue("name", "xqd").first().select("option").get(WeekUtils.getCurrentTerm() - 1).attr("value")));
+                    form.add(new BasicNameValuePair("__VIEWSTATE", viewStateElement.val()));
+                    form.add(new BasicNameValuePair("xnd", xndFirstOption.attr("value")));
+                    form.add(new BasicNameValuePair("xqd", xqdFormOptions.get(termIndex).attr("value")));
                     httpPost.setEntity(new UrlEncodedFormEntity(form, StandardCharsets.UTF_8));
                     httpResponse = httpClient.execute(httpPost);
                     document = Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()).replace("<br>", "$info$"));
@@ -401,9 +430,15 @@ public class EduSystemClient {
                 httpPost.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.146 Safari/537.36");
                 httpPost.setHeader("Referer", JWGL_BASE + "/jstjkbcx.aspx?zgh=" + teacherUsername);
                 List<BasicNameValuePair> form = new ArrayList<>();
-                form.add(new BasicNameValuePair("__EVENTTARGET", document.getElementsByAttributeValue("name", "__EVENTTARGET").val()));
-                form.add(new BasicNameValuePair("__EVENTARGUMENT", document.getElementsByAttributeValue("name", "__EVENTARGUMENT").val()));
-                form.add(new BasicNameValuePair("__VIEWSTATE", document.getElementsByAttributeValue("name", "__VIEWSTATE").val()));
+                Elements eventTargetElements = document.getElementsByAttributeValue("name", "__EVENTTARGET");
+                Elements eventArgumentElements = document.getElementsByAttributeValue("name", "__EVENTARGUMENT");
+                Elements viewStateElements = document.getElementsByAttributeValue("name", "__VIEWSTATE");
+                if (viewStateElements.isEmpty()) {
+                    throw new ServerErrorException("教务系统页面结构异常，未找到 __VIEWSTATE");
+                }
+                form.add(new BasicNameValuePair("__EVENTTARGET", eventTargetElements.val()));
+                form.add(new BasicNameValuePair("__EVENTARGUMENT", eventArgumentElements.val()));
+                form.add(new BasicNameValuePair("__VIEWSTATE", viewStateElements.val()));
                 form.add(new BasicNameValuePair("xn", year != null ? year : ""));
                 form.add(new BasicNameValuePair("xq", term != null ? term : ""));
                 form.add(new BasicNameValuePair("bm", ""));


### PR DESCRIPTION
## Summary
- CAS redirect URL whitelist — only `*.gdei.edu.cn` allowed, prevents open redirect attacks
- HTML structure validation — null checks on all Jsoup element access in EduSystemClient
- Student number extraction — regex `\d{10,12}` replaces fragile string splitting
- CAS timeout 3s → 10s — prevents false failures during peak hours
- Session credential TTL 30min → 10min — reduces credential exposure window
- Null checks for CAS form tokens (tokens/stamp)

## Test plan
- [ ] Verify grade query still works with valid credentials
- [ ] Verify schedule query returns correct data
- [ ] Verify CAS login with slow network (>3s) succeeds
- [ ] Verify redirect to non-gdei.edu.cn domain is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)