### PR TITLE
[codex] wait for cron task completions

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/cron/controller/CronController.java
+++ b/src/main/java/cn/gdeiassistant/core/cron/controller/CronController.java
@@ -5,6 +5,8 @@ import cn.gdeiassistant.common.pojo.Result.JsonResult;
 import cn.gdeiassistant.core.gradequery.service.GradeCronService;
 import cn.gdeiassistant.core.schedulequery.service.ScheduleCronService;
 import cn.gdeiassistant.core.information.service.SchoolNews.SchoolNewsCornService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -14,10 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 @RestController
 public class CronController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CronController.class);
 
     @Autowired(required = false)
     private GradeCronService gradeCronService;
@@ -47,9 +50,20 @@ public class CronController {
         return true;
     }
 
-    // TODO: These cron endpoints are fire-and-forget — they return success immediately
-    // while the underlying service methods may execute asynchronously. The response
-    // does not reflect whether the task actually completed successfully.
+    private JsonResult runCronTask(String taskName, CronTask task) {
+        try {
+            task.run();
+            return new JsonResult(true);
+        } catch (Exception e) {
+            LOGGER.error("Cron task failed: {}", taskName, e);
+            return new JsonResult(false, "Cron task failed: " + taskName);
+        }
+    }
+
+    @FunctionalInterface
+    private interface CronTask {
+        void run() throws Exception;
+    }
 
     @RateLimit(maxRequests = 2, windowSeconds = 60)
     @RequestMapping(value = "/cron/grade", method = RequestMethod.GET)
