### PR TITLE
[codex] validate topic action identifiers

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/controller/TopicController.java
@@ -32,6 +32,20 @@ public class TopicController {
         return new JsonResult(false, BackendTextLocalizer.localizeMessage(message, request != null ? request.getHeader("Accept-Language") : null));
     }
 
+    private int requirePositiveId(int id) {
+        if (id < 1) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return id;
+    }
+
+    private int requireImageIndex(int index) {
+        if (index < 1 || index > 9) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return index;
+    }
+
     @RequestMapping(value = "/api/topic/profile/start/{start}/size/{size}", method = RequestMethod.GET)
     public DataJsonResult<List<TopicVO>> getMyTopicList(HttpServletRequest request
             , @PathVariable("start") int start, @PathVariable("size") int size) {
@@ -43,6 +57,7 @@ public class TopicController {
 
     @RequestMapping(value = "/api/topic/id/{id}", method = RequestMethod.GET)
     public DataJsonResult<TopicVO> getTopicDetail(HttpServletRequest request, @PathVariable("id") int id) throws DataNotExistException {
+        id = requirePositiveId(id);
         String sessionId = (String) request.getAttribute("sessionId");
         TopicVO vo = topicService.queryTopicById(id, sessionId);
         return new DataJsonResult<>(true, vo);
@@ -113,6 +128,7 @@ public class TopicController {
 
     @RequestMapping(value = "/api/topic/id/{id}/like", method = RequestMethod.POST)
     public JsonResult likeTopic(HttpServletRequest request, @PathVariable("id") int id) throws DataNotExistException {
+        id = requirePositiveId(id);
         String sessionId = (String) request.getAttribute("sessionId");
         topicService.likeTopic(id, sessionId);
         return new JsonResult(true);
@@ -120,6 +136,8 @@ public class TopicController {
 
     @RequestMapping(value = "/api/topic/id/{id}/index/{index}/image", method = RequestMethod.GET)
     public DataJsonResult<String> getTopicImage(HttpServletRequest request, @PathVariable("id") int id, @PathVariable("index") int index) {
+        id = requirePositiveId(id);
+        index = requireImageIndex(index);
         String url = topicService.downloadTopicItemPicture(id, index);
         return new DataJsonResult<>(true, url);
     }

--- a/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
@@ -14,9 +14,11 @@ import java.util.Date;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -84,6 +86,69 @@ class TopicContractTest {
                 .andExpect(jsonPath("$.data.count").exists())
                 .andExpect(jsonPath("$.data.publishTime").exists())
                 .andExpect(jsonPath("$.data.likeCount").exists());
+    }
+
+    @Test
+    void detailEndpointRejectsInvalidIdBeforeService() throws Exception {
+        mockMvc.perform(get("/api/topic/id/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(topicService);
+    }
+
+    @Test
+    void likeEndpointAcceptsValidId() throws Exception {
+        mockMvc.perform(post("/api/topic/id/5/like")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(topicService).likeTopic(5, "test-session");
+    }
+
+    @Test
+    void likeEndpointRejectsInvalidIdBeforeService() throws Exception {
+        mockMvc.perform(post("/api/topic/id/0/like")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(topicService);
+    }
+
+    @Test
+    void imageEndpointReturnsUrlForValidIndex() throws Exception {
+        when(topicService.downloadTopicItemPicture(5, 1)).thenReturn("https://example.com/topic/5/1.jpg");
+
+        mockMvc.perform(get("/api/topic/id/5/index/1/image")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value("https://example.com/topic/5/1.jpg"));
+
+        verify(topicService).downloadTopicItemPicture(5, 1);
+    }
+
+    @Test
+    void imageEndpointRejectsInvalidIdOrIndexBeforeService() throws Exception {
+        mockMvc.perform(get("/api/topic/id/0/index/1/image")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/topic/id/5/index/0/image")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(get("/api/topic/id/5/index/10/image")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(topicService);
     }
 
     private static TopicVO mockTopicVO() {


### PR DESCRIPTION
## Summary
- reject non-positive Topic ids for detail, like, and image endpoints before service calls
- reject Topic image indexes outside the persisted 1..9 range
- add contract coverage for valid and invalid Topic action/image requests

## Validation
- ./gradlew test --tests 'cn.gdeiassistant.contract.TopicContractTest' --console=plain
- ./gradlew test --console=plain
- ./gradlew classes -x test --no-daemon --console=plain
- git diff --check