### PR TITLE
[codex] cap personal list queries

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -88,14 +88,12 @@ public class DatingController {
         return new DataJsonResult<>(true, datingService.queryMyRoommateProfiles(sessionId));
     }
 
-    // TODO(perf): unpaged endpoint; add pagination or server-side cap
     @RequestMapping(value = "/api/dating/pick/my/sent", method = RequestMethod.GET)
     public DataJsonResult<List<DatingPickVO>> getMySentPicks(HttpServletRequest request) {
         String sessionId = (String) request.getAttribute("sessionId");
         return new DataJsonResult<>(true, datingService.queryMySentPicks(sessionId));
     }
 
-    // TODO(perf): unpaged endpoint; add pagination or server-side cap
     @RequestMapping(value = "/api/dating/pick/my/received", method = RequestMethod.GET)
     public DataJsonResult<List<DatingPickVO>> getMyReceivedPicks(HttpServletRequest request) {
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/dating/mapper/DatingMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/mapper/DatingMapper.java
@@ -97,7 +97,7 @@ public interface DatingMapper {
             "d.profile_id as profile_id,d.username as profile_username,d.nickname,d.grade,d.faculty,d.hometown," +
             "d.content as profile_content,d.qq,d.wechat,d.area,d.state as profile_state " +
             "from dating_pick p inner join dating_profile d on p.profile_id=d.profile_id " +
-            "where p.username=#{username} order by p.pick_id desc")
+            "where p.username=#{username} order by p.pick_id desc limit #{limit}")
     @Results(id = "RoommatePickSent", value = {
             @Result(property = "pickId", column = "pick_id"),
             @Result(property = "username", column = "pick_username"),
@@ -115,15 +115,17 @@ public interface DatingMapper {
             @Result(property = "datingProfile.area", column = "area"),
             @Result(property = "datingProfile.state", column = "profile_state")
     })
-    List<DatingPickEntity> selectDatingPickListByUsername(@Param("username") String username);
+    List<DatingPickEntity> selectDatingPickListByUsername(@Param("username") String username,
+            @Param("limit") int limit);
 
     @Select("select p.pick_id as pick_id,p.username as pick_username,p.content as pick_content,p.state as pick_state," +
             "d.profile_id as profile_id,d.username as profile_username,d.nickname,d.grade,d.faculty,d.hometown," +
             "d.content as profile_content,d.qq,d.wechat,d.area,d.state as profile_state " +
             "from dating_pick p inner join dating_profile d on p.profile_id=d.profile_id " +
-            "where d.username=#{username} order by p.pick_id desc")
+            "where d.username=#{username} order by p.pick_id desc limit #{limit}")
     @ResultMap("RoommatePickSent")
-    List<DatingPickEntity> selectReceivedRoommatePickListByProfileOwner(@Param("username") String username);
+    List<DatingPickEntity> selectReceivedRoommatePickListByProfileOwner(@Param("username") String username,
+            @Param("limit") int limit);
 
     @Delete("delete from dating_profile where profile_id=#{profileId}")
     void deleteRoommateProfile(@Param("profileId") int profileId);

