### PR TITLE
Support external databases for staging and production

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,24 +32,34 @@ MONGO_EXPOSE_PORT=27017
 # Spring Profile：可选；统一使用 development / staging / production
 SPRING_PROFILES_ACTIVE=development
 
-# MySQL：本地直跑后端通常需要；使用 Docker Compose 时 DB_PASSWORD 为必填项
+# MySQL：本地直跑后端通常需要；使用 Docker Compose 时默认走 root@localhost
+# 演示 / 生产若接外部 MySQL，可改 DB_USERNAME / DB_JDBC_PARAMS，或直接覆盖三套 JDBC URL
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=gdeiassistant
 DB_NAME_LOG=gdeiassistant_log
 DB_NAME_DATA=gdeiassistant_data
+DB_USERNAME=root
 DB_PASSWORD=
+DB_JDBC_PARAMS=useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
+DB_JDBC_URL_APP=
+DB_JDBC_URL_LOG=
+DB_JDBC_URL_DATA=
 
-# Redis：按需；需要密码时填写 REDIS_PASSWORD，留空表示无密码
+# Redis：按需；外部托管 Redis 如要求 ACL/TLS，可配置 REDIS_USERNAME / REDIS_SSL_ENABLED
 REDIS_HOST=localhost
 REDIS_PORT=6379
+REDIS_USERNAME=
 REDIS_PASSWORD=
 REDIS_DATABASE=0
+REDIS_SSL_ENABLED=false
 
-# MongoDB：按需；启用依赖 Mongo 的功能时需要可用实例
+# MongoDB：按需；本地默认走 host/port/database
+# 如使用外部托管 MongoDB，优先填写完整连接串 MONGO_URI（包含账号、密码、TLS、数据库）
 MONGO_HOST=localhost
 MONGO_PORT=27017
 MONGO_DATABASE=gdeiassistant
+MONGO_URI=
 
 # 必填：JWT 签名密钥，建议至少 32 位随机串
 JWT_SECRET=

--- a/README.md
+++ b/README.md
@@ -44,9 +44,16 @@ cp .env.template .env
 
 填写数据库密码、Redis、JWT 等（见模板注释）。环境语义统一为：
 
-- `development`：本地开发
-- `staging`：测试验证
-- `production`：正式环境
+- `development`：本地开发，保持仓库内全栈 Docker 方案
+- `staging`：演示 / 测试环境，推荐前后端与数据库拆开部署
+- `production`：正式环境，推荐前后端与数据库拆开部署
+
+> **演示 / 生产外部数据库常用变量：**
+> - MySQL：`DB_USERNAME`、`DB_JDBC_PARAMS`、`DB_JDBC_URL_APP`、`DB_JDBC_URL_LOG`、`DB_JDBC_URL_DATA`
+> - Redis：`REDIS_USERNAME`、`REDIS_SSL_ENABLED`
+> - MongoDB：`MONGO_URI`
+>
+> 当前 MySQL 仍默认使用三套 schema：`DB_NAME`、`DB_NAME_LOG`、`DB_NAME_DATA`。
 
 > **生产环境必填变量：**
 > - `JWT_SECRET` — JWT 签名密钥（至少 32 位随机串）
@@ -58,10 +65,11 @@ cp .env.template .env
 
 **3. 运行**
 
-- **全栈（Docker）**：`docker compose up -d`（后端 8080，前端 5173）。
-- **测试编排**：`docker compose -f docker-compose-staging.yml up -d`。
-- **生产编排**：`docker compose -f docker-compose-prod.yml up -d`。
+- **开发全栈（Docker）**：`docker compose up -d`（前后端 + MySQL + Redis + MongoDB）。
+- **测试全栈编排**：`docker compose -f docker-compose-staging.yml up -d`。
+- **生产全栈编排**：`docker compose -f docker-compose-prod.yml up -d`。
 - **仅后端**：`./gradlew bootRun`（自动加载根目录 `.env`）。
+- **演示 / 生产推荐形态**：后端单独部署，前端单独构建，数据库改为外部服务；例如演示环境后端可使用 `https://gdeiassistant.azurewebsites.net/api`。
 - **仅前端**：进入前端目录安装依赖并启动开发服务器：
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,36 +17,38 @@ spring:
       max-request-size: 50MB
   datasource:
     app:
-      jdbc-url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:gdeiassistant}?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
-      username: root
+      jdbc-url: ${DB_JDBC_URL_APP:jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:gdeiassistant}?${DB_JDBC_PARAMS:useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true}}
+      username: ${DB_USERNAME:root}
       password: ${DB_PASSWORD:}
       driver-class-name: com.mysql.cj.jdbc.Driver
       hikari:
         maximum-pool-size: 10
         minimum-idle: 2
     log:
-      jdbc-url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME_LOG:gdeiassistant_log}?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
-      username: root
+      jdbc-url: ${DB_JDBC_URL_LOG:jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME_LOG:gdeiassistant_log}?${DB_JDBC_PARAMS:useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true}}
+      username: ${DB_USERNAME:root}
       password: ${DB_PASSWORD:}
       driver-class-name: com.mysql.cj.jdbc.Driver
       hikari:
         maximum-pool-size: 5
     data:
-      jdbc-url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME_DATA:gdeiassistant_data}?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
-      username: root
+      jdbc-url: ${DB_JDBC_URL_DATA:jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME_DATA:gdeiassistant_data}?${DB_JDBC_PARAMS:useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true}}
+      username: ${DB_USERNAME:root}
       password: ${DB_PASSWORD:}
       driver-class-name: com.mysql.cj.jdbc.Driver
       hikari:
         maximum-pool-size: 5
-  redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:6379}
-    password: ${REDIS_PASSWORD:}
-    database: ${REDIS_DATABASE:0}
   data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      username: ${REDIS_USERNAME:}
+      password: ${REDIS_PASSWORD:}
+      database: ${REDIS_DATABASE:0}
+      ssl:
+        enabled: ${REDIS_SSL_ENABLED:false}
     mongodb:
-      uri: mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}
-      database: ${MONGO_DATABASE:gdeiassistant}
+      uri: ${MONGO_URI:mongodb://${MONGO_HOST:localhost}:${MONGO_PORT:27017}/${MONGO_DATABASE:gdeiassistant}}
 
 mybatis:
   configuration:


### PR DESCRIPTION
## Summary
- support external MySQL credentials and JDBC URL overrides for app/log/data schemas
- support external Redis ACL and TLS settings plus external MongoDB URI
- document the recommended deployment split for development vs staging/production

## Testing
- ruby -e 'require "yaml"; YAML.load_file("src/main/resources/application.yml"); puts "application.yml ok"'
- ./gradlew clean test
