### PR TITLE
[codex] validate dating profile state updates

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -157,6 +157,7 @@ public class DatingController {
 
     @RequestMapping(value = "/api/dating/profile/id/{id}/state", method = RequestMethod.POST)
     public JsonResult updateMyRoommateProfileState(HttpServletRequest request, @PathVariable("id") Integer id, Integer state) throws DataNotExistException, NoAccessException {
+        if (state == null || (!state.equals(0) && !state.equals(1))) return failure(request, "请求参数不合法");
         String sessionId = (String) request.getAttribute("sessionId");
         datingService.verifyRoommateProfileOwner(sessionId, id);
         datingService.updateRoommateProfileState(id, state);

--- a/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
@@ -20,9 +20,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -73,6 +75,52 @@ class DatingContractTest {
                 .andExpect(jsonPath("$.success").value(false));
 
         mockMvc.perform(get("/api/dating/profile/area/2/start/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void updatePickStateAcceptsValidState() throws Exception {
+        mockMvc.perform(post("/api/dating/pick/id/3")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(datingService).verifyRoommatePickViewAccess("test-session", 3);
+        verify(datingService).updateRoommatePickState(3, 1);
+    }
+
+    @Test
+    void updatePickStateRejectsInvalidStateBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/pick/id/3")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void updateProfileStateAcceptsValidState() throws Exception {
+        mockMvc.perform(post("/api/dating/profile/id/4/state")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(datingService).verifyRoommateProfileOwner("test-session", 4);
+        verify(datingService).updateRoommateProfileState(4, 1);
+    }
+
+    @Test
+    void updateProfileStateRejectsInvalidStateBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/profile/id/4/state")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false));
 


### PR DESCRIPTION
## Summary
- reject invalid roommate profile state updates before owner/access checks
- add Dating contract coverage for pick state and profile state update endpoints
- assert invalid state inputs return failed JSON without hitting the service

## Validation
- ./gradlew test --tests 'cn.gdeiassistant.contract.DatingContractTest' --console=plain
- ./gradlew test --console=plain
- ./gradlew classes -x test --no-daemon --console=plain
- git diff --check