### PR TITLE
[codex] align publish contract validation

### DIFF
--- a/src/main/java/cn/gdeiassistant/core/secret/pojo/dto/SecretPublishDTO.java
+++ b/src/main/java/cn/gdeiassistant/core/secret/pojo/dto/SecretPublishDTO.java
@@ -2,7 +2,6 @@ package cn.gdeiassistant.core.secret.pojo.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.io.Serializable;
@@ -17,7 +16,6 @@ public class SecretPublishDTO implements Serializable {
     @Max(12)
     private Integer theme;
 
-    @NotBlank(message = "树洞内容不能为空")
     @Size(min = 1, max = 100)
     private String content;
 

--- a/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/SecretContractTest.java
@@ -7,6 +7,7 @@ import cn.gdeiassistant.core.secret.pojo.vo.SecretVO;
 import cn.gdeiassistant.core.secret.service.SecretService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -14,6 +15,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.Date;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -142,6 +147,41 @@ class SecretContractTest {
                 .andExpect(jsonPath("$.data[0].comment").exists())
                 .andExpect(jsonPath("$.data[0].avatarTheme").exists())
                 .andExpect(jsonPath("$.data[0].publishTime").exists());
+    }
+
+    @Test
+    void publishVoiceEndpointAllowsMissingTextContentWhenVoiceKeyIsProvided() throws Exception {
+        when(secretService.addSecretInfo(eq("test-session"), any())).thenReturn(7);
+
+        mockMvc.perform(post("/api/secret/info")
+                        .requestAttr("sessionId", "test-session")
+                        .param("theme", "1")
+                        .param("type", "1")
+                        .param("timer", "0")
+                        .param("voiceKey", "tmp/voice.m4a"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<cn.gdeiassistant.core.secret.pojo.dto.SecretPublishDTO> captor =
+                ArgumentCaptor.forClass(cn.gdeiassistant.core.secret.pojo.dto.SecretPublishDTO.class);
+        verify(secretService).addSecretInfo(eq("test-session"), captor.capture());
+        assertEquals(1, captor.getValue().getType());
+        assertNull(captor.getValue().getContent());
+        verify(secretService).moveVoiceSecretFromTempObject(7, "tmp/voice.m4a");
+    }
+
+    @Test
+    void publishTextEndpointRejectsBlankContentBeforeService() throws Exception {
+        mockMvc.perform(post("/api/secret/info")
+                        .requestAttr("sessionId", "test-session")
+                        .param("theme", "1")
+                        .param("type", "0")
+                        .param("timer", "0")
+                        .param("content", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(secretService);
     }
 
     @Test

--- a/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
+++ b/src/test/java/cn/gdeiassistant/contract/TopicContractTest.java
@@ -8,10 +8,13 @@ import cn.gdeiassistant.core.topic.service.TopicService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 
@@ -23,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -139,6 +143,28 @@ class TopicContractTest {
                 .andExpect(jsonPath("$.success").value(false));
 
         verifyNoInteractions(topicService);
+    }
+
+    @Test
+    void publishEndpointDerivesCountFromMultipartImagesWhenCountParamIsMissing() throws Exception {
+        TopicVO vo = mockTopicVO();
+        vo.setId(6);
+        when(topicService.addTopic(any(TopicPublishDTO.class), eq("test-session"))).thenReturn(vo);
+
+        mockMvc.perform(multipart("/api/topic")
+                        .file(new MockMultipartFile("images", "topic-1.jpg", "image/jpeg", "one".getBytes(StandardCharsets.UTF_8)))
+                        .file(new MockMultipartFile("images", "topic-2.jpg", "image/jpeg", "two".getBytes(StandardCharsets.UTF_8)))
+                        .requestAttr("sessionId", "test-session")
+                        .param("topic", "campus")
+                        .param("content", "topic content"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        ArgumentCaptor<TopicPublishDTO> captor = ArgumentCaptor.forClass(TopicPublishDTO.class);
+        verify(topicService).addTopic(captor.capture(), eq("test-session"));
+        assertEquals(2, captor.getValue().getCount());
+        verify(topicService).uploadTopicItemPicture(eq(6), eq(1), any(InputStream.class));
+        verify(topicService).uploadTopicItemPicture(eq(6), eq(2), any(InputStream.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Allow voice secret publish requests to omit text `content` while keeping text secret content validation in the controller.
- Add backend contract coverage for voice secret publish with `voiceKey` and multipart topic image count derivation.
- Confirm topic count is derived from uploaded `images` / `imageKeys` rather than caller-provided `count`.

## Validation
- `./gradlew test --tests cn.gdeiassistant.contract.SecretContractTest --tests cn.gdeiassistant.contract.TopicContractTest --no-daemon --console=plain`
- `git diff --check`