### PR TITLE
arch: add circuit breaker for external systems and reduce cookie TTL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'com.baomidou:mybatis-plus-spring-boot3-starter:3.5.5'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
+++ b/src/main/java/cn/gdeiassistant/common/redis/UserCertificate/UserCertificateDaoImpl.java
@@ -79,12 +79,12 @@ public class UserCertificateDaoImpl implements UserCertificateDao {
         } catch (JsonProcessingException e) {
             throw new RuntimeException("登录凭证序列化失败", e);
         }
-        redisDaoUtils.expire(key, 30, TimeUnit.DAYS);
+        redisDaoUtils.expire(key, 7, TimeUnit.DAYS);
     }
 
     @Override
     public void updateUserCookieCertificateExpiration(String cookieId) {
-        redisDaoUtils.expire(StringEncryptUtils.sha256HexString(COOKIE_PREFIX + cookieId), 30, TimeUnit.DAYS);
+        redisDaoUtils.expire(StringEncryptUtils.sha256HexString(COOKIE_PREFIX + cookieId), 7, TimeUnit.DAYS);
     }
 
     @Override

--- a/src/main/java/cn/gdeiassistant/integration/card/CardClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/card/CardClient.java
@@ -13,6 +13,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayOutputStream;
@@ -35,6 +36,7 @@ public class CardClient {
     /**
      * 获取校园卡基本信息页 Document（需已登录 ecard）
      */
+    @CircuitBreaker(name = "cardSystem", fallbackMethod = "cardSystemFallback")
     public Document fetchCardBasicInfoDocument(String sessionId) throws IOException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, true, CARD_TIMEOUT_SEC);
         CloseableHttpClient httpClient = httpClientSession.getCloseableHttpClient();
@@ -58,6 +60,7 @@ public class CardClient {
      * @param type      0=当日，1=历史
      * @param pageIndex 页码，从 1 开始
      */
+    @CircuitBreaker(name = "cardSystem", fallbackMethod = "cardSystemFallback")
     public Document fetchCardTrjnListDocument(String sessionId, int type, int pageIndex) throws IOException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, true, CARD_TIMEOUT_SEC);
         CloseableHttpClient httpClient = httpClientSession.getCloseableHttpClient();
@@ -80,6 +83,7 @@ public class CardClient {
     /**
      * 获取历史日期消费流水单页
      */
+    @CircuitBreaker(name = "cardSystem", fallbackMethod = "cardSystemFallback")
     public Document fetchCardTrjnListByDateDocument(String sessionId, int year, int month, int date, int pageIndex) throws IOException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, true, CARD_TIMEOUT_SEC);
         CloseableHttpClient httpClient = httpClientSession.getCloseableHttpClient();
@@ -103,6 +107,7 @@ public class CardClient {
     /**
      * 挂失流程：拉取挂失页 Document（POST LossCard needHeader=false）
      */
+    @CircuitBreaker(name = "cardSystem", fallbackMethod = "cardSystemFallback")
     public Document fetchLossCardPageDocument(String sessionId) throws IOException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, true, CARD_TIMEOUT_SEC);
         CloseableHttpClient httpClient = httpClientSession.getCloseableHttpClient();
@@ -126,6 +131,7 @@ public class CardClient {
     /**
      * 挂失流程：获取安全键盘图片（返回字节数组，避免连接关闭后流不可读）
      */
+    @CircuitBreaker(name = "cardSystem", fallbackMethod = "cardSystemFallbackBytes")
     public byte[] fetchKeyPadImage(String sessionId) throws IOException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, true, CARD_TIMEOUT_SEC);
         CloseableHttpClient httpClient = httpClientSession.getCloseableHttpClient();
@@ -146,6 +152,7 @@ public class CardClient {
     /**
      * 挂失流程：获取验证码图片（relativePath 如 /Account/GetCheckCodeImg?xxx）
      */
+    @CircuitBreaker(name = "cardSystem", fallbackMethod = "cardSystemFallbackBytes")
     public byte[] fetchCheckcodeImage(String sessionId, String relativePath) throws IOException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, true, CARD_TIMEOUT_SEC);
         CloseableHttpClient httpClient = httpClientSession.getCloseableHttpClient();
