### PR TITLE
[codex] close integration client resources

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/graduateExam/service/GraduateExamService.java
+++ b/src/main/java/cn/gdeiassistant/core/graduateExam/service/GraduateExamService.java
@@ -17,8 +17,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 @Service
 public class GraduateExamService {
@@ -44,8 +44,8 @@ public class GraduateExamService {
                 hasCheckCode = true;
                 String imageURL = "https://yz.chsi.com.cn" + cjcxForm.select("td[align='left']").get(5)
                         .select("img").first().attr("src");
-                InputStream inputStream = chsiClient.fetchPostgraduateCaptchaImage(imageURL);
-                String base64 = ImageEncodeUtils.convertToBase64(inputStream);
+                byte[] imageBytes = chsiClient.fetchPostgraduateCaptchaImage(imageURL);
+                String base64 = ImageEncodeUtils.convertToBase64(new ByteArrayInputStream(imageBytes));
                 checkcode = imageRecognitionService.CheckCodeRecognize(base64, CheckCodeTypeEnum.NUMBER, 4);
             }
             document = chsiClient.submitPostgraduateQuery(name, examNumber, idNumber, checkcode);

--- a/src/main/java/cn/gdeiassistant/integration/card/CardClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/card/CardClient.java
@@ -13,6 +13,8 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.stereotype.Component;
 
@@ -30,6 +32,7 @@ import java.util.List;
 @Component
 public class CardClient {
 
+    private static final Logger logger = LoggerFactory.getLogger(CardClient.class);
     private static final String ECARD_BASE = "http://ecard.gdei.edu.cn";
     private static final int CARD_TIMEOUT_SEC = 15;
 
@@ -49,7 +52,7 @@ public class CardClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
+            closeHttpClient(httpClient);
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
     }
@@ -75,7 +78,7 @@ public class CardClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
+            closeHttpClient(httpClient);
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
     }
@@ -99,7 +102,7 @@ public class CardClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
+            closeHttpClient(httpClient);
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
     }
@@ -123,7 +126,7 @@ public class CardClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
+            closeHttpClient(httpClient);
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
     }
@@ -144,7 +147,7 @@ public class CardClient {
             }
             return readBytes(httpResponse.getEntity().getContent());
         } finally {
-            if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
+            closeHttpClient(httpClient);
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
     }
@@ -166,17 +169,31 @@ public class CardClient {
             }
             return readBytes(httpResponse.getEntity().getContent());
         } finally {
-            if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
+            closeHttpClient(httpClient);
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
     }
 
     private static byte[] readBytes(InputStream in) throws IOException {
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-        byte[] b = new byte[4096];
-        int n;
-        while ((n = in.read(b)) != -1) buf.write(b, 0, n);
-        return buf.toByteArray();
+        try (InputStream input = in; ByteArrayOutputStream buf = new ByteArrayOutputStream()) {
+            byte[] b = new byte[4096];
+            int n;
+            while ((n = input.read(b)) != -1) {
+                buf.write(b, 0, n);
+            }
+            return buf.toByteArray();
+        }
+    }
+
+    private static void closeHttpClient(CloseableHttpClient httpClient) {
+        if (httpClient == null) {
+            return;
+        }
+        try {
+            httpClient.close();
+        } catch (IOException e) {
+            logger.warn("关闭一卡通 HTTP 客户端失败", e);
+        }
     }
 
     /**
@@ -203,7 +220,7 @@ public class CardClient {
             }
             return EntityUtils.toString(httpResponse.getEntity());
         } finally {
-            if (httpClient != null) try { httpClient.close(); } catch (IOException ignored) { }
+            closeHttpClient(httpClient);
             if (cookieStore != null) HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
         }
     }

--- a/src/main/java/cn/gdeiassistant/integration/chsi/ChsiClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/chsi/ChsiClient.java
@@ -12,10 +12,11 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -25,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class ChsiClient {
 
+    private static final Logger logger = LoggerFactory.getLogger(ChsiClient.class);
     private static final String CET_BASE = "http://www.chsi.com.cn/cet";
     private static final String KAOYAN_CJCX = "https://yz.chsi.com.cn/apply/cjcx";
     private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36";
@@ -59,9 +61,7 @@ public class ChsiClient {
             }
             return ImageEncodeUtils.convertToBase64(httpResponse.getEntity().getContent());
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -93,9 +93,7 @@ public class ChsiClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -114,30 +112,26 @@ public class ChsiClient {
                 .writeTimeout(OKHTTP_TIMEOUT_SEC, TimeUnit.SECONDS)
                 .build();
         Request request = new Request.Builder().url(KAOYAN_CJCX + "/").build();
-        Response response = httpClient.newCall(request).execute();
-        if (!response.isSuccessful()) {
-            throw new ServerErrorException("查询系统异常");
+        try (Response response = httpClient.newCall(request).execute()) {
+            return parseSuccessfulResponse(response);
         }
-        return Jsoup.parse(response.body().string());
     }
 
     /**
      * 考研验证码图片（研招网，无会话）
      *
      * @param imageUrl 完整 URL，如 https://yz.chsi.com.cn/...
-     * @return 图片字节流，调用方可转 Base64
+     * @return 图片字节数组，调用方可转 Base64
      */
