### PR TITLE
[codex] cover community action validation contracts

### DIFF
--- a/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
@@ -15,9 +15,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -150,6 +152,28 @@ class MarketplaceContractTest {
         mockMvc.perform(get("/api/ershou/item/id/99/preview"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void stateEndpointUpdatesValidState() throws Exception {
+        mockMvc.perform(post("/api/ershou/item/state/id/101")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(marketplaceService).updateItemState("test-session", 101, 2);
+    }
+
+    @Test
+    void stateEndpointRejectsInvalidStateBeforeService() throws Exception {
+        mockMvc.perform(post("/api/ershou/item/state/id/101")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(marketplaceService);
     }
 
     // ----------------------------------------------------------------

--- a/src/test/java/cn/gdeiassistant/contract/PhotographContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/PhotographContractTest.java
@@ -18,9 +18,11 @@ import java.util.Date;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -124,5 +126,33 @@ class PhotographContractTest {
                 .andExpect(jsonPath("$.data[0].commentId").value(10))
                 .andExpect(jsonPath("$.data[0].comment").value("great shot"))
                 .andExpect(jsonPath("$.data[0].createTime").exists());
+    }
+
+    @Test
+    void addPhotographCommentAcceptsValidComment() throws Exception {
+        mockMvc.perform(post("/api/photograph/id/1/comment")
+                        .requestAttr("sessionId", "test-session")
+                        .param("comment", "great shot"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(photographService).addPhotographComment(1, "great shot", "test-session");
+    }
+
+    @Test
+    void addPhotographCommentRejectsBlankOrOverlongComment() throws Exception {
+        mockMvc.perform(post("/api/photograph/id/1/comment")
+                        .requestAttr("sessionId", "test-session")
+                        .param("comment", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/photograph/id/1/comment")
+                        .requestAttr("sessionId", "test-session")
+                        .param("comment", "x".repeat(51)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(photographService);
     }
 }


### PR DESCRIPTION
## Summary
- add Marketplace state update contract coverage for valid and invalid states
- add Photograph comment post contract coverage for valid, blank, and overlong comments
- assert invalid inputs return failed JSON without hitting services

## Validation
- ./gradlew test --tests 'cn.gdeiassistant.contract.MarketplaceContractTest' --tests 'cn.gdeiassistant.contract.PhotographContractTest' --console=plain
- ./gradlew test --console=plain
- ./gradlew classes -x test --no-daemon --console=plain
- git diff --check