### PR TITLE
[codex] clean up social media entry links

### DIFF
--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -106,6 +106,36 @@ function aboutLinkLabel(key) {
   return labels[key] || ABOUT_LINK_LABELS.en[key] || key
 }
 
+const officialMediaLinks = [
+  {
+    key: 'wechat',
+    iconSrc: '/img/about/media/wechat.png',
+    alt: '微信',
+    title: '学校官网微信',
+    href: 'https://www.gdei.edu.cn/3989/list.htm'
+  },
+  {
+    key: 'bilibili',
+    iconSrc: '/img/about/media/bilibili.png',
+    alt: 'B站',
+    title: 'B站',
+    href: 'https://b23.tv/VlE7GPv'
+  },
+  {
+    key: 'xiaohongshu',
+    iconSrc: '/img/about/media/xiaohongshu.png',
+    alt: '小红书',
+    title: '小红书'
+  },
+  {
+    key: 'douyin',
+    iconSrc: '/img/about/media/douyin.png',
+    alt: '抖音',
+    title: '学校官网抖音',
+    href: 'https://www.gdei.edu.cn/3987/list.htm'
+  }
+]
+
 // Cookie 横幅状态
 const showCookieBanner = ref(false)
 
@@ -327,11 +357,23 @@ onMounted(() => {
     <!-- 页脚版权信息 -->
     <div class="w-full max-w-[600px] text-center mt-auto pt-10 border-t border-[var(--color-divider)] px-4">
       <div class="flex justify-center items-center mb-5">
-        <img src="/img/about/media/wechat.png" alt="微信" class="w-6 h-6 mx-2 align-middle opacity-70 transition-opacity duration-300 hover:opacity-100" />
-        <img src="/img/about/media/weibo.png" alt="微博" class="w-6 h-6 mx-2 align-middle opacity-70 transition-opacity duration-300 hover:opacity-100" />
-        <img src="/img/about/media/bilibili.png" alt="B站" class="w-6 h-6 mx-2 align-middle opacity-70 transition-opacity duration-300 hover:opacity-100" />
-        <img src="/img/about/media/xiaohongshu.png" alt="小红书" class="w-6 h-6 mx-2 align-middle opacity-70 transition-opacity duration-300 hover:opacity-100" />
-        <img src="/img/about/media/douyin.png" alt="抖音" class="w-6 h-6 mx-2 align-middle opacity-70 transition-opacity duration-300 hover:opacity-100" />
+        <component
+          v-for="item in officialMediaLinks"
+          :key="item.key"
+          :is="item.href ? 'a' : 'span'"
+          :href="item.href"
+          :title="item.title"
+          :aria-label="item.title"
+          :target="item.href ? '_blank' : undefined"
+          :rel="item.href ? 'noopener noreferrer' : undefined"
+          class="inline-flex items-center justify-center mx-2"
+        >
+          <img
+            :src="item.iconSrc"
+            :alt="item.alt"
+            class="w-6 h-6 align-middle opacity-70 transition-opacity duration-300 hover:opacity-100"
+          />
+        </component>
       </div>
       <p class="text-xs text-[var(--color-text-tertiary)] my-2">Copyright &copy; 2016 - 2026 GdeiAssistant</p>
       <p class="text-xs text-[var(--color-text-tertiary)] my-2">All rights reserved</p>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -161,12 +161,6 @@ function handleThirdPartyLogin(type) {
             @click="handleThirdPartyLogin('QQ')"
           />
           <img
-            src="/img/login/weibo.png"
-            alt="Weibo"
-            class="w-8 h-8 rounded-full cursor-pointer transition-opacity hover:opacity-70 active:opacity-50"
-            @click="handleThirdPartyLogin('Weibo')"
-          />
-          <img
             src="/img/login/apple.png"
             alt="Apple"
             class="w-8 h-8 rounded-full cursor-pointer transition-opacity hover:opacity-70 active:opacity-50"


### PR DESCRIPTION
## Summary
- update the About page footer media icons to remove the Weibo entry
- link the WeChat icon to the school official WeChat page and the Bilibili icon to the provided Bilibili link
- keep the Xiaohongshu icon visible without a click target and remove the Weibo login option from the Login page

## Why
- the current footer still showed a Weibo icon that should be removed
- the school media entry links needed to be aligned with the desired official destinations
- the Login page should no longer expose Weibo as a third-party login option

## Validation
- `npm --prefix frontend run test:unit`
- `npm --prefix frontend run build`

## Notes
- the Xiaohongshu icon is intentionally kept as display-only for now
- the Bilibili destination uses the provided `https://b23.tv/VlE7GPv` link