### PR TITLE
[codex] derive topic publish image count

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/topic/pojo/dto/TopicPublishDTO.java
+++ b/src/main/java/cn/gdeiassistant/core/topic/pojo/dto/TopicPublishDTO.java
@@ -3,9 +3,6 @@ package cn.gdeiassistant.core.topic.pojo.dto;
 import org.hibernate.validator.constraints.Length;
 import jakarta.validation.constraints.NotBlank;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 
 /**
@@ -21,9 +18,6 @@ public class TopicPublishDTO implements Serializable {
     @Length(min = 1, max = 250)
     private String content;
 
-    @NotNull
-    @Min(0)
-    @Max(9)
     private Integer count;
 
     public String getTopic() { return topic; }

--- a/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
@@ -2,10 +2,12 @@ package cn.gdeiassistant.contract;
 
 import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.topic.controller.TopicController;
+import cn.gdeiassistant.core.topic.pojo.dto.TopicPublishDTO;
 import cn.gdeiassistant.core.topic.pojo.vo.TopicVO;
 import cn.gdeiassistant.core.topic.service.TopicService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -13,6 +15,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.Date;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -86,6 +91,54 @@ class TopicContractTest {
                 .andExpect(jsonPath("$.data.count").exists())
                 .andExpect(jsonPath("$.data.publishTime").exists())
                 .andExpect(jsonPath("$.data.likeCount").exists());
+    }
+
+    @Test
+    void publishEndpointDerivesZeroCountWhenCountParamIsMissing() throws Exception {
+        mockMvc.perform(post("/api/topic")
+                        .requestAttr("sessionId", "test-session")
+                        .param("topic", "campus")
+                        .param("content", "topic content"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<TopicPublishDTO> captor = ArgumentCaptor.forClass(TopicPublishDTO.class);
+        verify(topicService).addTopic(captor.capture(), eq("test-session"));
+        assertEquals(0, captor.getValue().getCount());
+    }
+
+    @Test
+    void publishEndpointDerivesCountFromImageKeysWhenCountParamIsMissing() throws Exception {
+        TopicVO vo = mockTopicVO();
+        vo.setId(5);
+        when(topicService.addTopic(any(TopicPublishDTO.class), eq("test-session"))).thenReturn(vo);
+
+        mockMvc.perform(post("/api/topic")
+                        .requestAttr("sessionId", "test-session")
+                        .param("topic", "campus")
+                        .param("content", "topic content")
+                        .param("imageKeys", "tmp/topic-1.jpg", "tmp/topic-2.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<TopicPublishDTO> captor = ArgumentCaptor.forClass(TopicPublishDTO.class);
+        verify(topicService).addTopic(captor.capture(), eq("test-session"));
+        assertEquals(2, captor.getValue().getCount());
+        verify(topicService).moveTopicItemPictureFromTempObject(5, 1, "tmp/topic-1.jpg");
+        verify(topicService).moveTopicItemPictureFromTempObject(5, 2, "tmp/topic-2.jpg");
+    }
+
+    @Test
+    void publishEndpointRejectsBlankImageKeysBeforeService() throws Exception {
+        mockMvc.perform(post("/api/topic")
+                        .requestAttr("sessionId", "test-session")
+                        .param("topic", "campus")
+                        .param("content", "topic content")
+                        .param("imageKeys", "tmp/topic-1.jpg", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(topicService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- stop requiring clients to send TopicPublishDTO.count for topic publishing
- rely on the controller-derived image count from imageKeys/images before calling the service
- add contract coverage for publishing without count, derived imageKey count, and blank imageKey rejection

## Validation
- ./gradlew test --tests 'cn.gdeiassistant.contract.TopicContractTest' --console=plain
- ./gradlew test --console=plain
- ./gradlew classes -x test --no-daemon --console=plain
- git diff --check