### PR TITLE
feat(frontend): localize legal page shell copy

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1233,9 +1233,9 @@
     "appIntroContent": "GdeiAssistant is a campus service application exclusively built for Guangdong University of Education. It provides comprehensive academic features such as timetable, grades, CET scores, empty classroom search, library search, borrowing records, teaching evaluation, electricity bills, yellow pages, campus card info, transaction history, and card loss reporting, as well as community platforms including second-hand trading, lost & found, campus confessions, dating, confession wall, delivery, campus photography, topics, and anonymous course reviews. GdeiAssistant aims to deliver top-quality information on teaching, campus life, club activities, entertainment, and academic services for all students and faculty.",
     "screenshotsTitle": "Screenshots",
     "screenshotAlt": "Screenshot {n}",
-    "cookieNotice": "This website uses cookies to provide you with a more convenient and personalised browsing experience. Cookies store useful information on your computer to help us improve the efficiency and relevance of our website. In some cases, they are essential for the website to function properly. By visiting this website, you agree to our use of cookies.",
+    "cookieNotice": "This site uses cookies and browser storage to remember your sign-in status, interface preferences, data source selection, and dismissal of this notice. By continuing, you acknowledge this information.",
     "cookieLearnMore": "Please click {link} for more information.",
-    "cookiePolicy": "Cookie Policy",
+    "cookiePolicy": "Cookie & Local Storage Notice",
     "menuHelp": "Help",
     "menuSecuritySpec": "Security Specifications",
     "menuAccountSpec": "Campus Network Account Guide",
@@ -1244,8 +1244,8 @@
     "menuPrivacyPolicy": "Privacy Policy",
     "menuCommunityGuidelines": "Community Guidelines",
     "menuOpenSourceLicense": "Open Source License",
-    "menuCookiePolicy": "Cookie Policy",
-    "menuIPDeclaration": "Intellectual Property Notice",
+    "menuCookiePolicy": "Cookie & Local Storage Notice",
+    "menuIPDeclaration": "IP Complaints and Counter-Notice Rules",
     "menuFriendlyLinks": "Friendly Links",
     "menuSmartPartyBuilding": "Smart Party Building",
     "menuOpen": "Open menu",
@@ -1255,7 +1255,7 @@
     "securityTitle": "Security Specifications",
     "privacyPolicyTitle": "Privacy Policy",
     "userAgreementTitle": "User Agreement",
