### PR TITLE
security: fix global review findings — rate limits, XSS, pagination, IP spoofing

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/cn/gdeiassistant/common/interceptor/RateLimitInterceptor.java
@@ -33,9 +33,9 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String clientIp = getClientIp(request);
+        String rateLimitKey = getRateLimitKey(request);
         String path = request.getRequestURI();
-        String key = clientIp + ":" + path;
+        String key = rateLimitKey + ":" + path;
 
         long now = System.currentTimeMillis();
         long windowMillis = rateLimit.windowSeconds() * 1000L;
@@ -48,7 +48,7 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         }
 
         if (timestamps.size() >= rateLimit.maxRequests()) {
-            log.warn("请求限流: IP={}, path={}, 窗口内请求数={}", clientIp, path, timestamps.size());
+            log.warn("请求限流: key={}, path={}, 窗口内请求数={}", rateLimitKey, path, timestamps.size());
             response.setStatus(429);
             response.setContentType("application/json");
             response.setCharacterEncoding("UTF-8");
@@ -61,15 +61,13 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         return true;
     }
 
-    private String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
-            return ip.split(",")[0].trim();
+    private String getRateLimitKey(HttpServletRequest request) {
+        // For authenticated requests, use sessionId to prevent IP spoofing
+        Object sessionId = request.getAttribute("sessionId");
+        if (sessionId != null && !sessionId.toString().isEmpty()) {
+            return "session:" + sessionId;
         }
-        ip = request.getHeader("X-Real-IP");
-        if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
-            return ip;
-        }
-        return request.getRemoteAddr();
+        // For unauthenticated requests, use remote addr (not forwarded headers)
+        return "ip:" + request.getRemoteAddr();
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.dating.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.constant.ValueConstantUtils;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
@@ -96,6 +97,7 @@ public class DatingController {
         return new DataJsonResult<>(true, datingService.queryMyReceivedPicks(sessionId));
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/dating/profile", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addRoommateProfile(HttpServletRequest request, @Validated DatingPublishDTO dto,
@@ -133,6 +135,7 @@ public class DatingController {
         return new JsonResult(true);
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/dating/pick", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addRoommatePick(HttpServletRequest request, @Validated DatingPickSubmitDTO dto) throws SelfPickException, RepeatPickException, DataNotExistException {

--- a/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.delivery.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
@@ -79,6 +80,7 @@ public class DeliveryController {
     @RequestMapping(value = "/api/delivery/order/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<DeliveryOrderVO>> queryDeliveryOrderPage(HttpServletRequest request, @PathVariable("start") @Min(0) Integer start
             , @PathVariable("size") @Min(1) Integer size) {
+        if (size > 50) size = 50; // Cap page size
         List<DeliveryOrderVO> list = deliveryService.queryDeliveryOrderPage(start, size);
         return new DataJsonResult<>(true, list);
     }
@@ -138,6 +140,7 @@ public class DeliveryController {
      * @param deliveryOrder
      * @return
      */
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/delivery/order", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addDeliveryOrder(HttpServletRequest request, @Validated DeliveryPublishDTO dto) {

--- a/src/main/java/cn/gdeiassistant/core/email/controller/EmailController.java
+++ b/src/main/java/cn/gdeiassistant/core/email/controller/EmailController.java
@@ -6,6 +6,7 @@ import cn.gdeiassistant.common.pojo.Entity.Email;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
 import cn.gdeiassistant.core.email.service.EmailService;
+import cn.gdeiassistant.common.annotation.RateLimit;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,7 @@ public class EmailController {
      * @param email
      * @return
      */
+    @RateLimit(maxRequests = 3, windowSeconds = 60)
     @RequestMapping(value = "/api/email/verification", method = RequestMethod.POST)
     public JsonResult getEmailVerificationCode(HttpServletRequest request
             , @Validated @NotBlank @Length(min = 5, max = 50) @Pattern(regexp = "^\\w+([-+.]\\w+)*@\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*$") String email) throws SendEmailException {

--- a/src/main/java/cn/gdeiassistant/core/express/controller/ExpressController.java
+++ b/src/main/java/cn/gdeiassistant/core/express/controller/ExpressController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.express.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
@@ -35,6 +36,7 @@ public class ExpressController {
     @RequestMapping(value = "/api/express/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<ExpressVO>> getMyExpressList(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<ExpressVO> list = expressService.queryMyExpressList(sessionId, start, size);
         return new DataJsonResult<>(true, list);
@@ -50,6 +52,7 @@ public class ExpressController {
     @RequestMapping(value = "/api/express/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<ExpressVO>> queryExpressPage(HttpServletRequest request, @PathVariable("start") int start
             , @PathVariable("size") int size) {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<ExpressVO> list = expressService.queryExpressPage(start, size, sessionId);
         return new DataJsonResult<>(true, list);
@@ -58,11 +61,13 @@ public class ExpressController {
     @RequestMapping(value = "/api/express/keyword/{keyword}/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<ExpressVO>> queryExpressPageByKeyWord(HttpServletRequest request, @PathVariable("keyword") String keyword
             , @PathVariable("start") int start, @PathVariable("size") int size) {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<ExpressVO> list = expressService.queryExpressPageByKeyword(sessionId, start, size, keyword);
         return new DataJsonResult<>(true, list);
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/express", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addExpress(HttpServletRequest request, @Validated ExpressPublishDTO dto) {

--- a/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
+++ b/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.lostandfound.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.constant.ValueConstantUtils;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
@@ -117,6 +118,7 @@ public class LostAndFoundController {
         return new JsonResult(true);
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/lostandfound/item", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addLostAndFoundInfo(HttpServletRequest request,

--- a/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.marketplace.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.constant.ValueConstantUtils;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
@@ -68,6 +69,7 @@ public class MarketplaceController {
         return new DataJsonResult<>(true, data);
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/ershou/item", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addItem(HttpServletRequest request,

--- a/src/main/java/cn/gdeiassistant/core/phone/controller/PhoneController.java
+++ b/src/main/java/cn/gdeiassistant/core/phone/controller/PhoneController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.phone.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.exception.VerificationException.SendSMSException;
 import cn.gdeiassistant.common.exception.VerificationException.VerificationCodeInvalidException;
 import cn.gdeiassistant.common.pojo.Entity.Attribution;
@@ -54,6 +55,7 @@ public class PhoneController {
      * @param phone
      * @return
      */
+    @RateLimit(maxRequests = 3, windowSeconds = 60)
     @RequestMapping(value = "/api/phone/verification", method = RequestMethod.POST)
     public JsonResult GetPhoneVerificationCode(HttpServletRequest request, @Validated @NotNull @Min(0) @Max(999) Integer code
             , @Validated @NotBlank @Length(min = 7, max = 11) @Pattern(regexp = "^[0-9]*$") String phone) throws SendSMSException {

--- a/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.photograph.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.constant.ValueConstantUtils;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
@@ -57,6 +58,7 @@ public class PhotographController {
     public DataJsonResult<List<PhotographVO>> queryPhotographList(HttpServletRequest request
             , @Validated @NotNull @Min(0) @Max(1) @PathVariable("type") int type
             , @PathVariable("start") int start, @PathVariable("size") int size) {
+        if (size > 50) size = 50; // Cap page size
         List<PhotographVO> list = photographService.queryPhotographList(start, size, type, (String) request.getAttribute("sessionId"));
         return new DataJsonResult<>(true, list);
     }
@@ -93,11 +95,13 @@ public class PhotographController {
     @RequestMapping(value = "/api/photograph/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<PhotographVO>> getMyPhotographs(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<PhotographVO> list = photographService.queryMyPhotographList(sessionId, start, size);
         return new DataJsonResult<>(true, list);
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/photograph", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addPhotograph(HttpServletRequest request, @Validated PhotographPublishDTO dto

--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.secret.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.constant.ValueConstantUtils;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
@@ -48,6 +49,7 @@ public class SecretController {
     @RequestMapping(value = "/api/secret/info/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<SecretVO>> getMoreSecret(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) throws Exception {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<SecretVO> list = secretService.getSecretInfo(start, size, sessionId);
         return new DataJsonResult<>(true, list);
@@ -61,6 +63,7 @@ public class SecretController {
         return new DataJsonResult<>(true, list);
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/secret/info", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addSecretInfo(HttpServletRequest request, @Validated SecretPublishDTO dto

--- a/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.core.topic.controller;
 
+import cn.gdeiassistant.common.annotation.RateLimit;
 import cn.gdeiassistant.common.annotation.RecordIPAddress;
 import cn.gdeiassistant.common.constant.ValueConstantUtils;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
@@ -28,6 +29,7 @@ public class TopicController {
     @RequestMapping(value = "/api/topic/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<TopicVO>> getMyTopicList(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<TopicVO> list = topicService.queryMyTopicList(sessionId, start, size);
         return new DataJsonResult<>(true, list);
@@ -43,6 +45,7 @@ public class TopicController {
     @RequestMapping(value = "/api/topic/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<TopicVO>> queryTopic(HttpServletRequest request, @PathVariable("start") int start
             , @PathVariable("size") int size) {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<TopicVO> list = topicService.queryTopic(sessionId, start, size);
         return new DataJsonResult<>(true, list);
@@ -51,11 +54,13 @@ public class TopicController {
     @RequestMapping(value = "/api/topic/keyword/{keyword}/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<TopicVO>> queryTopicByKeyword(HttpServletRequest request, @PathVariable("start") int start
             , @PathVariable("size") int size, @PathVariable("keyword") String keyword) {
+        if (size > 50) size = 50; // Cap page size
         String sessionId = (String) request.getAttribute("sessionId");
         List<TopicVO> list = topicService.queryTopicByKeyword(sessionId, start, size, keyword);
         return new DataJsonResult<>(true, list);
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/topic", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addTopic(HttpServletRequest request, @Validated TopicPublishDTO dto,

--- a/src/main/java/cn/gdeiassistant/core/userlogin/service/UserCertificateService.java
+++ b/src/main/java/cn/gdeiassistant/core/userlogin/service/UserCertificateService.java
@@ -220,6 +220,10 @@ public class UserCertificateService {
                         // Validate redirect URL stays within trusted school domains
                         try {
                             java.net.URI uri = java.net.URI.create(casRedirectUrl);
+                            String scheme = uri.getScheme();
+                            if (scheme != null && !scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https")) {
+                                throw new ServerErrorException("CAS重定向地址协议不安全");
+                            }
                             String host = uri.getHost();
                             if (host != null && !host.toLowerCase().endsWith(".gdei.edu.cn") && !host.toLowerCase().equals("gdei.edu.cn")) {
                                 throw new ServerErrorException("CAS重定向地址不在可信域名范围内");
@@ -307,6 +311,10 @@ public class UserCertificateService {
             // Validate redirect URL stays within trusted school domains
             try {
                 java.net.URI uri1 = java.net.URI.create(loginRedirect1);
+                String scheme1 = uri1.getScheme();
+                if (scheme1 != null && !scheme1.equalsIgnoreCase("http") && !scheme1.equalsIgnoreCase("https")) {
+                    throw new ServerErrorException("CAS重定向地址协议不安全");
+                }
                 String host1 = uri1.getHost();
                 if (host1 != null && !host1.toLowerCase().endsWith(".gdei.edu.cn") && !host1.toLowerCase().equals("gdei.edu.cn")) {
                     throw new ServerErrorException("CAS重定向地址不在可信域名范围内");

--- a/src/main/java/cn/gdeiassistant/core/userprofile/controller/ProfileController.java
+++ b/src/main/java/cn/gdeiassistant/core/userprofile/controller/ProfileController.java
@@ -17,6 +17,7 @@ import cn.gdeiassistant.core.profile.service.UserProfileService;
 import cn.gdeiassistant.core.userProfile.service.ProfileOptionsFacade;
 import cn.gdeiassistant.common.tools.Utils.LocationUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
+import org.springframework.web.util.HtmlUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -160,6 +161,8 @@ public class ProfileController {
         if (introduction != null && introduction.length() <= 80) {
             if (introduction.isEmpty()) {
                 introduction = null;
+            } else {
+                introduction = HtmlUtils.htmlEscape(introduction);
             }
             userProfileService.updateIntroduction((String) request.getAttribute("sessionId"), introduction);
             return new JsonResult(true);
@@ -257,7 +260,9 @@ public class ProfileController {
             return new JsonResult(false, "不合法的国家/地区代码");
         }
         ProfileLocationValidator.ValidationResult vr = profileLocationValidator.validate(
-                body.getRegion(), body.getState(), body.getCity());
+                HtmlUtils.htmlEscape(body.getRegion()),
+                body.getState() != null ? HtmlUtils.htmlEscape(body.getState()) : null,
+                body.getCity() != null ? HtmlUtils.htmlEscape(body.getCity()) : null);
         if (!vr.isValid()) {
             return new JsonResult(false, vr.getErrorMessage());
         }
@@ -280,7 +285,9 @@ public class ProfileController {
             return new JsonResult(false, "不合法的国家/地区代码");
         }
         ProfileLocationValidator.ValidationResult vr = profileLocationValidator.validate(
-                body.getRegion(), body.getState(), body.getCity());
+                HtmlUtils.htmlEscape(body.getRegion()),
+                body.getState() != null ? HtmlUtils.htmlEscape(body.getState()) : null,
+                body.getCity() != null ? HtmlUtils.htmlEscape(body.getCity()) : null);
         if (!vr.isValid()) {
             return new JsonResult(false, vr.getErrorMessage());
         }
@@ -303,6 +310,7 @@ public class ProfileController {
         if (major == null || major.isEmpty() || major.length() > 20) {
             return new JsonResult(false, "专业长度不合法");
         }
+        major = HtmlUtils.htmlEscape(major);
         userProfileService.updateMajor((String) request.getAttribute("sessionId"), major);
         return new JsonResult(true);
     }
@@ -343,6 +351,7 @@ public class ProfileController {
         if (nickname == null || nickname.isEmpty() || nickname.length() > 32) {
             return new JsonResult(false, "昵称长度不合法");
         }
+        nickname = HtmlUtils.htmlEscape(nickname);
         userProfileService.updateNickname((String) request.getAttribute("sessionId"), nickname);
         return new JsonResult(true);
     }

--- a/src/main/java/cn/gdeiassistant/integration/cas/CasClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/cas/CasClient.java
@@ -85,6 +85,10 @@ public class CasClient {
             // Validate redirect URL stays within trusted school domains
             try {
                 java.net.URI uri = java.net.URI.create(redirectUrl);
+                String scheme = uri.getScheme();
+                if (scheme != null && !scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https")) {
+                    throw new ServerErrorException("CAS重定向地址协议不安全");
+                }
                 String host = uri.getHost();
                 if (host != null && !host.toLowerCase().endsWith(".gdei.edu.cn") && !host.toLowerCase().equals("gdei.edu.cn")) {
                     throw new ServerErrorException("CAS重定向地址不在可信域名范围内");


### PR DESCRIPTION
## Summary
- Rate limit SMS/email verification endpoints (3/min)
- Rate limit all community POST endpoints (5/min) — secret, topic, marketplace, lostfound, express, delivery, dating, photograph
- Fix rate limit IP spoofing: session-based keys for authenticated users, remoteAddr for anonymous
- Sanitize profile text fields with HtmlUtils.htmlEscape() to prevent stored XSS
- Cap pagination to max 50 items per page across all list endpoints
- Validate CAS redirect URL scheme (block javascript:/data: URIs)

## Test plan
- [ ] Verify SMS/email verification returns 429 after 3 rapid requests
- [ ] Verify community posting returns 429 after 5 rapid requests
- [ ] Verify rate limit cannot be bypassed with fake X-Forwarded-For
- [ ] Verify profile nickname with `<script>` tags gets escaped
- [ ] Verify list endpoints cap at 50 items even if size=9999

🤖 Generated with [Claude Code](https://claude.com/claude-code)