### PR TITLE
[codex] add paged secret profile endpoint

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -70,6 +70,9 @@ public class SecretController {
     @RequestMapping(value = "/api/secret/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<SecretVO>> getMySecrets(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) throws Exception {
+        if (start < 0 || size <= 0) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
         if (size > 50) size = 50;
         String sessionId = (String) request.getAttribute("sessionId");
         List<SecretVO> list = secretService.getSecretInfo(sessionId, start, size);

--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -67,6 +67,15 @@ public class SecretController {
         return new DataJsonResult<>(true, list);
     }
 
+    @RequestMapping(value = "/api/secret/profile/start/{start}/size/{size}", method = RequestMethod.GET)
+    public DataJsonResult<List<SecretVO>> getMySecrets(HttpServletRequest request
+            , @PathVariable("start") int start, @PathVariable("size") int size) throws Exception {
+        if (size > 50) size = 50;
+        String sessionId = (String) request.getAttribute("sessionId");
+        List<SecretVO> list = secretService.getSecretInfo(sessionId, start, size);
+        return new DataJsonResult<>(true, list);
+    }
+
     @RateLimit(maxRequests = 5, windowSeconds = 60)
     @RequestMapping(value = "/api/secret/info", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)

--- a/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/mapper/SecretMapper.java
@@ -120,9 +120,10 @@ public interface SecretMapper {
     })
     List<SecretContentEntity> selectSecretLight(@Param("start") int start, @Param("size") int size);
 
-    @Select("select * from secret_content where username=#{username} and state=0 order by id desc limit #{limit}")
+    @Select("select * from secret_content where username=#{username} and state=0 order by id desc limit #{start},#{size}")
     @ResultMap("SecretContentLight")
-    List<SecretContentEntity> selectSecretByUsernameLight(@Param("username") String username, @Param("limit") int limit);
+    List<SecretContentEntity> selectSecretByUsernameLight(@Param("username") String username,
+            @Param("start") int start, @Param("size") int size);
 
     // ---- Batch count/like queries ----
 

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -66,8 +66,12 @@ public class SecretService {
     }
 
     public List<SecretVO> getSecretInfo(String sessionId) throws Exception {
+        return getSecretInfo(sessionId, 0, PROFILE_SECRET_LIMIT);
+    }
+
+    public List<SecretVO> getSecretInfo(String sessionId, int start, int size) throws Exception {
         User user = userCertificateService.getUserLoginCertificate(sessionId);
-        List<SecretContentEntity> list = secretMapper.selectSecretByUsernameLight(user.getUsername(), PROFILE_SECRET_LIMIT);
+        List<SecretContentEntity> list = secretMapper.selectSecretByUsernameLight(user.getUsername(), start, size);
         if (list == null || list.isEmpty()) {
             return new ArrayList<>();
         }

--- a/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -52,6 +53,34 @@ class SecretContractTest {
                 .andExpect(jsonPath("$.data[0].publishTime").exists())
                 .andExpect(jsonPath("$.data[0].likeCount").exists())
                 .andExpect(jsonPath("$.data[0].commentCount").exists());
+    }
+
+    @Test
+    void profilePagedEndpointReturnsExpectedFields() throws Exception {
+        when(secretService.getSecretInfo("test-session", 20, 10))
+                .thenReturn(List.of(mockSecretVO()));
+
+        mockMvc.perform(get("/api/secret/profile/start/20/size/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].id").exists())
+                .andExpect(jsonPath("$.data[0].content").exists())
+                .andExpect(jsonPath("$.data[0].likeCount").exists())
+                .andExpect(jsonPath("$.data[0].commentCount").exists());
+    }
+
+    @Test
+    void profilePagedEndpointCapsPageSizeAtFifty() throws Exception {
+        when(secretService.getSecretInfo("test-session", 0, 50))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/secret/profile/start/0/size/100")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(secretService).getSecretInfo("test-session", 0, 50);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.secret.controller.SecretController;
 import cn.gdeiassistant.core.secret.pojo.vo.SecretCommentVO;
 import cn.gdeiassistant.core.secret.pojo.vo.SecretVO;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,7 +34,9 @@ class SecretContractTest {
         SecretController controller = new SecretController();
         ReflectionTestUtils.setField(controller, "secretService", secretService);
 
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -81,6 +85,21 @@ class SecretContractTest {
                 .andExpect(jsonPath("$.success").value(true));
 
         verify(secretService).getSecretInfo("test-session", 0, 50);
+    }
+
+    @Test
+    void profilePagedEndpointRejectsLowerBoundViolations() throws Exception {
+        mockMvc.perform(get("/api/secret/profile/start/-1/size/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/secret/profile/start/0/size/-5")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(secretService);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/core/secret/service/SecretServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/secret/service/SecretServiceTest.java
@@ -211,7 +211,7 @@ class SecretServiceTest {
         User user = new User("testuser");
         when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
         List<SecretContentEntity> entities = buildEntities(100, 200);
-        when(secretMapper.selectSecretByUsernameLight("testuser", 50)).thenReturn(entities);
+        when(secretMapper.selectSecretByUsernameLight("testuser", 0, 50)).thenReturn(entities);
         List<SecretVO> vos = buildVOs(100, 200);
         when(secretConverter.toVOList(entities)).thenReturn(vos);
 
@@ -277,11 +277,23 @@ class SecretServiceTest {
     void profilePathUsesLightweightQueryNotEagerComments() throws Exception {
         User user = new User("testuser");
         when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
-        when(secretMapper.selectSecretByUsernameLight("testuser", 50)).thenReturn(new ArrayList<>());
+        when(secretMapper.selectSecretByUsernameLight("testuser", 0, 50)).thenReturn(new ArrayList<>());
 
         secretService.getSecretInfo("session1");
 
-        verify(secretMapper).selectSecretByUsernameLight("testuser", 50);
+        verify(secretMapper).selectSecretByUsernameLight("testuser", 0, 50);
+        verify(secretMapper, never()).selectSecretByUsername(anyString());
+    }
+
+    @Test
+    void profilePagedPathPassesRequestedOffsetAndSize() throws Exception {
+        User user = new User("testuser");
+        when(userCertificateService.getUserLoginCertificate("session1")).thenReturn(user);
+        when(secretMapper.selectSecretByUsernameLight("testuser", 20, 10)).thenReturn(new ArrayList<>());
+
+        secretService.getSecretInfo("session1", 20, 10);
+
+        verify(secretMapper).selectSecretByUsernameLight("testuser", 20, 10);
         verify(secretMapper, never()).selectSecretByUsername(anyString());
     }
 }


### PR DESCRIPTION
## Summary
- add `/api/secret/profile/start/{start}/size/{size}` for paged Secret Center profile reads
- keep the legacy `/api/secret/profile` endpoint and make it delegate to the paged service path
- cap requested profile page size at 50 and add service/contract coverage

## Why
The WeChat mini-program remote Secret Center path calls the paged profile endpoint, but the backend only exposed `/api/secret/profile`. This could make the remote flow 404 outside mock mode.

## Validation
- `./gradlew test --tests cn.gdeiassistant.core.secret.service.SecretServiceTest --tests cn.gdeiassistant.contract.SecretContractTest --no-daemon`
- `./gradlew test --no-daemon`
- `git diff --check`