-    "chineseOnlyNotice": "This page is currently available in Chinese only."
+    "chineseOnlyNotice": "The legal text on this page is currently available in Chinese only."
   },
   "appearance": {
     "title": "Interface & Appearance",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -179,9 +179,9 @@
     "appIntroContent": "広東第二師範学院キャンパスアシスタントは、広東第二師範学院のために作られたキャンパスサービスアプリです。時間割検索、成績検索、CET成績検索、空き教室検索、図書館検索、貸出記録、教育品質評価、電気料金検索、イエローページ検索、キャンパスカード情報、消費記録、カード紛失届などの総合的な教務機能に加え、フリマ、落とし物、キャンパス掲示板、出会い、告白ウォール、宅配代行、キャンパス写真、トピック、匿名教員評価などのコミュニティプラットフォームも提供しています。",
     "screenshotsTitle": "スクリーンショット",
     "screenshotAlt": "スクリーンショット {n}",
-    "cookieNotice": "本ウェブサイトは、より便利でパーソナライズされたブラウジング体験を提供するためにCookieを使用しています。Cookieはお使いのコンピュータに有用な情報を保存し、ウェブサイトの効率性と有用性の向上に役立ちます。場合によっては、ウェブサイトの正常な動作に不可欠です。本ウェブサイトにアクセスすることにより、Cookieの使用に同意したものとみなされます。",
+    "cookieNotice": "本サイトは、ログイン状態、表示設定、データソースの選択、およびこの案内の非表示状態を記憶するために、Cookie とブラウザのローカルストレージを使用します。引き続き利用することで、これらの説明を確認したものとみなされます。",
     "cookieLearnMore": "詳細については{link}をクリックしてください。",
-    "cookiePolicy": "Cookieポリシー",
+    "cookiePolicy": "Cookieとローカルストレージについて",
     "menuHelp": "ヘルプ",
     "menuSecuritySpec": "セキュリティ技術仕様",
     "menuAccountSpec": "キャンパスネットワークアカウント説明",
@@ -190,8 +190,8 @@
     "menuPrivacyPolicy": "プライバシーポリシー",
     "menuCommunityGuidelines": "コミュニティガイドライン",
     "menuOpenSourceLicense": "オープンソースライセンス",
-    "menuCookiePolicy": "Cookieポリシー",
-    "menuIPDeclaration": "知的財産権宣言",
+    "menuCookiePolicy": "Cookieとローカルストレージについて",
+    "menuIPDeclaration": "権利侵害申告と反通知ルール",
     "menuFriendlyLinks": "リンク集",
     "menuSmartPartyBuilding": "スマート党建",
     "menuOpen": "メニューを開く",
@@ -201,7 +201,7 @@
     "securityTitle": "セキュリティ技術仕様",
     "privacyPolicyTitle": "プライバシーポリシー",
     "userAgreementTitle": "利用規約",
-    "chineseOnlyNotice": "このページは現在中国語版のみ提供されています。"
+    "chineseOnlyNotice": "このページの法的本文は現在中国語版のみ提供されています。"
   },
   "appearance": {
     "title": "インターフェースと外観",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -179,9 +179,9 @@
     "appIntroContent": "광둥제2사범대학교 캠퍼스 어시스턴트는 광둥제2사범대학교를 위해 특별히 제작된 캠퍼스 서비스 애플리케이션입니다. 시간표 조회, 성적 조회, CET 성적 조회, 빈 강의실 조회, 도서관 검색, 대출 기록, 교육 품질 평가, 전기 요금 조회, 옐로 페이지, 캠퍼스 카드 정보, 소비 기록, 카드 분실 신고 등 종합적인 교무 기능뿐만 아니라 중고 거래, 분실물, 캠퍼스 게시판, 연애, 고백 게시판, 배달 대행, 캠퍼스 사진, 토픽, 익명 교수 평가 등 커뮤니티 플랫폼도 제공합니다.",
     "screenshotsTitle": "스크린샷",
     "screenshotAlt": "스크린샷 {n}",
-    "cookieNotice": "본 웹사이트는 보다 편리하고 개인화된 브라우징 경험을 제공하기 위해 쿠키를 사용합니다. 쿠키는 컴퓨터에 유용한 정보를 저장하여 웹사이트의 효율성과 유용성을 개선하는 데 도움을 줍니다. 경우에 따라 웹사이트의 정상적인 작동에 필수적입니다. 본 웹사이트를 방문하면 쿠키 사용에 동의한 것으로 간주됩니다.",
+    "cookieNotice": "이 사이트는 로그인 상태, 화면 설정, 데이터 소스 선택, 그리고 이 안내의 닫힘 상태를 기억하기 위해 쿠키와 브라우저 로컬 저장소를 사용합니다. 계속 이용하면 관련 설명을 확인한 것으로 봅니다.",
     "cookieLearnMore": "자세한 내용은 {link}을 클릭하세요.",
-    "cookiePolicy": "쿠키 정책",
+    "cookiePolicy": "쿠키 및 로컬 저장소 안내",
     "menuHelp": "도움말",
     "menuSecuritySpec": "보안 기술 사양",
     "menuAccountSpec": "캠퍼스 네트워크 계정 안내",
@@ -190,8 +190,8 @@
     "menuPrivacyPolicy": "개인정보 처리방침",
     "menuCommunityGuidelines": "커뮤니티 가이드라인",
     "menuOpenSourceLicense": "오픈 소스 라이선스",
-    "menuCookiePolicy": "쿠키 정책",
-    "menuIPDeclaration": "지식재산권 선언",
+    "menuCookiePolicy": "쿠키 및 로컬 저장소 안내",
+    "menuIPDeclaration": "권리침해 신고 및 반통지 규칙",
     "menuFriendlyLinks": "링크 모음",
     "menuSmartPartyBuilding": "스마트 당건설",
     "menuOpen": "메뉴 열기",
@@ -201,7 +201,7 @@
     "securityTitle": "보안 기술 사양",
     "privacyPolicyTitle": "개인정보 처리방침",
     "userAgreementTitle": "이용 약관",
-    "chineseOnlyNotice": "이 페이지는 현재 중국어로만 제공됩니다."
+    "chineseOnlyNotice": "이 페이지의 법률 본문은 현재 중국어로만 제공됩니다."
   },
   "appearance": {
     "title": "인터페이스 및 외관",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1245,7 +1245,7 @@
     "menuCommunityGuidelines": "社区准则",
     "menuOpenSourceLicense": "开源协议",
     "menuCookiePolicy": "Cookie与本地存储说明",
-    "menuIPDeclaration": "知识产权声明",
+    "menuIPDeclaration": "侵权投诉与反通知规则",
     "menuFriendlyLinks": "友情链接",
     "menuSmartPartyBuilding": "智慧党建",
     "menuOpen": "打开菜单",
@@ -1255,7 +1255,7 @@
     "securityTitle": "安全技术规格说明",
     "privacyPolicyTitle": "隐私政策",
     "userAgreementTitle": "用户协议",
-    "chineseOnlyNotice": "本页面目前仅提供中文版本。"
+    "chineseOnlyNotice": "本页面正文目前仅提供中文版本。"
   },
   "appearance": {
     "title": "界面和外观",

--- a/frontend/src/locales/zh-HK.json
+++ b/frontend/src/locales/zh-HK.json
@@ -179,9 +179,9 @@
     "appIntroContent": "廣東第二師範學院校園助手，是為廣東第二師範學院專屬打造的校園服務應用。它不僅提供了課表查詢、成績查詢、四六級考試成績查詢、空課室查詢、圖書館檢索、我的借閱、教學質量評價、電費查詢、黃頁查詢、校園卡信息、消費記錄、校園卡掛失等綜合性的教務功能，還提供了二手交易、失物招領、校園樹洞、戀愛交友、表白牆、全民快遞、拍好校園、話題、匿名評教等社區交流平台。廣東二師助手旨在為廣東第二師範學院的在校師生們提供最優質的教育教學、校園生活、社團活動、文化娛樂和教務服務等信息。四年時光，廣東二師助手陪你一起走過。",
     "screenshotsTitle": "應用截圖",
     "screenshotAlt": "應用截圖 {n}",
-    "cookieNotice": "本網站使用Cookie的目的是為您提供更加簡捷和個性化的上網體驗。Cookie將有用的信息存儲在您的電腦上，可幫助我們改善您瀏覽我們網站的效率以及對您的實用性。在某些情況下，它們是網站正常運行所必不可少的。如果您訪問本網站，即表示您同意我們使用Cookie。",
+    "cookieNotice": "本網站會使用 Cookie 和瀏覽器本地儲存來記住登入狀態、介面偏好、資料來源選擇及提示關閉狀態。繼續訪問即表示您已知悉相關說明。",
     "cookieLearnMore": "請點擊{link}了解更多信息。",
-    "cookiePolicy": "Cookie政策",
+    "cookiePolicy": "Cookie與本地儲存說明",
     "menuHelp": "使用幫助",
     "menuSecuritySpec": "安全技術規格說明",
     "menuAccountSpec": "校園網絡賬號說明",
@@ -190,8 +190,8 @@
     "menuPrivacyPolicy": "隱私政策",
     "menuCommunityGuidelines": "社區準則",
     "menuOpenSourceLicense": "開源協議",
-    "menuCookiePolicy": "Cookie政策",
-    "menuIPDeclaration": "知識產權聲明",
+    "menuCookiePolicy": "Cookie與本地儲存說明",
+    "menuIPDeclaration": "侵權投訴與反通知規則",
     "menuFriendlyLinks": "友情鏈接",
     "menuSmartPartyBuilding": "智慧黨建",
     "menuOpen": "打開菜單",
@@ -201,7 +201,7 @@
     "securityTitle": "安全技術規格說明",
     "privacyPolicyTitle": "隱私政策",
     "userAgreementTitle": "用戶協議",
-    "chineseOnlyNotice": "本頁面目前僅提供中文版本。"
+    "chineseOnlyNotice": "本頁面正文目前僅提供中文版本。"
   },
   "appearance": {
     "title": "介面和外觀",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -179,9 +179,9 @@
     "appIntroContent": "廣東第二師範學院校園助手，是為廣東第二師範學院專屬打造的校園服務應用。它不僅提供了課表查詢、成績查詢、四六級考試成績查詢、空課室查詢、圖書館檢索、我的借閱、教學品質評價、電費查詢、黃頁查詢、校園卡資訊、消費記錄、校園卡掛失等綜合性的教務功能，還提供了二手交易、失物招領、校園樹洞、戀愛交友、表白牆、全民快遞、拍好校園、話題、匿名評教等社區交流平台。廣東二師助手旨在為廣東第二師範學院的在校師生們提供最優質的教育教學、校園生活、社團活動、文化娛樂和教務服務等資訊。四年時光，廣東二師助手陪你一起走過。",
     "screenshotsTitle": "應用截圖",
     "screenshotAlt": "應用截圖 {n}",
-    "cookieNotice": "本網站使用Cookie的目的是為您提供更加簡捷和個性化的上網體驗。Cookie將有用的資訊儲存在您的電腦上，可幫助我們改善您瀏覽我們網站的效率以及對您的實用性。在某些情況下，它們是網站正常運行所必不可少的。如果您訪問本網站，即表示您同意我們使用Cookie。",
+    "cookieNotice": "本網站會使用 Cookie 和瀏覽器本地儲存來記住登入狀態、介面偏好、資料來源選擇及提示關閉狀態。繼續存取即表示您已知悉相關說明。",
     "cookieLearnMore": "請點擊{link}了解更多資訊。",
-    "cookiePolicy": "Cookie政策",
+    "cookiePolicy": "Cookie與本地儲存說明",
     "menuHelp": "使用幫助",
     "menuSecuritySpec": "安全技術規格說明",
     "menuAccountSpec": "校園網路帳號說明",
@@ -190,8 +190,8 @@
     "menuPrivacyPolicy": "隱私政策",
     "menuCommunityGuidelines": "社群準則",
     "menuOpenSourceLicense": "開源協議",
-    "menuCookiePolicy": "Cookie政策",
-    "menuIPDeclaration": "智慧財產權聲明",
+    "menuCookiePolicy": "Cookie與本地儲存說明",
+    "menuIPDeclaration": "侵權投訴與反通知規則",
     "menuFriendlyLinks": "友情連結",
     "menuSmartPartyBuilding": "智慧黨建",
     "menuOpen": "開啟選單",
@@ -201,7 +201,7 @@
     "securityTitle": "安全技術規格說明",
     "privacyPolicyTitle": "隱私政策",
     "userAgreementTitle": "使用者協議",
-    "chineseOnlyNotice": "本頁面目前僅提供中文版本。"
+    "chineseOnlyNotice": "本頁面正文目前僅提供中文版本。"
   },
   "appearance": {
     "title": "介面和外觀",

--- a/frontend/src/views/about/CookiePolicy.vue
+++ b/frontend/src/views/about/CookiePolicy.vue
@@ -10,7 +10,7 @@ const isNonChinese = computed(() => !locale.value.startsWith('zh'))
   <div class="min-h-screen bg-[var(--c-bg)]">
     <div class="sticky top-0 z-30 flex items-center h-[52px] px-5 bg-[var(--c-surface)]/90 backdrop-blur-xl border-b border-[var(--c-border)]">
       <button @click="$router.back()" class="text-[var(--c-primary)] text-sm font-medium">← {{ t('about.back') }}</button>
-      <span class="flex-1 text-center text-sm font-bold">Cookie与本地存储说明</span>
+      <span class="flex-1 text-center text-sm font-bold">{{ t('about.menuCookiePolicy') }}</span>
       <div class="w-10"></div>
     </div>
 

--- a/frontend/src/views/about/IntellectualProperty.vue
+++ b/frontend/src/views/about/IntellectualProperty.vue
@@ -1,8 +1,16 @@
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t, locale } = useI18n()
+const isNonChinese = computed(() => !locale.value.startsWith('zh'))
+</script>
+
 <template>
   <div class="min-h-screen bg-[var(--c-bg)]">
     <div class="sticky top-0 z-30 flex items-center h-[52px] px-5 bg-[var(--c-surface)]/90 backdrop-blur-xl border-b border-[var(--c-border)]">
