### PR TITLE
[codex] upgrade Actions to Node 24 and CodeQL v4

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload test reports on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-reports
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,16 +20,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
           queries: security-and-quality
@@ -41,6 +41,6 @@ jobs:
           ENCRYPT_ENABLE: 'false'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:java-kotlin"

--- a/.github/workflows/hide-codex-limit-comments.yml
+++ b/.github/workflows/hide-codex-limit-comments.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Minimize comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const mutation = `


### PR DESCRIPTION
## What changed
- upgrade `actions/checkout` to v5, `actions/setup-java` to v5, `actions/cache` to v5, and `actions/upload-artifact` to v6
- upgrade `github/codeql-action` from v3 to v4
- upgrade `actions/github-script` from v7 to v8 in the Codex comment minimizer workflow

## Why
- remove GitHub Actions warnings about Node.js 20 deprecation
- remove the CodeQL Action v3 deprecation warning before the workflow starts breaking in the future

## Validation
- ruby YAML parse for all workflow files in this repo