-    public InputStream fetchPostgraduateCaptchaImage(String imageUrl) throws IOException, ServerErrorException {
+    public byte[] fetchPostgraduateCaptchaImage(String imageUrl) throws IOException, ServerErrorException {
         OkHttpClient httpClient = new OkHttpClient.Builder()
                 .connectTimeout(OKHTTP_TIMEOUT_SEC, TimeUnit.SECONDS)
                 .readTimeout(OKHTTP_TIMEOUT_SEC, TimeUnit.SECONDS)
                 .build();
         Request request = new Request.Builder().url(imageUrl).build();
-        Response response = httpClient.newCall(request).execute();
-        if (!response.isSuccessful()) {
-            throw new ServerErrorException("查询系统异常");
+        try (Response response = httpClient.newCall(request).execute()) {
+            return readSuccessfulResponseBytes(response);
         }
-        return response.body().byteStream();
     }
 
     /**
@@ -172,10 +166,35 @@ public class ChsiClient {
                 .addHeader("Referer", KAOYAN_CJCX + "/")
                 .addHeader("User-Agent", USER_AGENT_MAC)
                 .build();
-        Response response = httpClient.newCall(request).execute();
-        if (!response.isSuccessful()) {
+        try (Response response = httpClient.newCall(request).execute()) {
+            return parseSuccessfulResponse(response);
+        }
+    }
+
+    private static Document parseSuccessfulResponse(Response response) throws IOException, ServerErrorException {
+        ResponseBody responseBody = response.body();
+        if (!response.isSuccessful() || responseBody == null) {
             throw new ServerErrorException("查询系统异常");
         }
-        return Jsoup.parse(response.body().string());
+        return Jsoup.parse(responseBody.string());
+    }
+
+    private static byte[] readSuccessfulResponseBytes(Response response) throws IOException, ServerErrorException {
+        ResponseBody responseBody = response.body();
+        if (!response.isSuccessful() || responseBody == null) {
+            throw new ServerErrorException("查询系统异常");
+        }
+        return responseBody.bytes();
+    }
+
+    private static void closeHttpClient(CloseableHttpClient httpClient) {
+        if (httpClient == null) {
+            return;
+        }
+        try {
+            httpClient.close();
+        } catch (IOException e) {
+            logger.warn("关闭学信网 HTTP 客户端失败", e);
+        }
     }
 }

--- a/src/main/java/cn/gdeiassistant/integration/edu/EduSystemClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/edu/EduSystemClient.java
@@ -19,6 +19,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.stereotype.Component;
 
@@ -33,6 +35,7 @@ import java.util.List;
 @Component
 public class EduSystemClient {
 
+    private static final Logger logger = LoggerFactory.getLogger(EduSystemClient.class);
     private static final String JWGL_BASE = "http://jwgl.gdei.edu.cn";
     private static final int EDU_REQUEST_TIMEOUT_SEC = 15;
 
@@ -81,9 +84,7 @@ public class EduSystemClient {
             }
             throw new ServerErrorException("教务系统异常");
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -120,9 +121,7 @@ public class EduSystemClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -234,9 +233,7 @@ public class EduSystemClient {
             }
             throw new ServerErrorException("教务系统异常");
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -283,9 +280,7 @@ public class EduSystemClient {
             }
             throw new ServerErrorException("教务系统异常");
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -314,9 +309,7 @@ public class EduSystemClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -358,9 +351,7 @@ public class EduSystemClient {
             }
             throw new ServerErrorException("教务系统异常");
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -387,9 +378,7 @@ public class EduSystemClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -463,12 +452,21 @@ public class EduSystemClient {
             }
             return document;
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
+        }
+    }
+
+    private static void closeHttpClient(CloseableHttpClient httpClient) {
+        if (httpClient == null) {
+            return;
+        }
+        try {
+            httpClient.close();
+        } catch (IOException e) {
+            logger.warn("关闭教务系统 HTTP 客户端失败", e);
         }
     }
 

--- a/src/main/java/cn/gdeiassistant/integration/library/LibraryClient.java
+++ b/src/main/java/cn/gdeiassistant/integration/library/LibraryClient.java
@@ -10,6 +10,7 @@ import com.alibaba.fastjson2.JSONObject;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -20,6 +21,8 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -36,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class LibraryClient {
 
+    private static final Logger logger = LoggerFactory.getLogger(LibraryClient.class);
     private static final String OPAC_RENEW_BASE = "http://agentdockingopac.featurelib.libsou.com";
     private static final String OPAC_SEARCH_BASE = "http://agentdockingopac.featurelib.libsou.com";
     private static final String FIVEREAD_M = "http://m.5read.com";
@@ -68,9 +72,7 @@ public class LibraryClient {
             result.setMessage(jsonObject.getString("msg"));
             return result;
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -130,9 +132,7 @@ public class LibraryClient {
             }
             return Jsoup.parse(EntityUtils.toString(httpResponse.getEntity()));
         } finally {
-            if (httpClient != null) {
-                try { httpClient.close(); } catch (IOException ignored) { }
-            }
+            closeHttpClient(httpClient);
             if (cookieStore != null) {
                 HttpClientUtils.syncHttpClientCookieStore(sessionId, cookieStore);
             }
@@ -159,11 +159,9 @@ public class LibraryClient {
             url = url + "&page=" + page;
         }
         Request request = new Request.Builder().url(url).build();
-        Response response = okHttpClient.newCall(request).execute();
-        if (!response.isSuccessful()) {
-            throw new ServerErrorException("移动图书馆系统异常");
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            return parseSuccessfulResponse(response);
         }
-        return Jsoup.parse(response.body().string());
     }
 
     /**
@@ -192,10 +190,27 @@ public class LibraryClient {
                 + "&page=" + URLEncoder.encode(page != null ? page : "1", StandardCharsets.UTF_8)
                 + "&xc=" + URLEncoder.encode(xc != null ? xc : "3", StandardCharsets.UTF_8);
         Request request = new Request.Builder().url(u).build();
-        Response response = okHttpClient.newCall(request).execute();
-        if (!response.isSuccessful()) {
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            return parseSuccessfulResponse(response);
+        }
+    }
+
+    private static Document parseSuccessfulResponse(Response response) throws IOException, ServerErrorException {
+        ResponseBody responseBody = response.body();
+        if (!response.isSuccessful() || responseBody == null) {
             throw new ServerErrorException("移动图书馆系统异常");
         }
-        return Jsoup.parse(response.body().string());
+        return Jsoup.parse(responseBody.string());
+    }
+
+    private static void closeHttpClient(CloseableHttpClient httpClient) {
+        if (httpClient == null) {
+            return;
+        }
+        try {
+            httpClient.close();
+        } catch (IOException e) {
+            logger.warn("关闭图书馆 HTTP 客户端失败", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- close OkHttp responses with try-with-resources in CHSI and library integration clients
- make CHSI postgraduate captcha downloads return owned bytes instead of exposing an OkHttp response stream
- close card image response streams while reading bytes, and replace silent Apache HttpClient close failures with warning logs in integration clients

## Validation
- `./gradlew test --tests cn.gdeiassistant.integration.IntegrationBoundarySmokeTest --tests cn.gdeiassistant.contract.LibraryControllerContractTest --tests cn.gdeiassistant.core.cardquery.controller.CardControllerTest --no-daemon`
- `./gradlew test --no-daemon && git diff --check`