-      <button @click="$router.back()" class="text-[var(--c-primary)] text-sm font-medium">← 返回</button>
-      <span class="flex-1 text-center text-sm font-bold">侵权投诉与反通知规则</span>
+      <button @click="$router.back()" class="text-[var(--c-primary)] text-sm font-medium">← {{ t('about.back') }}</button>
+      <span class="flex-1 text-center text-sm font-bold">{{ t('about.menuIPDeclaration') }}</span>
       <div class="w-10"></div>
     </div>
 
@@ -17,6 +25,10 @@
             [&_ol]:mb-3 [&_ol]:list-decimal [&_ol]:pl-5
             [&_li]:mb-2
             [&_strong]:font-semibold">
+          <div v-if="isNonChinese" class="bg-amber-50 text-amber-800 border border-amber-300 rounded-lg px-4 py-3 mb-4 text-sm leading-relaxed">
+            {{ t('about.chineseOnlyNotice') }}
+          </div>
+
           <h3 class="!mt-0 text-center">《侵权投诉与反通知规则》</h3>
           <p class="text-center">更新日期：2026年4月15日</p>
           <p class="text-center">生效日期：2026年4月15日</p>

--- a/frontend/src/views/about/SocialPolicy.vue
+++ b/frontend/src/views/about/SocialPolicy.vue
@@ -10,7 +10,7 @@ const isNonChinese = computed(() => !locale.value.startsWith('zh'))
   <div class="min-h-screen bg-[var(--c-bg)]">
     <div class="sticky top-0 z-30 flex items-center h-[52px] px-5 bg-[var(--c-surface)]/90 backdrop-blur-xl border-b border-[var(--c-border)]">
       <button @click="$router.back()" class="text-[var(--c-primary)] text-sm font-medium">← {{ t('about.back') }}</button>
-      <span class="flex-1 text-center text-sm font-bold">社区准则</span>
+      <span class="flex-1 text-center text-sm font-bold">{{ t('about.menuCommunityGuidelines') }}</span>
       <div class="w-10"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- localize legal-page shell copy only, without translating legal body text
- wire SocialPolicy, CookiePolicy, and IntellectualProperty headers/back prompt to existing i18n flow
- update About menu and cookie banner copy in all supported locales

## What changed
- kept all legal body text in Chinese
- localized outer labels only: menu entries, page headers, cookie banner text, and the Chinese-only notice
- updated the intellectual property entry label to match the current complaint/counter-notice page

## Verification
- `git diff --check`
- `npm --prefix frontend run test:unit`
- `npm --prefix frontend run build`
