### PR TITLE
[codex] expand route contract validation coverage

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/exceptionhandler/GlobalRestExceptionHandler.java
+++ b/src/main/java/cn/gdeiassistant/common/exceptionhandler/GlobalRestExceptionHandler.java
@@ -54,6 +54,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
@@ -85,7 +86,8 @@ public class GlobalRestExceptionHandler {
                 BackendTextLocalizer.localizeMessage("请求方法不支持", request.getHeader("Accept-Language"))));
     }
 
-    @ExceptionHandler({ConstraintViolationException.class, BindException.class, MethodArgumentNotValidException.class})
+    @ExceptionHandler({ConstraintViolationException.class, BindException.class, MethodArgumentNotValidException.class,
+            HandlerMethodValidationException.class})
     public ResponseEntity<JsonResult> handleConstraintViolationException(HttpServletRequest request) {
         return ResponseEntity.ok(new JsonResult(ErrorConstantUtils.INCORRECT_REQUEST_PARAM, false,
                 BackendTextLocalizer.localizeMessage("请求参数不合法", request.getHeader("Accept-Language"))));

--- a/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
+++ b/src/main/java/cn/gdeiassistant/core/lostandfound/controller/LostAndFoundController.java
@@ -37,6 +37,7 @@ public class LostAndFoundController {
 
     @RequestMapping(value = "/api/lostandfound/lostitem/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<LostAndFoundItemVO>> getLostItem(HttpServletRequest request, @PathVariable("start") @Min(0) int start) throws Exception {
+        start = PageUtils.requireNonNegativeStart(start);
         List<LostAndFoundItemVO> list = lostAndFoundService.queryLostItems(start);
         return new DataJsonResult<>(true, list);
     }
@@ -66,6 +67,7 @@ public class LostAndFoundController {
 
     @RequestMapping(value = "/api/lostandfound/founditem/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<LostAndFoundItemVO>> getFoundInfo(HttpServletRequest request, @PathVariable("start") @Min(0) int start) throws Exception {
+        start = PageUtils.requireNonNegativeStart(start);
         List<LostAndFoundItemVO> list = lostAndFoundService.queryFoundItems(start);
         return new DataJsonResult<>(true, list);
     }
@@ -74,6 +76,10 @@ public class LostAndFoundController {
     public DataJsonResult<List<LostAndFoundItemVO>> searchLostAndFoundInfo(HttpServletRequest request, @Validated @Range(min = 0, max = 1) @PathVariable("type") Integer lostType,
             @PathVariable("start") @Min(0) Integer start,
             @Validated @NotBlank @Length(min = 1, max = 50) @RequestParam("keyword") String keywords) throws Exception {
+        if (lostType == null || (lostType != 0 && lostType != 1)) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        start = PageUtils.requireNonNegativeStart(start);
         List<LostAndFoundItemVO> list = lostType.equals(0)
                 ? lostAndFoundService.queryLostItemsWithKeyword(keywords, start)
                 : lostAndFoundService.queryFoundItemsWithKeyword(keywords, start);

--- a/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
@@ -167,6 +167,9 @@ public class MarketplaceController {
     @RequestMapping(value = "/api/ershou/item/type/{type}/start/{start}", method = RequestMethod.GET)
     public DataJsonResult<List<MarketplaceItemEntity>> getItemByType(HttpServletRequest request, @Validated @Range(min = 0, max = 11) @PathVariable("type") int type,
             @PathVariable("start") int start) throws Exception {
+        if (type < 0 || type > 11) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
         start = PageUtils.requireNonNegativeStart(start);
         List<MarketplaceItemEntity> list = marketplaceService.queryItemsByType(type, start);
         return new DataJsonResult<>(true, list);

--- a/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
+++ b/src/main/java/cn/gdeiassistant/core/photograph/controller/PhotographController.java
@@ -64,6 +64,9 @@ public class PhotographController {
     public DataJsonResult<List<PhotographVO>> queryPhotographList(HttpServletRequest request
             , @Validated @NotNull @Min(0) @Max(1) @PathVariable("type") int type
             , @PathVariable("start") int start, @PathVariable("size") int size) {
+        if (type < 0 || type > 1) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
         size = PageUtils.normalizePageSize(start, size);
         List<PhotographVO> list = photographService.queryPhotographList(start, size, type, (String) request.getAttribute("sessionId"));
         return new DataJsonResult<>(true, list);

--- a/src/test/java/cn/gdeiassistant/contract/LostAndFoundContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/LostAndFoundContractTest.java
@@ -2,8 +2,10 @@ package cn.gdeiassistant.contract;
 
 import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.lostandfound.controller.LostAndFoundController;
+import cn.gdeiassistant.core.lostandfound.pojo.vo.LostAndFoundDetailVO;
 import cn.gdeiassistant.core.lostandfound.pojo.vo.LostAndFoundItemVO;
 import cn.gdeiassistant.core.lostandfound.service.LostAndFoundService;
+import cn.gdeiassistant.core.profile.pojo.vo.ProfileVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -16,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -60,6 +63,63 @@ class LostAndFoundContractTest {
                 .andExpect(jsonPath("$.success").value(false));
 
         verifyNoInteractions(lostAndFoundService);
+    }
+
+    @Test
+    void listEndpointsRejectNegativeStart() throws Exception {
+        mockMvc.perform(get("/api/lostandfound/lostitem/start/-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/lostandfound/founditem/start/-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(lostAndFoundService);
+    }
+
+    @Test
+    void lostSearchEndpointRejectsInvalidTypeOrStart() throws Exception {
+        mockMvc.perform(post("/api/lostandfound/lostitem/type/2/start/0")
+                        .param("keyword", "校园卡"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/lostandfound/lostitem/type/0/start/-1")
+                        .param("keyword", "校园卡"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(lostAndFoundService);
+    }
+
+    @Test
+    void detailEndpointReturnsExpectedShape() throws Exception {
+        LostAndFoundDetailVO detail = new LostAndFoundDetailVO();
+        LostAndFoundItemVO item = mockLostAndFoundItem();
+        ProfileVO profile = new ProfileVO();
+        profile.setUsername("testuser");
+        profile.setNickname("Test User");
+        detail.setItem(item);
+        detail.setProfile(profile);
+
+        when(lostAndFoundService.queryLostAndFoundInfoByID(1)).thenReturn(detail);
+
+        mockMvc.perform(get("/api/lostandfound/item/id/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.item.id").value(1))
+                .andExpect(jsonPath("$.data.item.name").value("campus card"))
+                .andExpect(jsonPath("$.data.profile.nickname").value("Test User"));
+    }
+
+    @Test
+    void previewEndpointReturnsFailureWhenNoPictures() throws Exception {
+        when(lostAndFoundService.getLostAndFoundItemPictureURL(99)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/lostandfound/item/id/99/preview"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
     }
 
     private static LostAndFoundItemVO mockLostAndFoundItem() {

--- a/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
@@ -106,6 +106,19 @@ class MarketplaceContractTest {
     }
 
     @Test
+    void typeFilterEndpointRejectsInvalidTypeOrStart() throws Exception {
+        mockMvc.perform(get("/api/ershou/item/type/12/start/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/ershou/item/type/8/start/-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(marketplaceService);
+    }
+
+    @Test
     void detailEndpointReturnsExpectedShape() throws Exception {
         MarketplaceItemVO vo = mockItemVO(1);
 

--- a/src/test/java/cn/gdeiassistant/contract/PhotographContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/PhotographContractTest.java
@@ -78,6 +78,15 @@ class PhotographContractTest {
     }
 
     @Test
+    void listPhotographs_rejectsInvalidType() throws Exception {
+        mockMvc.perform(get("/api/photograph/type/2/start/0/size/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(photographService);
+    }
+
+    @Test
     void getPhotographById_returnsDataObjectWithExpectedFields() throws Exception {
         PhotographVO vo = new PhotographVO();
         vo.setId(1);


### PR DESCRIPTION
## Summary
- handle Spring method-validation failures with the stable validation error payload
- explicitly reject invalid lost/found, marketplace, and photograph route parameters before hitting services
- expand contract tests for type/start/id/preview validation and response shapes

## Validation
- `./gradlew test --tests 'cn.gdeiassistant.contract.LostAndFoundContractTest' --tests 'cn.gdeiassistant.contract.MarketplaceContractTest' --tests 'cn.gdeiassistant.contract.PhotographContractTest' --console=plain`
- `./gradlew test --console=plain`
- `./gradlew classes -x test --no-daemon --console=plain`
- `git diff --check`