### PR TITLE
fix: UI polish and mock state fixes

### DIFF
--- a/frontend/src/mock/index.js
+++ b/frontend/src/mock/index.js
@@ -27,7 +27,8 @@ function readState() {
     cardLostState: '正常',
     renewedBookCodes: [],
     profile: cloneValue(data.BASE_PROFILE),
-    interactionMessages: cloneValue(data.INTERACTION_MESSAGES)
+    interactionMessages: cloneValue(data.INTERACTION_MESSAGES),
+    userdataExportStatus: 0
   }
 
   try {
@@ -45,7 +46,8 @@ function readState() {
         renewedBookCodes: Array.isArray(state.renewedBookCodes) ? state.renewedBookCodes : [],
         profile: Object.assign({}, cloneValue(data.BASE_PROFILE), state.profile || {}),
         interactionMessages: Array.isArray(state.interactionMessages) ? state.interactionMessages : cloneValue(data.INTERACTION_MESSAGES),
-        community: state.community || undefined
+        community: state.community || undefined,
+        userdataExportStatus: typeof state.userdataExportStatus === 'number' ? state.userdataExportStatus : 0
       }
     }
   } catch (error) {
@@ -395,12 +397,16 @@ export function handleRequest(options) {
   if (path === '/api/userdata/state' && method === 'GET') {
     const authError = ensureAuthorized(token)
     if (authError) return authError
-    return resolveWithDelay(buildSuccess(0))
+    const s = readState()
+    return resolveWithDelay(buildSuccess(s.userdataExportStatus ?? 0))
   }
 
   if (path === '/api/userdata/export' && method === 'POST') {
     const authError = ensureAuthorized(token)
     if (authError) return authError
+    const s = readState()
+    s.userdataExportStatus = 2
+    saveState(s)
     return resolveWithDelay(buildSuccess(null))
   }
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -158,7 +158,7 @@ import { logout } from '../api/user.js'
 import { useToast } from '@/composables/useToast'
 import AppCard from '@/components/ui/AppCard.vue'
 import {
-  Shield, LayoutGrid, Palette, Smartphone, BadgeCheck,
+  Shield, Lock, LayoutGrid, Palette, Smartphone, BadgeCheck,
   Mail, Trash2, Download, MessageSquare, MessageCircle, LogOut, ChevronRight
 } from 'lucide-vue-next'
 

--- a/frontend/src/views/book/Book.vue
+++ b/frontend/src/views/book/Book.vue
@@ -56,7 +56,7 @@ function isReturnDateUrgent(returnDateStr) {
 function onRenew(item) {
   if (!item || item.sn == null || item.code == null) return
   renewingItem.value = item
-  verifyPassword.value = (borrowPassword.value || '').trim()
+  verifyPassword.value = ''
   showPasswordDialog.value = true
 }
 

--- a/frontend/src/views/info/InteractionList.vue
+++ b/frontend/src/views/info/InteractionList.vue
@@ -5,17 +5,6 @@
     </div>
 
     <template v-else>
-      <div
-        v-if="unreadCount > 0"
-        class="flex justify-end"
-      >
-        <button
-          type="button"
-          class="text-xs text-[var(--c-text-2)] bg-[var(--c-surface)] border border-[var(--c-border)] rounded-lg px-3 py-1.5 hover:bg-[var(--c-surface-hover)] transition-colors"
-          @click="markAllRead"
-        >全部已读</button>
-      </div>
-
       <div v-if="!items.length" class="py-16 text-center text-sm text-[var(--c-text-3)]">暂无互动消息</div>
 
       <button
@@ -41,15 +30,23 @@
         </div>
       </button>
 
-      <button
-        v-if="hasMore"
-        type="button"
-        class="w-full py-3 text-sm text-[var(--c-text-2)] bg-[var(--c-surface)] border border-[var(--c-border)] rounded-[14px] hover:bg-[var(--c-surface-hover)] transition-colors"
-        :disabled="loadingMore"
-        @click="loadMore"
-      >
-        {{ loadingMore ? '加载中...' : '加载更多' }}
-      </button>
+      <div v-if="hasMore || unreadCount > 0" class="flex gap-2">
+        <button
+          v-if="unreadCount > 0"
+          type="button"
+          class="flex-1 py-3 text-sm text-[var(--c-text-2)] bg-[var(--c-surface)] border border-[var(--c-border)] rounded-[14px] hover:bg-[var(--c-surface-hover)] transition-colors"
+          @click="markAllRead"
+        >全部已读</button>
+        <button
+          v-if="hasMore"
+          type="button"
+          class="flex-1 py-3 text-sm text-[var(--c-text-2)] bg-[var(--c-surface)] border border-[var(--c-border)] rounded-[14px] hover:bg-[var(--c-surface-hover)] transition-colors"
+          :disabled="loadingMore"
+          @click="loadMore"
+        >
+          {{ loadingMore ? '加载中...' : '加载更多' }}
+        </button>
+      </div>
     </template>
   </div>
 </template>

--- a/frontend/src/views/user/DeleteAccount.vue
+++ b/frontend/src/views/user/DeleteAccount.vue
@@ -2,8 +2,8 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import request from '../../utils/request'
-import { showErrorTopTips } from '@/utils/toast.js'
 import { useToast } from '@/composables/useToast'
+import { AlertTriangle } from 'lucide-vue-next'
 
 const router = useRouter()
 const { success: toastSuccess } = useToast()
@@ -55,7 +55,7 @@ async function handleConfirmDelete() {
     <div class="max-w-lg mx-auto px-4 py-6">
       <!-- Warning header -->
       <div class="bg-white rounded-xl shadow-sm p-8 text-center mb-3">
-        <div class="text-6xl text-red-500 mb-5">&#9888;</div>
+        <div class="text-6xl text-red-500 mb-5"><AlertTriangle class="w-16 h-16 mx-auto" /></div>
         <h2 class="text-lg font-semibold text-gray-800 leading-snug">将注销您的广东第二师范学院助手账号</h2>
       </div>
 


### PR DESCRIPTION
## Summary

- **Settings.vue**: restore missing `Lock` import so the password row icon renders correctly
- **InteractionList.vue**: move the mark-all-read button to the bottom row alongside load-more
- **DeleteAccount.vue**: replace `&#9888;` HTML entity with lucide `AlertTriangle` to prevent double-glyph rendering on some fonts; remove unused `showErrorTopTips` import
- **mock/index.js**: persist userdata export status in mock state so the export → download flow survives page refresh instead of resetting to not-exported
- **Book.vue**: clear the renew password input when opening the dialog instead of pre-filling with the query password

## Test plan

- [ ] Settings page "Change Password" row shows Lock icon
- [ ] Interaction messages: mark-all-read and load-more buttons appear on the same row
- [ ] Delete account page shows a single AlertTriangle icon (no double glyph)
- [ ] Download personal data: export status persists after page refresh
- [ ] Book renew dialog opens with an empty password field

🤖 Generated with [Claude Code](https://claude.com/claude-code)