### PR TITLE
[codex] log upload cleanup failures

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/service/DatingService.java
@@ -118,7 +118,11 @@ public class DatingService {
             throw new RuntimeException("上传失败", e);
         } finally {
             if (inputStream != null) {
-                try { inputStream.close(); } catch (IOException ignored) {}
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    logger.warn("关闭室友信息图片上传输入流失败，id={}", id, e);
+                }
             }
         }
     }
@@ -261,7 +265,9 @@ public class DatingService {
     public void deleteDatingImage(int id) {
         try {
             r2StorageService.deleteObject("gdeiassistant-userdata", "dating/" + id + ".jpg");
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            logger.warn("删除室友信息图片失败，id={}", id, e);
+        }
     }
 
     public void deleteDatingProfile(int id) {

--- a/src/main/java/cn/gdeiassistant/core/lostandfound/service/LostAndFoundService.java
+++ b/src/main/java/cn/gdeiassistant/core/lostandfound/service/LostAndFoundService.java
@@ -163,7 +163,11 @@ public class LostAndFoundService {
             throw new RuntimeException("上传失败", e);
         } finally {
             if (inputStream != null) {
-                try { inputStream.close(); } catch (IOException ignored) {}
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    logger.warn("关闭失物招领图片上传输入流失败，id={}，index={}", id, index, e);
+                }
             }
         }
     }
@@ -176,7 +180,9 @@ public class LostAndFoundService {
         for (int i = 1; i <= count; i++) {
             try {
                 r2StorageService.deleteObject("gdeiassistant-userdata", "lostandfound/" + id + "_" + i + ".jpg");
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                logger.warn("删除失物招领图片失败，id={}，index={}", id, i, e);
+            }
         }
     }
 

--- a/src/main/java/cn/gdeiassistant/core/marketplace/service/MarketplaceService.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/service/MarketplaceService.java
@@ -176,7 +176,11 @@ public class MarketplaceService {
             throw new RuntimeException("图片上传失败", e);
         } finally {
             if (inputStream != null) {
-                try { inputStream.close(); } catch (IOException ignored) {}
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    logger.warn("关闭二手交易图片上传输入流失败，id={}，index={}", id, index, e);
+                }
             }
         }
     }
@@ -189,7 +193,9 @@ public class MarketplaceService {
         for (int i = 1; i <= count; i++) {
             try {
                 r2StorageService.deleteObject("gdeiassistant-userdata", "ershou/" + id + "_" + i + ".jpg");
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                logger.warn("删除二手交易图片失败，id={}，index={}", id, i, e);
+            }
         }
     }
 

--- a/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/service/PhotographService.java
@@ -169,7 +169,11 @@ public class PhotographService {
             throw new RuntimeException("拍好校园图片上传失败", e);
         } finally {
             if (inputStream != null) {
-                try { inputStream.close(); } catch (IOException ignored) {}
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    logger.warn("关闭拍好校园图片上传输入流失败，id={}，index={}", id, index, e);
+                }
             }
         }
     }
@@ -186,7 +190,9 @@ public class PhotographService {
         for (int i = 1; i <= count; i++) {
             try {
                 r2StorageService.deleteObject("gdeiassistant-userdata", "photograph/" + id + "_" + i + ".jpg");
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                logger.warn("删除拍好校园图片失败，id={}，index={}", id, i, e);
+            }
         }
     }
 

--- a/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/service/SecretService.java
@@ -109,7 +109,11 @@ public class SecretService {
             throw new RuntimeException("语音上传失败", e);
         } finally {
             if (inputStream != null) {
-                try { inputStream.close(); } catch (IOException ignored) {}
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    logger.warn("关闭树洞语音上传输入流失败，id={}", id, e);
+                }
             }
         }
     }
@@ -170,7 +174,9 @@ public class SecretService {
         for (String ext : extensions) {
             try {
                 r2StorageService.deleteObject("gdeiassistant-userdata", "secret/voice/" + id + ext);
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                logger.warn("删除树洞语音失败，id={}，extension={}", id, ext, e);
+            }
         }
     }
 

--- a/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/service/TopicService.java
@@ -150,7 +150,11 @@ public class TopicService {
             throw new RuntimeException("话题图片上传失败", e);
         } finally {
             if (inputStream != null) {
-                try { inputStream.close(); } catch (IOException ignored) {}
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    logger.warn("关闭话题图片上传输入流失败，id={}，index={}", id, index, e);
+                }
             }
         }
     }
@@ -171,7 +175,9 @@ public class TopicService {
         for (int i = 1; i <= count; i++) {
             try {
                 r2StorageService.deleteObject("gdeiassistant-userdata", "topic/" + id + "_" + i + ".jpg");
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                logger.warn("删除话题图片失败，id={}，index={}", id, i, e);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add warning logs when upload input stream closing fails in marketplace, lost-and-found, dating, secret, photograph, and topic services
- add warning logs when best-effort R2 cleanup deletes fail for those upload flows
- keep cleanup control flow unchanged: failures are still non-blocking

## Validation
- `./gradlew test --tests cn.gdeiassistant.core.marketplace.service.MarketplaceServiceTest --tests cn.gdeiassistant.core.lostandfound.service.LostAndFoundServiceTest --tests cn.gdeiassistant.core.dating.service.DatingServiceTest --tests cn.gdeiassistant.core.secret.service.SecretServiceTest --tests cn.gdeiassistant.core.photograph.service.PhotographServiceTest --no-daemon`
- `./gradlew test --no-daemon && git diff --check`