### PR TITLE
[codex] cover delivery publish validation contracts

### DIFF
--- a/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DeliveryContractTest.java
@@ -2,16 +2,21 @@ package cn.gdeiassistant.contract;
 
 import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.delivery.controller.DeliveryController;
+import cn.gdeiassistant.core.delivery.pojo.dto.DeliveryPublishDTO;
 import cn.gdeiassistant.core.delivery.pojo.vo.DeliveryOrderVO;
 import cn.gdeiassistant.core.delivery.service.DeliveryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -159,6 +164,70 @@ class DeliveryContractTest {
     }
 
     @Test
+    void publishEndpointAcceptsValidPayload() throws Exception {
+        mockMvc.perform(validPublishRequestBuilder())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<DeliveryPublishDTO> captor = ArgumentCaptor.forClass(DeliveryPublishDTO.class);
+        verify(deliveryService).addDeliveryOrder(eq("test-session"), captor.capture());
+        DeliveryPublishDTO dto = captor.getValue();
+        assertEquals("代收", dto.getName());
+        assertEquals("00000000000", dto.getNumber());
+        assertEquals("13800138000", dto.getPhone());
+        assertEquals(5.50f, dto.getPrice());
+        assertEquals("菜鸟驿站", dto.getCompany());
+        assertEquals("南苑5栋307", dto.getAddress());
+        assertEquals("轻拿轻放", dto.getRemarks());
+    }
+
+    @Test
+    void publishEndpointRejectsMissingRequiredFieldsBeforeService() throws Exception {
+        mockMvc.perform(post("/api/delivery/order")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "")
+                        .param("number", "00000000000")
+                        .param("phone", "13800138000")
+                        .param("price", "5.50")
+                        .param("company", "菜鸟驿站")
+                        .param("address", "南苑5栋307"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
+    }
+
+    @Test
+    void publishEndpointRejectsInvalidNumberOrPhoneBeforeService() throws Exception {
+        mockMvc.perform(publishRequestBuilder("代收", "1234567890", "13800138000", "5.50", "菜鸟驿站", "南苑5栋307", "轻拿轻放"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(publishRequestBuilder("代收", "00000000000", "138001380001", "5.50", "菜鸟驿站", "南苑5栋307", "轻拿轻放"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
+    }
+
+    @Test
+    void publishEndpointRejectsInvalidPriceOrRemarksBeforeService() throws Exception {
+        mockMvc.perform(publishRequestBuilder("代收", "00000000000", "13800138000", "0", "菜鸟驿站", "南苑5栋307", "轻拿轻放"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(publishRequestBuilder("代收", "00000000000", "13800138000", "10000.00", "菜鸟驿站", "南苑5栋307", "轻拿轻放"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(publishRequestBuilder("代收", "00000000000", "13800138000", "5.50", "菜鸟驿站", "南苑5栋307", "x".repeat(101)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(deliveryService);
+    }
+
+    @Test
     void detailEndpointReturnsFullFieldsForOwner() throws Exception {
         DeliveryOrderVO order = mockDeliveryOrderVO();
         order.setState(0);
@@ -193,6 +262,23 @@ class DeliveryContractTest {
                 .andExpect(jsonPath("$.data.order.number").doesNotExist())
                 .andExpect(jsonPath("$.data.order.phone").doesNotExist())
                 .andExpect(jsonPath("$.data.detailType").value(1));
+    }
+
+    private static MockHttpServletRequestBuilder validPublishRequestBuilder() {
+        return publishRequestBuilder("代收", "00000000000", "13800138000", "5.50", "菜鸟驿站", "南苑5栋307", "轻拿轻放");
+    }
+
+    private static MockHttpServletRequestBuilder publishRequestBuilder(String name,
+            String number, String phone, String price, String company, String address, String remarks) {
+        return post("/api/delivery/order")
+                .requestAttr("sessionId", "test-session")
+                .param("name", name)
+                .param("number", number)
+                .param("phone", phone)
+                .param("price", price)
+                .param("company", company)
+                .param("address", address)
+                .param("remarks", remarks);
     }
 
     private static DeliveryOrderVO mockDeliveryOrderVO() {


### PR DESCRIPTION
## Summary
- add Delivery publish contract coverage for a valid order payload
- cover missing required fields plus invalid pickup number, phone, price, and remarks
- assert invalid publish inputs return failed JSON without hitting the service

## Validation
- ./gradlew test --tests 'cn.gdeiassistant.contract.DeliveryContractTest' --console=plain
- ./gradlew test --console=plain
- ./gradlew classes -x test --no-daemon --console=plain
- git diff --check