### PR TITLE
[codex] soften web surface radius

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -31,7 +31,7 @@
 
   --radius-sm: 8px;
   --radius-md: 10px;
-  --radius-lg: 14px;
+  --radius-lg: 16px;
   --radius-xl: 20px;
   --radius-full: 9999px;
 }


### PR DESCRIPTION
## What changed
- increase the shared web large radius token from 14px to 16px
- keep the change scoped to the shared CSS token so existing components pick it up automatically

## Why
- soften large surfaces so the web UI feels closer to the native polish work landing in the other clients

## Impact
- cards, sheets, and other large-radius surfaces render with slightly softer corners on web

## Validation
- npm --prefix frontend run test:unit
- npm --prefix frontend run build