### PR TITLE
[codex] validate community pagination bounds

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/tools/Utils/PageUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/Utils/PageUtils.java
@@ -1,0 +1,16 @@
+package cn.gdeiassistant.common.tools.Utils;
+
+public class PageUtils {
+
+    public static final int MAX_PAGE_SIZE = 50;
+
+    private PageUtils() {
+    }
+
+    public static int normalizePageSize(int start, int size) {
+        if (start < 0 || size <= 0) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/src/main/java/cn/gdeiassistant/core/express/controller/ExpressController.java
+++ b/src/main/java/cn/gdeiassistant/core/express/controller/ExpressController.java
@@ -11,6 +11,7 @@ import cn.gdeiassistant.core.express.pojo.dto.ExpressPublishDTO;
 import cn.gdeiassistant.core.express.pojo.vo.ExpressVO;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.express.service.ExpressService;
 import org.hibernate.validator.constraints.Length;
 import jakarta.validation.constraints.NotBlank;
@@ -36,7 +37,7 @@ public class ExpressController {
     @RequestMapping(value = "/api/express/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<ExpressVO>> getMyExpressList(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<ExpressVO> list = expressService.queryMyExpressList(sessionId, start, size);
         return new DataJsonResult<>(true, list);
@@ -52,7 +53,7 @@ public class ExpressController {
     @RequestMapping(value = "/api/express/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<ExpressVO>> queryExpressPage(HttpServletRequest request, @PathVariable("start") int start
             , @PathVariable("size") int size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<ExpressVO> list = expressService.queryExpressPage(start, size, sessionId);
         return new DataJsonResult<>(true, list);
@@ -61,7 +62,7 @@ public class ExpressController {
     @RequestMapping(value = "/api/express/keyword/{keyword}/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<ExpressVO>> queryExpressPageByKeyWord(HttpServletRequest request, @PathVariable("keyword") String keyword
             , @PathVariable("start") int start, @PathVariable("size") int size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<ExpressVO> list = expressService.queryExpressPageByKeyword(sessionId, start, size, keyword);
         return new DataJsonResult<>(true, list);

--- a/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
@@ -7,6 +7,7 @@ import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import cn.gdeiassistant.core.i18n.BackendTextLocalizer;
 import cn.gdeiassistant.core.photograph.pojo.dto.PhotographPublishDTO;
@@ -63,7 +64,7 @@ public class PhotographController {
     public DataJsonResult<List<PhotographVO>> queryPhotographList(HttpServletRequest request
             , @Validated @NotNull @Min(0) @Max(1) @PathVariable("type") int type
             , @PathVariable("start") int start, @PathVariable("size") int size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         List<PhotographVO> list = photographService.queryPhotographList(start, size, type, (String) request.getAttribute("sessionId"));
         return new DataJsonResult<>(true, list);
     }
@@ -100,7 +101,7 @@ public class PhotographController {
     @RequestMapping(value = "/api/photograph/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<PhotographVO>> getMyPhotographs(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<PhotographVO> list = photographService.queryMyPhotographList(sessionId, start, size);
         return new DataJsonResult<>(true, list);

--- a/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/controller/SecretController.java
@@ -7,6 +7,7 @@ import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.i18n.BackendTextLocalizer;
 import cn.gdeiassistant.core.secret.pojo.dto.SecretPublishDTO;
 import cn.gdeiassistant.core.secret.pojo.vo.SecretCommentVO;
@@ -54,7 +55,7 @@ public class SecretController {
     @RequestMapping(value = "/api/secret/info/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<SecretVO>> getMoreSecret(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) throws Exception {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<SecretVO> list = secretService.getSecretInfo(start, size, sessionId);
         return new DataJsonResult<>(true, list);
@@ -70,10 +71,7 @@ public class SecretController {
     @RequestMapping(value = "/api/secret/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<SecretVO>> getMySecrets(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) throws Exception {
-        if (start < 0 || size <= 0) {
-            throw new IllegalArgumentException("请求参数不合法");
-        }
-        if (size > 50) size = 50;
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<SecretVO> list = secretService.getSecretInfo(sessionId, start, size);
         return new DataJsonResult<>(true, list);

--- a/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
@@ -7,6 +7,7 @@ import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import cn.gdeiassistant.core.i18n.BackendTextLocalizer;
 import cn.gdeiassistant.core.topic.pojo.dto.TopicPublishDTO;
@@ -34,7 +35,7 @@ public class TopicController {
     @RequestMapping(value = "/api/topic/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<TopicVO>> getMyTopicList(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<TopicVO> list = topicService.queryMyTopicList(sessionId, start, size);
         return new DataJsonResult<>(true, list);
@@ -50,7 +51,7 @@ public class TopicController {
     @RequestMapping(value = "/api/topic/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<TopicVO>> queryTopic(HttpServletRequest request, @PathVariable("start") int start
             , @PathVariable("size") int size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<TopicVO> list = topicService.queryTopic(sessionId, start, size);
         return new DataJsonResult<>(true, list);
@@ -59,7 +60,7 @@ public class TopicController {
     @RequestMapping(value = "/api/topic/keyword/{keyword}/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<TopicVO>> queryTopicByKeyword(HttpServletRequest request, @PathVariable("start") int start
             , @PathVariable("size") int size, @PathVariable("keyword") String keyword) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<TopicVO> list = topicService.queryTopicByKeyword(sessionId, start, size, keyword);
         return new DataJsonResult<>(true, list);

--- a/src/test/java/cn/gdeiassistant/contract/ExpressContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/ExpressContractTest.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.common.pojo.Entity.ExpressComment;
 import cn.gdeiassistant.core.express.controller.ExpressController;
 import cn.gdeiassistant.core.express.pojo.vo.ExpressVO;
@@ -14,6 +15,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -31,7 +33,9 @@ class ExpressContractTest {
         ExpressController controller = new ExpressController();
         ReflectionTestUtils.setField(controller, "expressService", expressService);
 
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -51,6 +55,21 @@ class ExpressContractTest {
                 .andExpect(jsonPath("$.data[0].publishTime").exists())
                 .andExpect(jsonPath("$.data[0].likeCount").exists())
                 .andExpect(jsonPath("$.data[0].commentCount").exists());
+    }
+
+    @Test
+    void listEndpointRejectsLowerBoundViolations() throws Exception {
+        mockMvc.perform(get("/api/express/start/-1/size/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/express/profile/start/0/size/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(expressService);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/PhotographContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/PhotographContractTest.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.photograph.controller.PhotographController;
 import cn.gdeiassistant.core.photograph.pojo.vo.PhotographCommentVO;
 import cn.gdeiassistant.core.photograph.pojo.vo.PhotographVO;
@@ -17,6 +18,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -33,7 +35,9 @@ class PhotographContractTest {
     void setUp() {
         PhotographController controller = new PhotographController();
         ReflectionTestUtils.setField(controller, "photographService", photographService);
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -58,6 +62,19 @@ class PhotographContractTest {
                 .andExpect(jsonPath("$.data[0].type").value(0))
                 .andExpect(jsonPath("$.data[0].likeCount").value(10))
                 .andExpect(jsonPath("$.data[0].commentCount").value(3));
+    }
+
+    @Test
+    void listPhotographs_rejectsLowerBoundViolations() throws Exception {
+        mockMvc.perform(get("/api/photograph/type/1/start/-1/size/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/photograph/profile/start/0/size/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(photographService);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
@@ -99,6 +99,11 @@ class SecretContractTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false));
 
+        mockMvc.perform(get("/api/secret/info/start/-1/size/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
         verifyNoInteractions(secretService);
     }
 

--- a/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.topic.controller.TopicController;
 import cn.gdeiassistant.core.topic.pojo.vo.TopicVO;
 import cn.gdeiassistant.core.topic.service.TopicService;
@@ -13,6 +14,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -30,7 +32,9 @@ class TopicContractTest {
         TopicController controller = new TopicController();
         ReflectionTestUtils.setField(controller, "topicService", topicService);
 
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -48,6 +52,21 @@ class TopicContractTest {
                 .andExpect(jsonPath("$.data[0].count").exists())
                 .andExpect(jsonPath("$.data[0].publishTime").exists())
                 .andExpect(jsonPath("$.data[0].likeCount").exists());
+    }
+
+    @Test
+    void listEndpointRejectsLowerBoundViolations() throws Exception {
+        mockMvc.perform(get("/api/topic/start/-1/size/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/topic/profile/start/0/size/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(topicService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a shared `PageUtils.normalizePageSize` helper for community pagination
- reject `start < 0` and `size <= 0` before controller calls reach MyBatis `LIMIT` queries
- preserve the existing 50-item page size cap for Express, Photograph, Secret, and Topic pagination endpoints
- add contract coverage for invalid lower-bound requests

## Why
Several community list endpoints capped only oversized pages, but let negative offsets or non-positive sizes reach SQL-layer pagination. That can surface as DB errors instead of a clean client-facing invalid-parameter response.

## Validation
- `./gradlew test --tests cn.gdeiassistant.contract.ExpressContractTest --tests cn.gdeiassistant.contract.PhotographContractTest --tests cn.gdeiassistant.contract.SecretContractTest --tests cn.gdeiassistant.contract.TopicContractTest --no-daemon`
- `./gradlew test --no-daemon`
- `git diff --check`