### PR TITLE
[codex] cover marketplace lostfound publish boundaries

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/lostandfound/pojo/dto/LostAndFoundPublishDTO.java
+++ b/src/main/java/cn/gdeiassistant/core/lostandfound/pojo/dto/LostAndFoundPublishDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 
 /**
@@ -24,10 +25,12 @@ public class LostAndFoundPublishDTO implements Serializable {
     @Length(max = 30)
     private String location;
 
+    @NotNull
     @Min(0)
     @Max(11)
     private Integer itemType;
 
+    @NotNull
     @Min(0)
     @Max(1)
     private Integer lostType;

--- a/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/controller/MarketplaceController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +35,9 @@ import java.util.stream.Collectors;
 
 @RestController
 public class MarketplaceController {
+
+    private static final BigDecimal MIN_PRICE = new BigDecimal("0.01");
+    private static final BigDecimal MAX_PRICE = new BigDecimal("9999.99");
 
     /**
      * Per-group cap for the personal profile endpoint.
@@ -48,6 +52,14 @@ public class MarketplaceController {
 
     private JsonResult failure(HttpServletRequest request, String message) {
         return new JsonResult(false, localize(request, message));
+    }
+
+    private boolean isInvalidPrice(Float price) {
+        if (price == null) {
+            return true;
+        }
+        BigDecimal value = new BigDecimal(price.toString());
+        return value.compareTo(MIN_PRICE) < 0 || value.compareTo(MAX_PRICE) > 0;
     }
 
     @RequestMapping(value = "/api/ershou/item/start/{start}", method = RequestMethod.GET)
@@ -87,6 +99,9 @@ public class MarketplaceController {
             @Validated MarketplacePublishDTO dto, MultipartFile image1,
             MultipartFile image2, MultipartFile image3, MultipartFile image4,
             @RequestParam(value = "imageKeys", required = false) String[] imageKeys) throws Exception {
+        if (isInvalidPrice(dto.getPrice())) {
+            return failure(request, "商品价格不合法");
+        }
         MultipartFile[] images = new MultipartFile[]{image1, image2, image3, image4};
         int uploadedFileCount = 0;
         for (MultipartFile image : images) {
@@ -179,7 +194,7 @@ public class MarketplaceController {
     @RecordIPAddress(type = IPAddressEnum.POST)
     public JsonResult updateItem(HttpServletRequest request, @Validated MarketplacePublishDTO dto,
             @PathVariable("id") int id) throws Exception {
-        if (dto.getPrice() <= 0 || dto.getPrice() > 9999.99) {
+        if (isInvalidPrice(dto.getPrice())) {
             return failure(request, "商品价格不合法");
         }
         String sessionId = (String) request.getAttribute("sessionId");

--- a/src/main/java/cn/gdeiassistant/core/marketplace/pojo/dto/MarketplacePublishDTO.java
+++ b/src/main/java/cn/gdeiassistant/core/marketplace/pojo/dto/MarketplacePublishDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 
 /**
@@ -20,12 +21,14 @@ public class MarketplacePublishDTO implements Serializable {
     @Length(max = 100)
     private String description;
 
+    @NotNull
     private Float price;
 
     @NotBlank(message = "交易地点不能为空")
     @Length(max = 30)
     private String location;
 
+    @NotNull
     @Min(0)
     @Max(11)
     private Integer type;

--- a/src/test/java/cn/gdeiassistant/contract/LostAndFoundContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/LostAndFoundContractTest.java
@@ -2,19 +2,25 @@ package cn.gdeiassistant.contract;
 
 import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.lostandfound.controller.LostAndFoundController;
+import cn.gdeiassistant.core.lostandfound.pojo.dto.LostAndFoundPublishDTO;
 import cn.gdeiassistant.core.lostandfound.pojo.vo.LostAndFoundDetailVO;
 import cn.gdeiassistant.core.lostandfound.pojo.vo.LostAndFoundItemVO;
 import cn.gdeiassistant.core.lostandfound.service.LostAndFoundService;
 import cn.gdeiassistant.core.profile.pojo.vo.ProfileVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -120,6 +126,106 @@ class LostAndFoundContractTest {
         mockMvc.perform(get("/api/lostandfound/item/id/99/preview"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false));
+    }
+
+
+    @Test
+    void publishEndpointAcceptsValidPayloadAndImageKeys() throws Exception {
+        LostAndFoundItemVO saved = mockLostAndFoundItem();
+        saved.setId(8);
+        when(lostAndFoundService.addLostAndFoundItem(any(LostAndFoundPublishDTO.class), eq("test-session")))
+                .thenReturn(saved);
+
+        mockMvc.perform(post("/api/lostandfound/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "校园卡")
+                        .param("description", "图书馆门口捡到")
+                        .param("location", "图书馆")
+                        .param("itemType", "3")
+                        .param("lostType", "1")
+                        .param("qq", "123456")
+                        .param("wechat", "wechat-id")
+                        .param("phone", "13612340001")
+                        .param("imageKeys", "upload/lost-1.jpg", "upload/lost-2.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<LostAndFoundPublishDTO> captor = ArgumentCaptor.forClass(LostAndFoundPublishDTO.class);
+        verify(lostAndFoundService).addLostAndFoundItem(captor.capture(), eq("test-session"));
+        LostAndFoundPublishDTO dto = captor.getValue();
+        assertEquals("校园卡", dto.getName());
+        assertEquals("图书馆门口捡到", dto.getDescription());
+        assertEquals("图书馆", dto.getLocation());
+        assertEquals(3, dto.getItemType());
+        assertEquals(1, dto.getLostType());
+        assertEquals("123456", dto.getQq());
+        assertEquals("wechat-id", dto.getWechat());
+        assertEquals("13612340001", dto.getPhone());
+        verify(lostAndFoundService).moveLostAndFoundItemPictureFromTempObject(8, 1, "upload/lost-1.jpg");
+        verify(lostAndFoundService).moveLostAndFoundItemPictureFromTempObject(8, 2, "upload/lost-2.jpg");
+    }
+
+    @Test
+    void publishEndpointRejectsMissingTypeFieldsBeforeService() throws Exception {
+        mockMvc.perform(post("/api/lostandfound/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "校园卡")
+                        .param("description", "图书馆门口捡到")
+                        .param("location", "图书馆")
+                        .param("lostType", "1")
+                        .param("imageKeys", "upload/lost-1.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/lostandfound/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "校园卡")
+                        .param("description", "图书馆门口捡到")
+                        .param("location", "图书馆")
+                        .param("itemType", "3")
+                        .param("imageKeys", "upload/lost-1.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(lostAndFoundService);
+    }
+
+    @Test
+    void publishEndpointRejectsInvalidImageKeysBeforeService() throws Exception {
+        mockMvc.perform(post("/api/lostandfound/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "校园卡")
+                        .param("description", "图书馆门口捡到")
+                        .param("location", "图书馆")
+                        .param("itemType", "3")
+                        .param("lostType", "1")
+                        .param("imageKeys", "upload/lost-1.jpg", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/lostandfound/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "校园卡")
+                        .param("description", "图书馆门口捡到")
+                        .param("location", "图书馆")
+                        .param("itemType", "3")
+                        .param("lostType", "1")
+                        .param("imageKeys", "upload/lost-1.jpg", "upload/lost-2.jpg", "upload/lost-3.jpg",
+                                "upload/lost-4.jpg", "upload/lost-5.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/lostandfound/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "校园卡")
+                        .param("description", "图书馆门口捡到")
+                        .param("location", "图书馆")
+                        .param("itemType", "3")
+                        .param("lostType", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(lostAndFoundService);
     }
 
     private static LostAndFoundItemVO mockLostAndFoundItem() {

--- a/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/MarketplaceContractTest.java
@@ -2,18 +2,23 @@ package cn.gdeiassistant.contract;
 
 import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
 import cn.gdeiassistant.core.marketplace.controller.MarketplaceController;
+import cn.gdeiassistant.core.marketplace.pojo.dto.MarketplacePublishDTO;
 import cn.gdeiassistant.core.marketplace.pojo.entity.MarketplaceItemEntity;
 import cn.gdeiassistant.core.marketplace.pojo.vo.MarketplaceItemVO;
 import cn.gdeiassistant.core.marketplace.service.MarketplaceService;
 import cn.gdeiassistant.core.profile.pojo.vo.ProfileVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -170,6 +175,150 @@ class MarketplaceContractTest {
         mockMvc.perform(post("/api/ershou/item/state/id/101")
                         .requestAttr("sessionId", "test-session")
                         .param("state", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(marketplaceService);
+    }
+
+
+    @Test
+    void publishEndpointAcceptsValidPayloadAndImageKeys() throws Exception {
+        MarketplaceItemEntity saved = mockItemEntity();
+        saved.setId(6);
+        when(marketplaceService.publishItem(any(MarketplacePublishDTO.class), eq("test-session")))
+                .thenReturn(saved);
+
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "教材")
+                        .param("description", "九成新微积分教材")
+                        .param("price", "25.50")
+                        .param("location", "图书馆门口")
+                        .param("type", "8")
+                        .param("qq", "123456")
+                        .param("phone", "13612340001")
+                        .param("imageKeys", "upload/item-1.jpg", "upload/item-2.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<MarketplacePublishDTO> captor = ArgumentCaptor.forClass(MarketplacePublishDTO.class);
+        verify(marketplaceService).publishItem(captor.capture(), eq("test-session"));
+        MarketplacePublishDTO dto = captor.getValue();
+        assertEquals("教材", dto.getName());
+        assertEquals("九成新微积分教材", dto.getDescription());
+        assertEquals(Float.valueOf(25.50f), dto.getPrice());
+        assertEquals("图书馆门口", dto.getLocation());
+        assertEquals(8, dto.getType());
+        assertEquals("123456", dto.getQq());
+        assertEquals("13612340001", dto.getPhone());
+        verify(marketplaceService).moveItemPictureFromTempObject(6, 1, "upload/item-1.jpg");
+        verify(marketplaceService).moveItemPictureFromTempObject(6, 2, "upload/item-2.jpg");
+    }
+
+    @Test
+    void publishEndpointAcceptsInclusivePriceBounds() throws Exception {
+        MarketplaceItemEntity minSaved = mockItemEntity();
+        minSaved.setId(7);
+        MarketplaceItemEntity maxSaved = mockItemEntity();
+        maxSaved.setId(8);
+        when(marketplaceService.publishItem(any(MarketplacePublishDTO.class), eq("test-session")))
+                .thenReturn(minSaved, maxSaved);
+
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "贴纸")
+                        .param("description", "边界价格测试")
+                        .param("price", "0.01")
+                        .param("location", "图书馆门口")
+                        .param("type", "8")
+                        .param("imageKeys", "upload/min-price.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "电脑")
+                        .param("description", "边界价格测试")
+                        .param("price", "9999.99")
+                        .param("location", "图书馆门口")
+                        .param("type", "8")
+                        .param("imageKeys", "upload/max-price.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(marketplaceService).moveItemPictureFromTempObject(7, 1, "upload/min-price.jpg");
+        verify(marketplaceService).moveItemPictureFromTempObject(8, 1, "upload/max-price.jpg");
+    }
+
+    @Test
+    void publishEndpointRejectsInvalidPriceOrTypeBeforeService() throws Exception {
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "教材")
+                        .param("description", "九成新微积分教材")
+                        .param("location", "图书馆门口")
+                        .param("type", "8")
+                        .param("imageKeys", "upload/item-1.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "教材")
+                        .param("description", "九成新微积分教材")
+                        .param("price", "0")
+                        .param("location", "图书馆门口")
+                        .param("type", "8")
+                        .param("imageKeys", "upload/item-1.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "教材")
+                        .param("description", "九成新微积分教材")
+                        .param("price", "25.50")
+                        .param("location", "图书馆门口")
+                        .param("imageKeys", "upload/item-1.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(marketplaceService);
+    }
+
+    @Test
+    void publishEndpointRejectsInvalidImageKeysBeforeService() throws Exception {
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "教材")
+                        .param("description", "九成新微积分教材")
+                        .param("price", "25.50")
+                        .param("location", "图书馆门口")
+                        .param("type", "8")
+                        .param("imageKeys", "upload/item-1.jpg", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "教材")
+                        .param("description", "九成新微积分教材")
+                        .param("price", "25.50")
+                        .param("location", "图书馆门口")
+                        .param("type", "8")
+                        .param("imageKeys", "upload/item-1.jpg", "upload/item-2.jpg", "upload/item-3.jpg",
+                                "upload/item-4.jpg", "upload/item-5.jpg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        mockMvc.perform(post("/api/ershou/item")
+                        .requestAttr("sessionId", "test-session")
+                        .param("name", "教材")
+                        .param("description", "九成新微积分教材")
+                        .param("price", "25.50")
+                        .param("location", "图书馆门口")
+                        .param("type", "8"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(false));
 


### PR DESCRIPTION
## Summary
- Require LostAndFound `itemType` and `lostType` at the DTO boundary.
- Require Marketplace `price` and `type`, and bound `price` to `0.01..9999.99` before service calls.
- Add publish contract coverage for valid `imageKeys`, missing required type/price fields, invalid image keys, and missing images.

## Validation
- `./gradlew test --tests 'cn.gdeiassistant.contract.LostAndFoundContractTest' --tests 'cn.gdeiassistant.contract.MarketplaceContractTest' --console=plain`
- `./gradlew test --console=plain`
- `./gradlew classes -x test --no-daemon --console=plain`
- `git diff --check`