### PR TITLE
[codex] cover express secret validation contracts

### DIFF
--- a/src/test/java/cn/gdeiassistant/contract/ExpressContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/ExpressContractTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -103,6 +104,40 @@ class ExpressContractTest {
                 .andExpect(jsonPath("$.data[0].id").exists())
                 .andExpect(jsonPath("$.data[0].comment").exists())
                 .andExpect(jsonPath("$.data[0].publishTime").exists());
+    }
+
+    @Test
+    void commentEndpointRejectsBlankOrOverlongComment() throws Exception {
+        mockMvc.perform(post("/api/express/id/1/comment")
+                        .requestAttr("sessionId", "test-session")
+                        .param("comment", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/express/id/1/comment")
+                        .requestAttr("sessionId", "test-session")
+                        .param("comment", "x".repeat(51)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(expressService);
+    }
+
+    @Test
+    void guessEndpointRejectsBlankOrOverlongName() throws Exception {
+        mockMvc.perform(post("/api/express/id/1/guess")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/express/id/1/guess")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "x".repeat(11)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(expressService);
     }
 
     private static ExpressVO mockExpressVO() {

--- a/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -141,6 +142,34 @@ class SecretContractTest {
                 .andExpect(jsonPath("$.data[0].comment").exists())
                 .andExpect(jsonPath("$.data[0].avatarTheme").exists())
                 .andExpect(jsonPath("$.data[0].publishTime").exists());
+    }
+
+    @Test
+    void commentEndpointRejectsBlankOrOverlongComment() throws Exception {
+        mockMvc.perform(post("/api/secret/id/1/comment")
+                        .requestAttr("sessionId", "test-session")
+                        .param("comment", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/secret/id/1/comment")
+                        .requestAttr("sessionId", "test-session")
+                        .param("comment", "x".repeat(51)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(secretService);
+    }
+
+    @Test
+    void likeEndpointRejectsInvalidLikeState() throws Exception {
+        mockMvc.perform(post("/api/secret/id/1/like")
+                        .requestAttr("sessionId", "test-session")
+                        .param("like", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(secretService);
     }
 
     private static SecretVO mockSecretVO() {


### PR DESCRIPTION
## Summary
- add Express contract coverage for blank/overlong comments and guesses
- add Secret contract coverage for blank/overlong comments and invalid like states
- assert invalid inputs return the stable failed JSON payload without hitting services

## Validation
- `./gradlew test --tests 'cn.gdeiassistant.contract.ExpressContractTest' --tests 'cn.gdeiassistant.contract.SecretContractTest' --console=plain`
- `./gradlew test --console=plain`
- `./gradlew classes -x test --no-daemon --console=plain`
- `git diff --check`