@@ -175,7 +182,9 @@ public class CardClient {
     /**
      * 挂失流程：提交挂失请求，返回响应 JSON 字符串（含 ret、msg）
      */
-    public String submitSetCardLost(String sessionId, String passwordMapped, String checkCode) throws IOException, ServerErrorException {
+    @CircuitBreaker(name = "cardSystem", fallbackMethod = "cardSystemFallbackString")
+    public String submitSetCardLost(String sessionId, String passwordMapped, String checkCode)
+            throws IOException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, true, CARD_TIMEOUT_SEC);
         CloseableHttpClient httpClient = httpClientSession.getCloseableHttpClient();
         CookieStore cookieStore = httpClientSession.getCookieStore();
@@ -197,5 +206,35 @@ public class CardClient {
             if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
+    }
+
+    // ---- Circuit breaker fallback methods ----
+
+    private Document cardSystemFallback(String sessionId, Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("一卡通系统暂时不可用，请稍后再试");
+    }
+
+    private Document cardSystemFallback(String sessionId, int type, int pageIndex,
+                                        Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("一卡通系统暂时不可用，请稍后再试");
+    }
+
+    private Document cardSystemFallback(String sessionId, int year, int month, int date, int pageIndex,
+                                        Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("一卡通系统暂时不可用，请稍后再试");
+    }
+
+    private byte[] cardSystemFallbackBytes(String sessionId, Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("一卡通系统暂时不可用，请稍后再试");
+    }
+
+    private byte[] cardSystemFallbackBytes(String sessionId, String relativePath,
+                                           Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("一卡通系统暂时不可用，请稍后再试");
+    }
+
+    private String cardSystemFallbackString(String sessionId, String passwordMapped, String checkCode,
+                                            Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("一卡通系统暂时不可用，请稍后再试");
     }
 }

--- a/src/main/java/cn/gdeiassistant/integration/edu/EduSystemClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/edu/EduSystemClient.java
@@ -19,6 +19,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ public class EduSystemClient {
      * @param credential 教务会话凭证
      * @return 成绩查询列表页 Jsoup Document
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document fetchGradeListPage(String sessionId, EduSessionCredential credential)
             throws IOException, TimeStampIncorrectException, PasswordIncorrectException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, false, EDU_REQUEST_TIMEOUT_SEC);
