### PR TITLE
[codex] validate remaining pagination bounds

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/tools/Utils/PageUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/Utils/PageUtils.java
@@ -8,9 +8,31 @@ public class PageUtils {
     }
 
     public static int normalizePageSize(int start, int size) {
-        if (start < 0 || size <= 0) {
+        requireNonNegativeStart(start);
+        if (size <= 0) {
             throw new IllegalArgumentException("请求参数不合法");
         }
         return Math.min(size, MAX_PAGE_SIZE);
+    }
+
+    public static int normalizePageSize(Integer start, Integer size) {
+        if (start == null || size == null) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return normalizePageSize(start.intValue(), size.intValue());
+    }
+
+    public static int requireNonNegativeStart(int start) {
+        if (start < 0) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return start;
+    }
+
+    public static int requireNonNegativeStart(Integer start) {
+        if (start == null) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return requireNonNegativeStart(start.intValue());
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/announcement/controller/AnnouncementController.java
+++ b/src/main/java/cn/gdeiassistant/core/announcement/controller/AnnouncementController.java
@@ -3,6 +3,7 @@ package cn.gdeiassistant.core.announcement.controller;
 import cn.gdeiassistant.common.pojo.Entity.Announcement;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.information.pojo.vo.AnnouncementVO;
 import cn.gdeiassistant.core.information.service.Announcement.AnnouncementService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,7 @@ public class AnnouncementController {
     @RequestMapping(value = "/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<AnnouncementVO>> queryAnnouncementPage(@PathVariable("start") Integer start,
             @PathVariable("size") Integer size) {
+        size = PageUtils.normalizePageSize(start, size);
         return new DataJsonResult<>(true, announcementService.queryAnnouncementPage(start, size));
     }
 

--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -16,6 +16,7 @@ import cn.gdeiassistant.core.dating.pojo.dto.DatingPublishDTO;
 import cn.gdeiassistant.core.dating.pojo.vo.DatingPickVO;
 import cn.gdeiassistant.core.dating.pojo.vo.DatingProfileVO;
 import cn.gdeiassistant.core.dating.service.DatingService;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
@@ -69,6 +70,10 @@ public class DatingController {
 
     @RequestMapping(value = "/api/dating/profile/area/{area}/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<DatingProfileVO>> queryDatingProfile(@PathVariable("start") Integer start, @PathVariable("area") Integer area) {
+        if (area == null || area < 0 || area > 1) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        start = PageUtils.requireNonNegativeStart(start);
         List<DatingProfileVO> list = datingService.queryDatingProfile(start, 10, area);
         for (DatingProfileVO p : list) {
             if (p.getProfileId() != null) p.setPictureURL(datingService.getRoommateProfilePictureURL(p.getProfileId()));

--- a/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
@@ -8,6 +8,7 @@ import cn.gdeiassistant.common.exception.DeliveryException.DeliveryOrderStateUpd
 import cn.gdeiassistant.common.exception.DeliveryException.NoAccessUpdatingException;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.delivery.pojo.dto.DeliveryPublishDTO;
 import cn.gdeiassistant.core.delivery.pojo.vo.DeliveryOrderVO;
 import cn.gdeiassistant.core.delivery.pojo.vo.DeliveryTradeVO;
@@ -80,7 +81,7 @@ public class DeliveryController {
     @RequestMapping(value = "/api/delivery/order/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<DeliveryOrderVO>> queryDeliveryOrderPage(HttpServletRequest request, @PathVariable("start") @Min(0) Integer start
             , @PathVariable("size") @Min(1) Integer size) {
-        if (size > 50) size = 50; // Cap page size
+        size = PageUtils.normalizePageSize(start, size);
         List<DeliveryOrderVO> list = deliveryService.queryDeliveryOrderPage(start, size);
         return new DataJsonResult<>(true, list);
     }

--- a/src/main/java/cn/gdeiassistant/core/ipaddress/controller/IPAddressController.java
+++ b/src/main/java/cn/gdeiassistant/core/ipaddress/controller/IPAddressController.java
@@ -3,6 +3,7 @@ package cn.gdeiassistant.core.iPAddress.controller;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
 import cn.gdeiassistant.common.pojo.Entity.IPAddressRecord;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.iPAddress.service.IPAddressService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,6 +31,7 @@ public class IPAddressController {
     @RequestMapping(value = "/api/ip/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<IPAddressRecord>> getRecentLoginIPAddressRecord(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         List<IPAddressRecord> recordList = ipAddressService.getSelfUserAddressRecord(sessionId
                 , IPAddressEnum.LOGIN.getValue(), start, size);

--- a/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
+++ b/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
@@ -6,6 +6,7 @@ import cn.gdeiassistant.common.constant.ValueConstantUtils;
 import cn.gdeiassistant.common.enums.IPAddress.IPAddressEnum;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import cn.gdeiassistant.core.lostandfound.pojo.dto.LostAndFoundPublishDTO;
 import cn.gdeiassistant.core.lostandfound.pojo.vo.LostAndFoundDetailVO;
@@ -97,6 +98,10 @@ public class LostAndFoundController {
     @RequestMapping(value = "/api/lostandfound/founditem/type/{type}/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<LostAndFoundItemVO>> searchFoundInfoByType(HttpServletRequest request, @PathVariable("type") Integer type,
             @PathVariable("start") Integer start) throws Exception {
+        if (type == null || type < 0 || type > 11) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        start = PageUtils.requireNonNegativeStart(start);
         List<LostAndFoundItemVO> list = lostAndFoundService.queryFoundItemsByType(type, start);
         return new DataJsonResult<>(true, list);
     }

--- a/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
@@ -13,6 +13,7 @@ import cn.gdeiassistant.core.marketplace.pojo.vo.MarketplaceItemVO;
 import cn.gdeiassistant.core.marketplace.service.MarketplaceService;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.common.tools.Utils.StringUtils;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +52,7 @@ public class MarketplaceController {
 
     @RequestMapping(value = "/api/ershou/item/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<MarketplaceItemEntity>> getItemList(HttpServletRequest request, @PathVariable("start") int start) throws Exception {
+        start = PageUtils.requireNonNegativeStart(start);
         List<MarketplaceItemEntity> list = marketplaceService.queryItems(start);
         return new DataJsonResult<>(true, list);
     }
@@ -136,6 +138,7 @@ public class MarketplaceController {
     @RequestMapping(value = "/api/ershou/keyword/{keyword}/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<MarketplaceItemEntity>> getItemWithKeyword(HttpServletRequest request, @PathVariable("keyword") String keyword,
             @PathVariable("start") int start) throws Exception {
+        start = PageUtils.requireNonNegativeStart(start);
         List<MarketplaceItemEntity> list = marketplaceService.queryItemsWithKeyword(keyword, start);
         return new DataJsonResult<>(true, list);
     }
@@ -164,6 +167,7 @@ public class MarketplaceController {
     @RequestMapping(value = "/api/ershou/item/type/{type}/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<MarketplaceItemEntity>> getItemByType(HttpServletRequest request, @Validated @Range(min = 0, max = 11) @PathVariable("type") int type,
             @PathVariable("start") int start) throws Exception {
+        start = PageUtils.requireNonNegativeStart(start);
         List<MarketplaceItemEntity> list = marketplaceService.queryItemsByType(type, start);
         return new DataJsonResult<>(true, list);
     }

--- a/src/main/java/cn/gdeiassistant/core/message/controller/MessageController.java
+++ b/src/main/java/cn/gdeiassistant/core/message/controller/MessageController.java
@@ -2,6 +2,7 @@ package cn.gdeiassistant.core.message.controller;
 
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.i18n.ApiLanguageResolver;
 import cn.gdeiassistant.core.i18n.BackendTextLocalizer;
 import cn.gdeiassistant.core.message.pojo.vo.InteractionMessageVO;
@@ -27,6 +28,7 @@ public class MessageController {
     public DataJsonResult<List<InteractionMessageVO>> getInteractionMessages(HttpServletRequest request,
             @PathVariable("start") Integer start,
             @PathVariable("size") Integer size) {
+        size = PageUtils.normalizePageSize(start, size);
         String sessionId = (String) request.getAttribute("sessionId");
         String language = ApiLanguageResolver.normalizeLanguage(request.getHeader("Accept-Language"));
         List<InteractionMessageVO> messages = messageService.queryInteractionMessages(sessionId, start, size);

--- a/src/main/java/cn/gdeiassistant/core/schoolnews/controller/SchoolNewsController.java
+++ b/src/main/java/cn/gdeiassistant/core/schoolnews/controller/SchoolNewsController.java
@@ -4,6 +4,7 @@ import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException
 import cn.gdeiassistant.common.pojo.Entity.NewInfo;
 import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
 import cn.gdeiassistant.common.pojo.Result.JsonResult;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.information.service.SchoolNews.SchoolNewsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,6 +34,7 @@ public class SchoolNewsController {
     public DataJsonResult<List<NewInfo>> queryNewInfoList(@PathVariable("type") Integer type
             , @PathVariable("start") Integer start, @PathVariable("size") Integer size) {
         try {
+            size = PageUtils.normalizePageSize(start, size);
             List<NewInfo> newInfoList = schoolNewsService.queryNewInfoList(type, start, size);
             return new DataJsonResult<>(true, newInfoList);
         } catch (DataNotExistException e) {

--- a/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -63,6 +64,19 @@ class DatingContractTest {
                 .andExpect(jsonPath("$.data[0].faculty").value("CS"))
                 .andExpect(jsonPath("$.data[0].hometown").value("GZ"))
                 .andExpect(jsonPath("$.data[0].content").value("looking for roommate"));
+    }
+
+    @Test
+    void listProfiles_rejectsInvalidPagingOrArea() throws Exception {
+        mockMvc.perform(get("/api/dating/profile/area/0/start/-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/dating/profile/area/2/start/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.delivery.controller.DeliveryController;
 import cn.gdeiassistant.core.delivery.pojo.vo.DeliveryOrderVO;
 import cn.gdeiassistant.core.delivery.service.DeliveryService;
@@ -12,6 +13,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -29,7 +32,9 @@ class DeliveryContractTest {
         DeliveryController controller = new DeliveryController();
         ReflectionTestUtils.setField(controller, "deliveryService", deliveryService);
 
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -49,6 +54,34 @@ class DeliveryContractTest {
                 .andExpect(jsonPath("$.data[0].company").exists())
                 .andExpect(jsonPath("$.data[0].address").exists())
                 .andExpect(jsonPath("$.data[0].state").exists());
+    }
+
+    @Test
+    void listEndpointCapsPageSizeAtFifty() throws Exception {
+        when(deliveryService.queryDeliveryOrderPage(0, 50))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/delivery/order/start/0/size/100")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(deliveryService).queryDeliveryOrderPage(0, 50);
+    }
+
+    @Test
+    void listEndpointRejectsLowerBoundViolations() throws Exception {
+        mockMvc.perform(get("/api/delivery/order/start/-1/size/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/delivery/order/start/0/size/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/IPAddressContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/IPAddressContractTest.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.common.pojo.Entity.IPAddressRecord;
 import cn.gdeiassistant.core.iPAddress.controller.IPAddressController;
 import cn.gdeiassistant.core.iPAddress.service.IPAddressService;
@@ -12,6 +13,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,7 +37,9 @@ class IPAddressContractTest {
         IPAddressController controller = new IPAddressController();
         ReflectionTestUtils.setField(controller, "ipAddressService", ipAddressService);
 
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -89,6 +94,34 @@ class IPAddressContractTest {
                 .andExpect(jsonPath("$.data[0].ip").value("1.2.3.4"))
                 .andExpect(jsonPath("$.data[0].country").value("中国"))
                 .andExpect(jsonPath("$.data[0].province").value("广东省"));
+    }
+
+    @Test
+    void historyEndpointCapsPageSizeAtFifty() throws Exception {
+        when(ipAddressService.getSelfUserAddressRecord("test-session", 0, 0, 50))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/ip/start/0/size/100")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(ipAddressService).getSelfUserAddressRecord("test-session", 0, 0, 50);
+    }
+
+    @Test
+    void historyEndpointRejectsLowerBoundViolations() throws Exception {
+        mockMvc.perform(get("/api/ip/start/-1/size/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/ip/start/0/size/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(ipAddressService);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/InformationCenterContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/InformationCenterContractTest.java
@@ -1,6 +1,7 @@
 package cn.gdeiassistant.contract;
 
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.announcement.controller.AnnouncementController;
 import cn.gdeiassistant.core.information.pojo.vo.AnnouncementVO;
 import cn.gdeiassistant.core.information.service.Announcement.AnnouncementService;
@@ -19,9 +20,11 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class InformationCenterContractTest {
@@ -50,7 +53,7 @@ class InformationCenterContractTest {
                 schoolNewsController,
                 announcementController,
                 messageController
-        ).build();
+        ).setControllerAdvice(new GlobalRestExceptionHandler()).build();
     }
 
     @Test
@@ -63,6 +66,18 @@ class InformationCenterContractTest {
                 .andExpect(content().json(
                         ContractResourceSupport.loadJson("contracts/information-news.empty.json")
                 ));
+    }
+
+    @Test
+    void newsListCapsPageSizeAtFifty() throws Exception {
+        when(schoolNewsService.queryNewInfoList(1, 0, 50))
+                .thenThrow(new DataNotExistException("no data"));
+
+        mockMvc.perform(get("/api/information/news/type/1/start/0/size/100"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(schoolNewsService).queryNewInfoList(1, 0, 50);
     }
 
     @Test
@@ -81,6 +96,17 @@ class InformationCenterContractTest {
                 .andExpect(content().json(
                         ContractResourceSupport.loadJson("contracts/information-announcements.success.json")
                 ));
+    }
+
+    @Test
+    void announcementListCapsPageSizeAtFifty() throws Exception {
+        when(announcementService.queryAnnouncementPage(0, 50)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/information/announcement/start/0/size/100"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(announcementService).queryAnnouncementPage(0, 50);
     }
 
     @Test
@@ -118,6 +144,19 @@ class InformationCenterContractTest {
                 .andExpect(content().json(
                         ContractResourceSupport.loadJson("contracts/information-message-list.success.json")
                 ));
+    }
+
+    @Test
+    void interactionMessagesCapPageSizeAtFifty() throws Exception {
+        when(messageService.queryInteractionMessages("session-1", 0, 50))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/information/message/interaction/start/0/size/100")
+                        .requestAttr("sessionId", "session-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(messageService).queryInteractionMessages("session-1", 0, 50);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/LostAndFoundContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/LostAndFoundContractTest.java
@@ -1,0 +1,76 @@
+package cn.gdeiassistant.contract;
+
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
+import cn.gdeiassistant.core.lostandfound.controller.LostAndFoundController;
+import cn.gdeiassistant.core.lostandfound.pojo.vo.LostAndFoundItemVO;
+import cn.gdeiassistant.core.lostandfound.service.LostAndFoundService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LostAndFoundContractTest {
+
+    private MockMvc mockMvc;
+    private LostAndFoundService lostAndFoundService;
+
+    @BeforeEach
+    void setUp() {
+        lostAndFoundService = mock(LostAndFoundService.class);
+
+        LostAndFoundController controller = new LostAndFoundController();
+        ReflectionTestUtils.setField(controller, "lostAndFoundService", lostAndFoundService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void foundTypeEndpointReturnsExpectedFields() throws Exception {
+        when(lostAndFoundService.queryFoundItemsByType(3, 0))
+                .thenReturn(List.of(mockLostAndFoundItem()));
+
+        mockMvc.perform(get("/api/lostandfound/founditem/type/3/start/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].name").value("campus card"))
+                .andExpect(jsonPath("$.data[0].itemType").value(3));
+    }
+
+    @Test
+    void foundTypeEndpointRejectsInvalidTypeOrStart() throws Exception {
+        mockMvc.perform(get("/api/lostandfound/founditem/type/12/start/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/lostandfound/founditem/type/3/start/-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(lostAndFoundService);
+    }
+
+    private static LostAndFoundItemVO mockLostAndFoundItem() {
+        LostAndFoundItemVO item = new LostAndFoundItemVO();
+        item.setId(1);
+        item.setName("campus card");
+        item.setDescription("found near library");
+        item.setLocation("Library");
+        item.setItemType(3);
+        item.setLostType(1);
+        item.setState(0);
+        return item;
+    }
+}

--- a/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
@@ -1,5 +1,6 @@
 package cn.gdeiassistant.contract;
 
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.marketplace.controller.MarketplaceController;
 import cn.gdeiassistant.core.marketplace.pojo.entity.MarketplaceItemEntity;
 import cn.gdeiassistant.core.marketplace.pojo.vo.MarketplaceItemVO;
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -35,7 +37,9 @@ class MarketplaceContractTest {
         MarketplaceController controller = new MarketplaceController();
         ReflectionTestUtils.setField(controller, "marketplaceService", marketplaceService);
 
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
     }
 
     @Test
@@ -52,6 +56,19 @@ class MarketplaceContractTest {
                 .andExpect(jsonPath("$.data[0].location").exists())
                 .andExpect(jsonPath("$.data[0].type").exists())
                 .andExpect(jsonPath("$.data[0].state").exists());
+    }
+
+    @Test
+    void listEndpointRejectsNegativeStart() throws Exception {
+        mockMvc.perform(get("/api/ershou/item/start/-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/ershou/keyword/textbook/start/-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(marketplaceService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- extend `PageUtils` for nullable path variables and start-only pagination endpoints
- cap oversized page requests at 50 for announcement, school news, interaction messages, delivery, and IP history endpoints
- reject invalid lower bounds for marketplace, dating, found-item type, delivery, IP history, and information-center pagination before service/mapper calls
- add contract coverage for the newly guarded routes

## Why
After the first pagination cleanup, a few remaining endpoints could still pass negative offsets or oversized page sizes down to repository/mapper layers. This keeps pagination behavior consistent and avoids avoidable DB/repository errors or overly large reads.

## Validation
- `./gradlew test --tests cn.gdeiassistant.contract.MarketplaceContractTest --tests cn.gdeiassistant.contract.LostAndFoundContractTest --tests cn.gdeiassistant.contract.DatingContractTest --tests cn.gdeiassistant.contract.DeliveryContractTest --tests cn.gdeiassistant.contract.IPAddressContractTest --tests cn.gdeiassistant.contract.InformationCenterContractTest --no-daemon`
- `./gradlew test --no-daemon`
- `git diff --check`