### PR TITLE
ci(frontend): add Azure Static Web Apps demo deploy

### DIFF
--- a/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
@@ -27,6 +27,15 @@ jobs:
         with:
           submodules: true
           lfs: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.14.1
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build frontend
+        run: |
+          npm ci --prefix frontend
+          npm run build --prefix frontend
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -36,10 +45,10 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "frontend" # App source code path
+          app_location: "frontend/dist" # Built app content path
           api_location: "" # Api source code path - optional
-          output_location: "dist" # Built app content directory - optional
-          app_build_command: "npm run build"
+          output_location: "" # Empty when skip_app_build is enabled
+          skip_app_build: true
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
@@ -4,16 +4,24 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - master
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml'
 
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      VITE_APP_BASE_API: https://gdeiassistant.azurewebsites.net/api
     steps:
       - uses: actions/checkout@v3
         with:
@@ -31,6 +39,7 @@ jobs:
           app_location: "frontend" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
+          app_build_command: "npm run build"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
@@ -8,12 +8,16 @@ on:
       - 'frontend/**'
       - '.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml'
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     branches:
       - master
     paths:
       - 'frontend/**'
       - '.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml'
+  pull_request_target:
+    types: [closed]
+    branches:
+      - master
 
 jobs:
   build_and_deploy_job:
@@ -52,7 +56,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cp .env.template .env
 - **测试全栈编排**：`docker compose -f docker-compose-staging.yml up -d`。
 - **生产全栈编排**：`docker compose -f docker-compose-prod.yml up -d`。
 - **仅后端**：`./gradlew bootRun`（自动加载根目录 `.env`，按 `development` 语义启动）。
-- **演示 / 生产推荐形态**：后端单独部署，前端单独构建，数据库改为外部服务；例如当前演示环境后端可使用 `https://gdeiassistant.azurewebsites.net/api`。
+- **演示 / 生产推荐形态**：后端单独部署，前端单独构建，数据库改为外部服务；例如当前演示环境前端可使用 `https://gentle-moss-05e781600.7.azurestaticapps.net`，后端 API 使用 `https://gdeiassistant.azurewebsites.net/api`。
 - **仅前端**：进入前端目录安装依赖并启动开发服务器：
 
 
@@ -132,7 +132,7 @@ npm run dev
 
 ## 客户端与官网
 
-[官网](https://gdeiassistant.cn) · [功能演示](https://gdeiassistant.azurewebsites.net) · [Android](https://github.com/GdeiAssistant/GdeiAssistant-Android) · [iOS](https://github.com/GdeiAssistant/GdeiAssistant-iOS) · [微信小程序](https://github.com/GdeiAssistant/GdeiAssistant-WechatApp)
+[官网](https://gdeiassistant.cn) · [功能演示](https://gentle-moss-05e781600.7.azurestaticapps.net) · [后端 API](https://gdeiassistant.azurewebsites.net/actuator/health) · [Android](https://github.com/GdeiAssistant/GdeiAssistant-Android) · [iOS](https://github.com/GdeiAssistant/GdeiAssistant-iOS) · [微信小程序](https://github.com/GdeiAssistant/GdeiAssistant-WechatApp)
 
 ---
 

--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,0 +1,20 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/assets/*",
+      "/*.css",
+      "/*.js",
+      "/*.ico",
+      "/*.png",
+      "/*.jpg",
+      "/*.jpeg",
+      "/*.gif",
+      "/*.svg",
+      "/*.webp",
+      "/*.woff2",
+      "/*.ttf",
+      "/*.map"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary\n- add SPA fallback config for Azure Static Web Apps\n- scope the Azure SWA workflow to frontend changes only\n- inject the demo backend API base URL during SWA builds\n- update README demo links to point at the frontend demo site\n\n## Verify\n- npm --prefix frontend ci\n- VITE_APP_BASE_API=https://gdeiassistant.azurewebsites.net/api npm --prefix frontend run build\n- git diff --check\n\n## Demo URLs\n- Frontend demo: https://gentle-moss-05e781600.7.azurestaticapps.net\n- Backend API: https://gdeiassistant.azurewebsites.net/api\n