### PR TITLE
[codex] validate dating contract boundaries

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/controller/DatingController.java
@@ -45,8 +45,16 @@ public class DatingController {
         return new JsonResult(false, BackendTextLocalizer.localizeMessage(message, request != null ? request.getHeader("Accept-Language") : null));
     }
 
+    private int requirePositiveId(Integer id) {
+        if (id == null || id < 1) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        return id;
+    }
+
     @RequestMapping(value = "/api/dating/profile/id/{id}", method = RequestMethod.GET)
     public DataJsonResult<Map<String, Object>> getRoommateProfileDetail(HttpServletRequest request, @PathVariable("id") Integer id) throws DataNotExistException {
+        id = requirePositiveId(id);
         String sessionId = (String) request.getAttribute("sessionId");
         DatingProfileVO profile = datingService.queryDatingProfile(id);
         String pictureURL = datingService.getRoommateProfilePictureURL(id);
@@ -83,6 +91,7 @@ public class DatingController {
 
     @RequestMapping(value = "/api/dating/profile/id/{id}/picture", method = RequestMethod.GET)
     public DataJsonResult<String> getRoommateProfilePicture(@PathVariable("id") Integer id) {
+        id = requirePositiveId(id);
         String url = datingService.getRoommateProfilePictureURL(id);
         return StringUtils.isNotBlank(url) ? new DataJsonResult<>(true, url) : new DataJsonResult<>(new JsonResult(false));
     }
@@ -129,6 +138,7 @@ public class DatingController {
 
     @RequestMapping(value = "/api/dating/pick/id/{id}", method = RequestMethod.GET)
     public DataJsonResult<DatingPickVO> getRoommatePickDetail(HttpServletRequest request, @PathVariable("id") Integer id) throws DataNotExistException, NoAccessException {
+        id = requirePositiveId(id);
         datingService.verifyRoommatePickViewAccess((String) request.getAttribute("sessionId"), id);
         DatingPickVO vo = datingService.getRoommatePickDetailVo(id);
         return new DataJsonResult<>(true, vo);
@@ -136,6 +146,7 @@ public class DatingController {
 
     @RequestMapping(value = "/api/dating/pick/id/{id}", method = RequestMethod.POST)
     public JsonResult updateRoommatePickState(HttpServletRequest request, @PathVariable("id") Integer id, Integer state) throws DataNotExistException, NoAccessException {
+        id = requirePositiveId(id);
         if (state == null || (!state.equals(-1) && !state.equals(1))) return failure(request, "请求参数不合法");
         String sessionId = (String) request.getAttribute("sessionId");
         datingService.verifyRoommatePickViewAccess(sessionId, id);
@@ -147,16 +158,17 @@ public class DatingController {
     @RequestMapping(value = "/api/dating/pick", method = RequestMethod.POST)
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult addRoommatePick(HttpServletRequest request, @Validated DatingPickSubmitDTO dto) throws SelfPickException, RepeatPickException, DataNotExistException {
-        if (dto.getProfileId() == null) return failure(request, "请求参数不合法");
+        int profileId = requirePositiveId(dto.getProfileId());
         if (dto.getContent() != null && dto.getContent().length() > 50) return failure(request, "文本内容超过限制");
         String sessionId = (String) request.getAttribute("sessionId");
-        datingService.verifyRoommatePickRequestAccess(sessionId, dto.getProfileId());
+        datingService.verifyRoommatePickRequestAccess(sessionId, profileId);
         datingService.addRoommatePick(sessionId, dto);
         return new JsonResult(true);
     }
 
     @RequestMapping(value = "/api/dating/profile/id/{id}/state", method = RequestMethod.POST)
     public JsonResult updateMyRoommateProfileState(HttpServletRequest request, @PathVariable("id") Integer id, Integer state) throws DataNotExistException, NoAccessException {
+        id = requirePositiveId(id);
         if (state == null || (!state.equals(0) && !state.equals(1))) return failure(request, "请求参数不合法");
         String sessionId = (String) request.getAttribute("sessionId");
         datingService.verifyRoommateProfileOwner(sessionId, id);

--- a/src/main/java/cn/gdeiassistant/core/dating/pojo/dto/DatingPickSubmitDTO.java
+++ b/src/main/java/cn/gdeiassistant/core/dating/pojo/dto/DatingPickSubmitDTO.java
@@ -2,6 +2,7 @@ package cn.gdeiassistant.core.dating.pojo.dto;
 
 import org.hibernate.validator.constraints.Length;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 
@@ -11,6 +12,7 @@ import java.io.Serializable;
 public class DatingPickSubmitDTO implements Serializable {
 
     @NotNull
+    @Min(1)
     private Integer profileId;
 
     @Length(max = 50)

--- a/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/DatingContractTest.java
@@ -2,23 +2,24 @@ package cn.gdeiassistant.contract;
 
 import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.dating.controller.DatingController;
-import cn.gdeiassistant.core.dating.pojo.vo.DatingPickVO;
+import cn.gdeiassistant.core.dating.pojo.dto.DatingPickSubmitDTO;
+import cn.gdeiassistant.core.dating.pojo.dto.DatingPublishDTO;
 import cn.gdeiassistant.core.dating.pojo.vo.DatingProfileVO;
 import cn.gdeiassistant.core.dating.service.DatingService;
 import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -105,6 +106,17 @@ class DatingContractTest {
     }
 
     @Test
+    void updatePickStateRejectsInvalidIdBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/pick/id/0")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
     void updateProfileStateAcceptsValidState() throws Exception {
         mockMvc.perform(post("/api/dating/profile/id/4/state")
                         .requestAttr("sessionId", "test-session")
@@ -121,6 +133,17 @@ class DatingContractTest {
         mockMvc.perform(post("/api/dating/profile/id/4/state")
                         .requestAttr("sessionId", "test-session")
                         .param("state", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void updateProfileStateRejectsInvalidIdBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/profile/id/0/state")
+                        .requestAttr("sessionId", "test-session")
+                        .param("state", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false));
 
@@ -150,6 +173,34 @@ class DatingContractTest {
     }
 
     @Test
+    void getProfileByIdRejectsInvalidIdBeforeService() throws Exception {
+        mockMvc.perform(get("/api/dating/profile/id/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void getProfilePictureRejectsInvalidIdBeforeService() throws Exception {
+        mockMvc.perform(get("/api/dating/profile/id/0/picture"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void getPickDetailRejectsInvalidIdBeforeService() throws Exception {
+        mockMvc.perform(get("/api/dating/pick/id/0")
+                        .requestAttr("sessionId", "test-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
     void getProfileById_hiddenProfileReturnsDataNotExistError() throws Exception {
         when(datingService.queryDatingProfile(Integer.valueOf(99)))
                 .thenThrow(new DataNotExistException("该卖室友信息不存在"));
@@ -158,5 +209,133 @@ class DatingContractTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.code").value(40401));
+    }
+
+    @Test
+    void publishProfileAcceptsValidPayloadAndImageKey() throws Exception {
+        when(datingService.addRoommateProfile(eq("test-session"), any(DatingPublishDTO.class)))
+                .thenReturn(7);
+
+        mockMvc.perform(post("/api/dating/profile")
+                        .requestAttr("sessionId", "test-session")
+                        .param("nickname", "小明")
+                        .param("grade", "3")
+                        .param("faculty", "计科")
+                        .param("hometown", "广州")
+                        .param("content", "想找饭搭子")
+                        .param("qq", "123456")
+                        .param("wechat", "wechat-id")
+                        .param("area", "1")
+                        .param("imageKey", "upload/dating/tmp.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<DatingPublishDTO> captor = ArgumentCaptor.forClass(DatingPublishDTO.class);
+        verify(datingService).addRoommateProfile(eq("test-session"), captor.capture());
+        DatingPublishDTO dto = captor.getValue();
+        assertEquals("小明", dto.getNickname());
+        assertEquals(3, dto.getGrade());
+        assertEquals("计科", dto.getFaculty());
+        assertEquals("广州", dto.getHometown());
+        assertEquals("想找饭搭子", dto.getContent());
+        assertEquals("123456", dto.getQq());
+        assertEquals("wechat-id", dto.getWechat());
+        assertEquals(1, dto.getArea());
+        verify(datingService).movePictureFromTempObject(7, "upload/dating/tmp.jpg");
+    }
+
+    @Test
+    void publishProfileRejectsMissingRequiredFieldsBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/profile")
+                        .requestAttr("sessionId", "test-session")
+                        .param("nickname", "")
+                        .param("grade", "3")
+                        .param("faculty", "计科")
+                        .param("hometown", "广州")
+                        .param("content", "想找饭搭子")
+                        .param("area", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void publishProfileRejectsInvalidBoundsBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/profile")
+                        .requestAttr("sessionId", "test-session")
+                        .param("nickname", "小明")
+                        .param("grade", "0")
+                        .param("faculty", "计科")
+                        .param("hometown", "广州")
+                        .param("content", "想找饭搭子")
+                        .param("area", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/dating/profile")
+                        .requestAttr("sessionId", "test-session")
+                        .param("nickname", "小明")
+                        .param("grade", "3")
+                        .param("faculty", "计科")
+                        .param("hometown", "广州")
+                        .param("content", "想找饭搭子")
+                        .param("area", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/dating/profile")
+                        .requestAttr("sessionId", "test-session")
+                        .param("nickname", "小明")
+                        .param("grade", "3")
+                        .param("faculty", "计科")
+                        .param("hometown", "广州")
+                        .param("content", "想找饭搭子")
+                        .param("qq", "x".repeat(16))
+                        .param("area", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void addPickAcceptsValidPayload() throws Exception {
+        mockMvc.perform(post("/api/dating/pick")
+                        .requestAttr("sessionId", "test-session")
+                        .param("profileId", "3")
+                        .param("content", "一起吃饭吗"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<DatingPickSubmitDTO> captor = ArgumentCaptor.forClass(DatingPickSubmitDTO.class);
+        verify(datingService).verifyRoommatePickRequestAccess("test-session", 3);
+        verify(datingService).addRoommatePick(eq("test-session"), captor.capture());
+        assertEquals(3, captor.getValue().getProfileId());
+        assertEquals("一起吃饭吗", captor.getValue().getContent());
+    }
+
+    @Test
+    void addPickRejectsInvalidProfileIdBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/pick")
+                        .requestAttr("sessionId", "test-session")
+                        .param("profileId", "0")
+                        .param("content", "一起吃饭吗"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
+    }
+
+    @Test
+    void addPickRejectsOversizeContentBeforeService() throws Exception {
+        mockMvc.perform(post("/api/dating/pick")
+                        .requestAttr("sessionId", "test-session")
+                        .param("profileId", "3")
+                        .param("content", "x".repeat(51)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(datingService);
     }
 }


### PR DESCRIPTION
## Summary
- Reject non-positive dating profile and pick ids at the controller boundary before service calls.
- Add `@Min(1)` to dating pick `profileId` validation.
- Extend Dating contract coverage for profile publish, pick submit, id bounds, and validation failures.

## Validation
- `./gradlew test --tests 'cn.gdeiassistant.contract.DatingContractTest' --console=plain`
- `./gradlew test --console=plain`
- `./gradlew classes -x test --no-daemon --console=plain`
- `git diff --check`