### PR TITLE
[codex] validate delivery action identifiers

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
+++ b/src/main/java/cn/gdeiassistant/core/delivery/controller/DeliveryController.java
@@ -31,11 +31,19 @@ public class DeliveryController {
     @Autowired
     private DeliveryService deliveryService;
 
+    private int requirePositiveId(Integer id) {
+        if (id == null || id < 1) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return id;
+    }
+
     /**
      * 订单详情（含 detailType；已接单时含 trade）。GET /api/delivery/order/id/{id}
      */
     @RequestMapping(value = "/api/delivery/order/id/{id}", method = RequestMethod.GET)
-    public DataJsonResult<Map<String, Object>> getDeliveryOrderDetail(HttpServletRequest request, @PathVariable("id") Integer id) throws DataNotExistException {
+    public DataJsonResult<Map<String, Object>> getDeliveryOrderDetail(HttpServletRequest request, @PathVariable("id") @Min(1) Integer id) throws DataNotExistException {
+        id = requirePositiveId(id);
         String sessionId = (String) request.getAttribute("sessionId");
         DeliveryOrderVO order = deliveryService.queryDeliveryOrderByOrderId(id);
         int detailType = deliveryService.queryDeliveryOrderDetailType(sessionId, id);
@@ -95,7 +103,8 @@ public class DeliveryController {
      * @throws Exception
      */
     @RequestMapping(value = "/api/delivery/acceptorder", method = RequestMethod.POST)
-    public JsonResult acceptOrder(HttpServletRequest request, @RequestParam Integer orderId) throws Exception {
+    public JsonResult acceptOrder(HttpServletRequest request, @RequestParam @Min(1) Integer orderId) throws Exception {
+        orderId = requirePositiveId(orderId);
         String sessionId = (String) request.getAttribute("sessionId");
         deliveryService.acceptOrder(orderId, sessionId);
         return new JsonResult(true);
@@ -112,7 +121,8 @@ public class DeliveryController {
      * @throws DeliveryOrderStateUpdatedException
      */
     @RequestMapping(value = "/api/delivery/order/id/{id}", method = RequestMethod.DELETE)
-    public JsonResult deleteOrder(HttpServletRequest request, @PathVariable("id") Integer orderId) throws NoAccessUpdatingException, DataNotExistException, DeliveryOrderStateUpdatedException {
+    public JsonResult deleteOrder(HttpServletRequest request, @PathVariable("id") @Min(1) Integer orderId) throws NoAccessUpdatingException, DataNotExistException, DeliveryOrderStateUpdatedException {
+        orderId = requirePositiveId(orderId);
         String sessionId = (String) request.getAttribute("sessionId");
         deliveryService.deleteOrder(orderId, sessionId);
         return new JsonResult(true);
@@ -128,7 +138,8 @@ public class DeliveryController {
      * @throws NoAccessUpdatingException
      */
     @RequestMapping(value = "/api/delivery/trade/id/{id}/finishtrade", method = RequestMethod.POST)
-    public JsonResult finishTrade(HttpServletRequest request, @PathVariable("id") Integer tradeId) throws DataNotExistException, NoAccessUpdatingException {
+    public JsonResult finishTrade(HttpServletRequest request, @PathVariable("id") @Min(1) Integer tradeId) throws DataNotExistException, NoAccessUpdatingException {
+        tradeId = requirePositiveId(tradeId);
         String sessionId = (String) request.getAttribute("sessionId");
         deliveryService.finishTrade(tradeId, sessionId);
         return new JsonResult(true);

--- a/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
@@ -16,7 +16,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -77,6 +79,78 @@ class DeliveryContractTest {
                 .andExpect(jsonPath("$.success").value(false));
 
         mockMvc.perform(get("/api/delivery/order/start/0/size/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
+    }
+
+    @Test
+    void acceptOrderAcceptsValidOrderId() throws Exception {
+        mockMvc.perform(post("/api/delivery/acceptorder")
+                        .requestAttr("sessionId", "test-session")
+                        .param("orderId", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(deliveryService).acceptOrder(10, "test-session");
+    }
+
+    @Test
+    void acceptOrderRejectsInvalidOrderIdBeforeService() throws Exception {
+        mockMvc.perform(post("/api/delivery/acceptorder")
+                        .requestAttr("sessionId", "test-session")
+                        .param("orderId", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
+    }
+
+    @Test
+    void deleteOrderAcceptsValidOrderId() throws Exception {
+        mockMvc.perform(delete("/api/delivery/order/id/10")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(deliveryService).deleteOrder(10, "test-session");
+    }
+
+    @Test
+    void deleteOrderRejectsInvalidOrderIdBeforeService() throws Exception {
+        mockMvc.perform(delete("/api/delivery/order/id/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
+    }
+
+    @Test
+    void finishTradeAcceptsValidTradeId() throws Exception {
+        mockMvc.perform(post("/api/delivery/trade/id/10/finishtrade")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(deliveryService).finishTrade(10, "test-session");
+    }
+
+    @Test
+    void finishTradeRejectsInvalidTradeIdBeforeService() throws Exception {
+        mockMvc.perform(post("/api/delivery/trade/id/0/finishtrade")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
+    }
+
+    @Test
+    void detailEndpointRejectsInvalidOrderIdBeforeService() throws Exception {
+        mockMvc.perform(get("/api/delivery/order/id/0")
                         .requestAttr("sessionId", "test-session"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false));


### PR DESCRIPTION
## Summary
- reject non-positive Delivery order/trade identifiers before service calls
- add contract coverage for accept, delete, finish-trade, and detail id validation
- assert invalid identifiers return failed JSON without hitting the service

## Validation
- ./gradlew test --tests 'cn.gdeiassistant.contract.DeliveryContractTest' --console=plain
- ./gradlew test --console=plain
- ./gradlew classes -x test --no-daemon --console=plain
- git diff --check