@@ -58,11 +72,10 @@ public class CronController {
         if (!authenticateCron(secret, response)) {
             return null;
         }
-        if (gradeCronService != null) {
-            gradeCronService.synchronizeGradeData();
-            return new JsonResult(true);
+        if (gradeCronService == null) {
+            return new JsonResult(false);
         }
-        return new JsonResult(false);
+        return runCronTask("grade", gradeCronService::synchronizeGradeData);
     }
 
     @RateLimit(maxRequests = 2, windowSeconds = 60)
@@ -72,25 +85,23 @@ public class CronController {
         if (!authenticateCron(secret, response)) {
             return null;
         }
-        if (scheduleCronService != null) {
-            scheduleCronService.synchronizeScheduleData();
-            return new JsonResult(true);
+        if (scheduleCronService == null) {
+            return new JsonResult(false);
         }
-        return new JsonResult(false);
+        return runCronTask("schedule", scheduleCronService::synchronizeScheduleData);
     }
 
     @RateLimit(maxRequests = 2, windowSeconds = 60)
     @RequestMapping(value = "/cron/news", method = RequestMethod.GET)
     public JsonResult collectNews(@RequestHeader(value = "X-Cron-Secret", required = false) String secret,
-                                  HttpServletResponse response) throws InterruptedException, ExecutionException, IOException {
+                                  HttpServletResponse response) throws IOException {
         if (!authenticateCron(secret, response)) {
             return null;
         }
-        if (schoolNewsCornService != null) {
-            schoolNewsCornService.collectNews();
-            return new JsonResult(true);
+        if (schoolNewsCornService == null) {
+            return new JsonResult(false);
         }
-        return new JsonResult(false);
+        return runCronTask("news", schoolNewsCornService::collectNews);
     }
 
 }

--- a/src/main/java/cn/gdeiassistant/core/gradequery/service/GradeCronService.java
+++ b/src/main/java/cn/gdeiassistant/core/gradequery/service/GradeCronService.java
@@ -52,6 +52,7 @@ public class GradeCronService {
      */
     public void synchronizeGradeData() {
         logger.info(LocalDateTime.now().atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("yyyy年MM月dd日 HH:mm:ss")) + "启动了查询保存用户成绩信息的任务");
+        List<CompletableFuture<Void>> pendingTasks = new ArrayList<>();
         try {
             //获取所有允许教务缓存的用户
             List<User> userList = cronMapper.selectCacheAllowUsers();
@@ -66,10 +67,10 @@ public class GradeCronService {
                     CompletableFuture<GradeCacheResult> future = ((GradeCronService) AopContext.currentProxy())
                             .asyncQueryGrade(semaphore, user);
                     User finalUser = user;
-                    future.whenComplete((result, throwable) -> {
+                    CompletableFuture<Void> completion = future.handle((result, throwable) -> {
                         if (throwable != null) {
                             logger.error("定时查询保存成绩信息异常：", throwable);
-                            return;
+                            return null;
                         }
                         try {
                             if (result != null) {
@@ -119,11 +120,19 @@ public class GradeCronService {
                         } catch (Exception e) {
                             logger.error("定时查询保存成绩信息异常：", e);
                         }
+                        return null;
                     });
+                    pendingTasks.add(completion);
                 }
             }
         } catch (Exception e) {
             logger.error("定时查询保存成绩信息异常：", e);
+        } finally {
+            try {
+                CompletableFuture.allOf(pendingTasks.toArray(new CompletableFuture<?>[0])).join();
+            } catch (Exception e) {
+                logger.error("等待定时查询保存成绩信息任务完成异常：", e);
+            }
         }
     }
 

--- a/src/main/java/cn/gdeiassistant/core/schedulequery/service/ScheduleCronService.java
+++ b/src/main/java/cn/gdeiassistant/core/schedulequery/service/ScheduleCronService.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -50,6 +51,7 @@ public class ScheduleCronService {
     public void synchronizeScheduleData() {
         logger.info("{}启动了查询保存用户课表信息的任务", LocalDateTime.now().atZone(ZoneId.systemDefault())
                 .format(DateTimeFormatter.ofPattern("yyyy年MM月dd日 HH:mm:ss")));
+        List<CompletableFuture<Void>> pendingTasks = new ArrayList<>();
         try {
             List<User> userList = cronMapper.selectCacheAllowUsers();
             //设置线程信号量，限制最大同时查询的线程数为5
@@ -62,10 +64,10 @@ public class ScheduleCronService {
                     CompletableFuture<ScheduleQueryVO> future = ((ScheduleCronService) AopContext.currentProxy())
                             .asyncQuerySchedule(semaphore, user);
                     User finalUser = user;
-                    future.whenComplete((result, throwable) -> {
+                    CompletableFuture<Void> completion = future.handle((result, throwable) -> {
                         if (throwable != null) {
                             logger.error("定时查询保存课表信息异常：", throwable);
-                            return;
+                            return null;
                         }
                         try {
                             if (result != null) {
@@ -81,11 +83,19 @@ public class ScheduleCronService {
                         } catch (Exception e) {
                             logger.error("定时查询保存课表信息异常：", e);
                         }
+                        return null;
                     });
+                    pendingTasks.add(completion);
                 }
             }
         } catch (Exception e) {
             logger.error("定时查询保存课表信息异常：", e);
+        } finally {
+            try {
+                CompletableFuture.allOf(pendingTasks.toArray(new CompletableFuture<?>[0])).join();
+            } catch (Exception e) {
+                logger.error("等待定时查询保存课表信息任务完成异常：", e);
+            }
         }
     }
 

--- a/src/test/java/cn/gdeiassistant/core/cron/controller/CronControllerTest.java
+++ b/src/test/java/cn/gdeiassistant/core/cron/controller/CronControllerTest.java
@@ -70,6 +70,34 @@ class CronControllerTest {
     }
 
     @Test
+    void cacheGradeDataReportsMissingService() throws Exception {
+        ReflectionTestUtils.setField(controller, "cronSecret", "expected-secret");
+        ReflectionTestUtils.setField(controller, "gradeCronService", null);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        JsonResult result = controller.cacheGradeData("expected-secret", response);
+
+        assertNotNull(result);
+        assertFalse(result.isSuccess());
+        verifyNoInteractions(scheduleCronService, schoolNewsCornService);
+    }
+
+    @Test
+    void cacheGradeDataReportsServiceFailure() throws Exception {
+        ReflectionTestUtils.setField(controller, "cronSecret", "expected-secret");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        doThrow(new IllegalStateException("boom")).when(gradeCronService).synchronizeGradeData();
+
+        JsonResult result = controller.cacheGradeData("expected-secret", response);
+
+        assertNotNull(result);
+        assertFalse(result.isSuccess());
+        assertEquals("Cron task failed: grade", result.getMessage());
+        verify(gradeCronService).synchronizeGradeData();
+        verifyNoInteractions(scheduleCronService, schoolNewsCornService);
+    }
+
+    @Test
     void cacheScheduleDataRunsWhenSecretMatches() throws Exception {
         ReflectionTestUtils.setField(controller, "cronSecret", "expected-secret");
         MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
## Summary
- wait for grade and schedule cron task completions before HTTP cron endpoints return
- wrap cron trigger failures into a failed `JsonResult` instead of bubbling raw exceptions
- add controller coverage for missing grade service and grade service failure paths

## Validation
- `./gradlew test --console=plain`
- `./gradlew classes -x test --no-daemon --console=plain`
- `git diff --check`