### PR TITLE
fix: prevent log injection in rate limiter (CodeQL #129)

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/cn/gdeiassistant/common/interceptor/RateLimitInterceptor.java
@@ -48,7 +48,7 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         }
 
         if (timestamps.size() >= rateLimit.maxRequests()) {
-            log.warn("请求限流: key={}, path={}, 窗口内请求数={}", rateLimitKey, path, timestamps.size());
+            log.warn("请求限流: key={}, path={}, 窗口内请求数={}", sanitizeLogParam(rateLimitKey), sanitizeLogParam(path), timestamps.size());
             response.setStatus(429);
             response.setContentType("application/json");
             response.setCharacterEncoding("UTF-8");
@@ -59,6 +59,11 @@ public class RateLimitInterceptor implements HandlerInterceptor {
 
         timestamps.addLast(now);
         return true;
+    }
+
+    private static String sanitizeLogParam(String value) {
+        if (value == null) return "null";
+        return value.replaceAll("[\\r\\n\\t]", "_");
     }
 
     private String getRateLimitKey(HttpServletRequest request) {


### PR DESCRIPTION
## Summary
Sanitize `rateLimitKey` and `path` in log output to prevent log injection via crafted session IDs containing newlines.

Fixes CodeQL code scanning alert: https://github.com/GdeiAssistant/GdeiAssistant/security/code-scanning/129

## Test plan
- [ ] Verify rate limit logs no longer contain raw user input

🤖 Generated with [Claude Code](https://claude.com/claude-code)