### PR TITLE
[codex] cover contact data validation contracts

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/dataquery/controller/DataQueryController.java
+++ b/src/main/java/cn/gdeiassistant/core/dataquery/controller/DataQueryController.java
@@ -36,7 +36,7 @@ public class DataQueryController {
      */
     @RequestMapping(value = "/api/data/electricfees", method = RequestMethod.POST)
     public DataJsonResult<ElectricFees> queryElectricFeesData(@Validated @NotBlank @Length(max = 5) String name
-            , @Validated @NotBlank Long number, @Validated @NotNull @Range(min = 2016, max = 2050) Integer year) throws DataNotExistException {
+            , @Validated @NotNull Long number, @Validated @NotNull @Range(min = 2016, max = 2050) Integer year) throws DataNotExistException {
         ElectricFees electricFees = dataQueryService.queryElectricFees(name, number, year);
         return new DataJsonResult<>(true, electricFees);
     }

--- a/src/test/java/cn/gdeiassistant/contract/ContactValidationContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/ContactValidationContractTest.java
@@ -1,0 +1,117 @@
+package cn.gdeiassistant.contract;
+
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
+import cn.gdeiassistant.common.pojo.Entity.Email;
+import cn.gdeiassistant.core.email.controller.EmailController;
+import cn.gdeiassistant.core.email.service.EmailService;
+import cn.gdeiassistant.core.phone.controller.PhoneController;
+import cn.gdeiassistant.core.phone.pojo.vo.PhoneVO;
+import cn.gdeiassistant.core.phone.service.PhoneService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ContactValidationContractTest {
+
+    private MockMvc mockMvc;
+    private EmailService emailService;
+    private PhoneService phoneService;
+
+    @BeforeEach
+    void setUp() {
+        emailService = mock(EmailService.class);
+        phoneService = mock(PhoneService.class);
+
+        EmailController emailController = new EmailController();
+        ReflectionTestUtils.setField(emailController, "emailService", emailService);
+
+        PhoneController phoneController = new PhoneController();
+        ReflectionTestUtils.setField(phoneController, "phoneService", phoneService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(emailController, phoneController)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void emailVerificationRejectsInvalidEmail() throws Exception {
+        mockMvc.perform(post("/api/email/verification")
+                        .param("email", "not-an-email"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(emailService, phoneService);
+    }
+
+    @Test
+    void bindEmailRejectsInvalidVerificationCodeBounds() throws Exception {
+        mockMvc.perform(post("/api/email/bind")
+                        .requestAttr("sessionId", "test-session")
+                        .param("email", "student@example.com")
+                        .param("randomCode", "9999"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(emailService, phoneService);
+    }
+
+    @Test
+    void emailStatusReturnsBoundAddress() throws Exception {
+        Email email = new Email();
+        email.setEmail("student@example.com");
+        when(emailService.queryUserEmail("test-session")).thenReturn(email);
+
+        mockMvc.perform(get("/api/email/status")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value("student@example.com"));
+    }
+
+    @Test
+    void phoneVerificationRejectsInvalidPhone() throws Exception {
+        mockMvc.perform(post("/api/phone/verification")
+                        .param("code", "86")
+                        .param("phone", "abc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(emailService, phoneService);
+    }
+
+    @Test
+    void phoneVerificationRejectsUnsupportedCodeBeforeService() throws Exception {
+        mockMvc.perform(post("/api/phone/verification")
+                        .param("code", "999")
+                        .param("phone", "13800138000"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(emailService, phoneService);
+    }
+
+    @Test
+    void phoneStatusReturnsBoundPhone() throws Exception {
+        PhoneVO phone = new PhoneVO();
+        phone.setUsername("testuser");
+        phone.setPhone("138********");
+        when(phoneService.queryUserPhone("test-session")).thenReturn(phone);
+
+        mockMvc.perform(get("/api/phone/status")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.username").value("testuser"))
+                .andExpect(jsonPath("$.data.phone").value("138********"));
+    }
+}

--- a/src/test/java/cn/gdeiassistant/contract/DataQueryContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DataQueryContractTest.java
@@ -1,0 +1,81 @@
+package cn.gdeiassistant.contract;
+
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
+import cn.gdeiassistant.common.pojo.Entity.ElectricFees;
+import cn.gdeiassistant.core.dataquery.controller.DataQueryController;
+import cn.gdeiassistant.core.dataquery.service.DataQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DataQueryContractTest {
+
+    private MockMvc mockMvc;
+    private DataQueryService dataQueryService;
+
+    @BeforeEach
+    void setUp() {
+        dataQueryService = mock(DataQueryService.class);
+
+        DataQueryController controller = new DataQueryController();
+        ReflectionTestUtils.setField(controller, "dataQueryService", dataQueryService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void electricFeesReturnsExpectedFields() throws Exception {
+        ElectricFees fees = new ElectricFees();
+        fees.setName("林知远");
+        fees.setNumber(20231234567L);
+        fees.setYear(2026);
+        fees.setTotalElectricBill(32.5f);
+
+        when(dataQueryService.queryElectricFees("林知远", 20231234567L, 2026)).thenReturn(fees);
+
+        mockMvc.perform(post("/api/data/electricfees")
+                        .param("name", "林知远")
+                        .param("number", "20231234567")
+                        .param("year", "2026"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.name").value("林知远"))
+                .andExpect(jsonPath("$.data.number").value(20231234567L))
+                .andExpect(jsonPath("$.data.year").value(2026))
+                .andExpect(jsonPath("$.data.totalElectricBill").value(32.5));
+    }
+
+    @Test
+    void electricFeesRejectsInvalidYearBounds() throws Exception {
+        mockMvc.perform(post("/api/data/electricfees")
+                        .param("name", "林知远")
+                        .param("number", "20231234567")
+                        .param("year", "2015"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(dataQueryService);
+    }
+
+    @Test
+    void electricFeesRejectsMissingNumberBeforeService() throws Exception {
+        mockMvc.perform(post("/api/data/electricfees")
+                        .param("name", "林知远")
+                        .param("year", "2026"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(dataQueryService);
+    }
+}


### PR DESCRIPTION
## Summary
- add email and phone validation contract coverage for invalid form parameters and status payloads
- add electric-fee query contract coverage for success and invalid bounds/missing input
- use `@NotNull` for electric-fee student number validation instead of applying string-only `@NotBlank` to a `Long`

## Validation
- `./gradlew test --tests 'cn.gdeiassistant.contract.ContactValidationContractTest' --tests 'cn.gdeiassistant.contract.DataQueryContractTest' --console=plain`
- `./gradlew test --console=plain`
- `./gradlew classes -x test --no-daemon --console=plain`
- `git diff --check`