@@ -97,6 +99,7 @@ public class EduSystemClient {
      * @param yearOptionValue 学年下拉框选项 value（如 "2024-2025"）
      * @return 该学年成绩表页 Jsoup Document（含 datelist 表格）
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document fetchGradeByYear(String sessionId, EduSessionCredential credential,
                                      String viewState, String yearOptionValue)
             throws IOException, PasswordIncorrectException, ServerErrorException {
@@ -133,6 +136,7 @@ public class EduSystemClient {
      * @param credential 教务会话凭证
      * @return 课表页 Jsoup Document（含 Table1）
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document fetchScheduleDocument(String sessionId, EduSessionCredential credential)
             throws IOException, TimeStampIncorrectException, PasswordIncorrectException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, false, EDU_REQUEST_TIMEOUT_SEC);
@@ -242,6 +246,7 @@ public class EduSystemClient {
     /**
      * 空闲教室：时间戳校验 + 进入学生主页 + 打开空课室查询页（xxjsjy.aspx），返回初始页 Document，供 Service 解析表单并组 POST 参数。
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document fetchSpareRoomInitialDocument(String sessionId, EduSessionCredential credential)
             throws IOException, TimeStampIncorrectException, PasswordIncorrectException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, false, EDU_REQUEST_TIMEOUT_SEC);
@@ -293,6 +298,7 @@ public class EduSystemClient {
      * @param formAction Form1 的 action 相对路径（如 xxjsjy.aspx）
      * @param formParams 表单参数列表（__EVENTTARGET、__VIEWSTATE、xiaoq、jslb 等）
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document submitSpareRoomForm(String sessionId, EduSessionCredential credential,
                                         String formAction, List<BasicNameValuePair> formParams)
             throws IOException, ServerErrorException {
@@ -320,6 +326,7 @@ public class EduSystemClient {
     /**
      * 教务学生主页：时间戳校验 + 进入 xs_main，返回学生主页 Document。供评教等仅需主页菜单的流程使用。
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document fetchEduMainPage(String sessionId, EduSessionCredential credential)
             throws IOException, TimeStampIncorrectException, PasswordIncorrectException, ServerErrorException {
         HttpClientSession httpClientSession = HttpClientUtils.getHttpClient(sessionId, false, EDU_REQUEST_TIMEOUT_SEC);
@@ -365,6 +372,7 @@ public class EduSystemClient {
      *
      * @param relativePath 相对路径，如 xs_jxpj.aspx?xh=xxx，可有或无前导 /
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document fetchEduPage(String sessionId, EduSessionCredential credential, String relativePath)
             throws IOException, ServerErrorException {
         String path = relativePath != null && relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
@@ -398,6 +406,7 @@ public class EduSystemClient {
      * @param term 学期（POST 时使用，可为空）
      * @return 课表页 Jsoup Document（含 Table6）
      */
+    @CircuitBreaker(name = "eduSystem", fallbackMethod = "eduSystemFallback")
     public Document fetchTeacherScheduleDocument(String sessionId, String teacherUsername, String teacherName,
                                                  String year, String term)
             throws IOException, PasswordIncorrectException, ServerErrorException {
@@ -461,5 +470,35 @@ public class EduSystemClient {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
         }
+    }
+
+    // ---- Circuit breaker fallback methods ----
+
+    private Document eduSystemFallback(String sessionId, EduSessionCredential credential,
+                                       Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("教务系统暂时不可用，请稍后再试");
+    }
+
+    private Document eduSystemFallback(String sessionId, EduSessionCredential credential,
+                                       String viewState, String yearOptionValue,
+                                       Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("教务系统暂时不可用，请稍后再试");
+    }
+
+    private Document eduSystemFallback(String sessionId, EduSessionCredential credential,
+                                       String formAction, List<BasicNameValuePair> formParams,
+                                       Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("教务系统暂时不可用，请稍后再试");
+    }
+
+    private Document eduSystemFallback(String sessionId, EduSessionCredential credential,
+                                       String relativePath, Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("教务系统暂时不可用，请稍后再试");
+    }
+
+    private Document eduSystemFallback(String sessionId, String teacherUsername, String teacherName,
+                                       String year, String term,
+                                       Throwable t) throws ServerErrorException {
+        throw new ServerErrorException("教务系统暂时不可用，请稍后再试");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -213,3 +213,26 @@ theme:
 observability:
   slow-request-threshold-ms: ${SLOW_REQUEST_THRESHOLD_MS:800}
   slow-query-threshold-ms: ${SLOW_QUERY_THRESHOLD_MS:1500}
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      eduSystem:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        slow-call-duration-threshold: 8s
+        slow-call-rate-threshold: 80
+      cardSystem:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        slow-call-duration-threshold: 10s
+        slow-call-rate-threshold: 80
+    instances:
+      eduSystem:
+        base-config: eduSystem
+      cardSystem:
+        base-config: cardSystem


### PR DESCRIPTION
## Summary
- Add Resilience4j circuit breaker to EduSystemClient (7 methods) and CardClient (7 methods)
- Prevents cascading failures when school systems are down
- Reduce cookie credential TTL from 30 days to 7 days
- Clear fallback messages: "教务系统暂时不可用" / "一卡通系统暂时不可用"

## Test plan
- [ ] Verify grade/schedule queries work normally
- [ ] Verify circuit opens after repeated failures (simulate by blocking edu system)
- [ ] Verify circuit half-opens after 30s and retries
- [ ] Verify cookie credentials expire after 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)