--- a/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 public class DatingService {
 
     private static final Logger logger = LoggerFactory.getLogger(DatingService.class);
+    private static final int MY_PICK_LIMIT = 50;
     @Autowired
     private UserCertificateService userCertificateService;
 
@@ -229,7 +230,7 @@ public class DatingService {
 
     public List<DatingPickVO> queryMySentPicks(String sessionId) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
-        List<DatingPickEntity> list = datingMapper.selectDatingPickListByUsername(user.getUsername());
+        List<DatingPickEntity> list = datingMapper.selectDatingPickListByUsername(user.getUsername(), MY_PICK_LIMIT);
         if (list == null) return new ArrayList<>();
         return list.stream().map(e -> {
             DatingPickVO vo = pickEntityToVO(e);
@@ -246,7 +247,7 @@ public class DatingService {
 
     public List<DatingPickVO> queryMyReceivedPicks(String sessionId) {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
-        List<DatingPickEntity> list = datingMapper.selectReceivedRoommatePickListByProfileOwner(user.getUsername());
+        List<DatingPickEntity> list = datingMapper.selectReceivedRoommatePickListByProfileOwner(user.getUsername(), MY_PICK_LIMIT);
         if (list == null) return new ArrayList<>();
         return list.stream().map(e -> {
             DatingPickVO vo = pickEntityToVO(e);

--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -60,7 +60,6 @@ public class SecretController {
         return new DataJsonResult<>(true, list);
     }
 
-    // TODO(perf): unpaged endpoint; add pagination or server-side cap
     @RequestMapping(value = "/api/secret/profile", method = RequestMethod.GET)
     public DataJsonResult<List<SecretVO>> getMySecrets(HttpServletRequest request) throws Exception {
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
@@ -120,9 +120,9 @@ public interface SecretMapper {
     })
     List<SecretContentEntity> selectSecretLight(@Param("start") int start, @Param("size") int size);
 
-    @Select("select * from secret_content where username=#{username} and state=0 order by id desc")
+    @Select("select * from secret_content where username=#{username} and state=0 order by id desc limit #{limit}")
     @ResultMap("SecretContentLight")
-    List<SecretContentEntity> selectSecretByUsernameLight(String username);
+    List<SecretContentEntity> selectSecretByUsernameLight(@Param("username") String username, @Param("limit") int limit);
 
     // ---- Batch count/like queries ----
 

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 public class SecretService {
 
     private static final Logger logger = LoggerFactory.getLogger(SecretService.class);
+    private static final int PROFILE_SECRET_LIMIT = 50;
     @Autowired
     private UserCertificateService userCertificateService;
 
@@ -66,7 +67,7 @@ public class SecretService {
 
     public List<SecretVO> getSecretInfo(String sessionId) throws Exception {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
-        List<SecretContentEntity> list = secretMapper.selectSecretByUsernameLight(user.getUsername());
+        List<SecretContentEntity> list = secretMapper.selectSecretByUsernameLight(user.getUsername(), PROFILE_SECRET_LIMIT);
         if (list == null || list.isEmpty()) {
             return new ArrayList<>();
         }

--- a/src/test/java/cn/gdeiassistant/core/dating/service/DatingServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/dating/service/DatingServiceTest.java
@@ -165,4 +165,26 @@ class DatingServiceTest {
         assertDoesNotThrow(() -> datingService.updateRoommateProfileState(1, 1));
         verify(datingMapper, times(2)).updateRoommateProfileState(anyInt(), anyInt());
     }
+    @Test
+    void queryMySentPicks_usesServerSideLimit() {
+        User user = new User("testuser");
+        when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
+
+        datingService.queryMySentPicks("session1");
+
+        verify(datingMapper).selectDatingPickListByUsername("testuser", 50);
+        verify(datingMapper, never()).selectDatingPickListByUsername(anyString(), intThat(limit -> limit > 50));
+    }
+
+    @Test
+    void queryMyReceivedPicks_usesServerSideLimit() {
+        User user = new User("testuser");
+        when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
+
+        datingService.queryMyReceivedPicks("session1");
+
+        verify(datingMapper).selectReceivedRoommatePickListByProfileOwner("testuser", 50);
+        verify(datingMapper, never()).selectReceivedRoommatePickListByProfileOwner(anyString(), intThat(limit -> limit > 50));
+    }
+
 }

--- a/src/test/java/cn/gdeiassistant/core/secret/service/SecretServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/secret/service/SecretServiceTest.java
@@ -211,7 +211,7 @@ class SecretServiceTest {
         User user = new User("testuser");
         when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
         List<SecretContentEntity> entities = buildEntities(100, 200);
-        when(secretMapper.selectSecretByUsernameLight("testuser")).thenReturn(entities);
+        when(secretMapper.selectSecretByUsernameLight("testuser", 50)).thenReturn(entities);
         List<SecretVO> vos = buildVOs(100, 200);
         when(secretConverter.toVOList(entities)).thenReturn(vos);
 
@@ -277,11 +277,11 @@ class SecretServiceTest {
     void profilePathUsesLightweightQueryNotEagerComments() throws Exception {
         User user = new User("testuser");
         when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
-        when(secretMapper.selectSecretByUsernameLight("testuser")).thenReturn(new ArrayList<>());
+        when(secretMapper.selectSecretByUsernameLight("testuser", 50)).thenReturn(new ArrayList<>());
 
         secretService.getSecretInfo("session1");
 
-        verify(secretMapper).selectSecretByUsernameLight("testuser");
+        verify(secretMapper).selectSecretByUsernameLight("testuser", 50);
         verify(secretMapper, never()).selectSecretByUsername(anyString());
     }
 }


### PR DESCRIPTION
## What
- Add server-side caps to personal Secret and Dating pick list queries.
- Pass explicit limits through MyBatis mapper methods and cover the service paths in tests.
- Remove the TODO markers for the now-capped endpoints.

## Why
These personal endpoints were unpaged, so a single request could pull an unbounded number of rows for a user. This keeps the current API shape while limiting database and response size.

## Impact
Response payloads for `/api/secret/profile`, `/api/dating/pick/my/sent`, and `/api/dating/pick/my/received` are capped at 50 newest records.

## Checks
- `./gradlew test --tests cn.gdeiassistant.core.secret.service.SecretServiceTest --tests cn.gdeiassistant.core.dating.service.DatingServiceTest --no-daemon`
- `./gradlew test --no-daemon`
- `git diff --check`