### PR TITLE
[codex] Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-moss-05e781600.yml
@@ -27,11 +27,11 @@ jobs:
     env:
       VITE_APP_BASE_API: https://gdeiassistant.azurewebsites.net/api
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
           lfs: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24.14.1
           cache: npm

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version-file: frontend/.nvmrc
           cache: npm

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version-file: frontend/.nvmrc
           cache: npm


### PR DESCRIPTION
## Summary
- upgrade official GitHub Actions to Node 24 runtime majors
- replace older checkout/setup/upload action majors without changing workflow logic

## Verification
- parsed changed workflow YAML files with PyYAML
- confirmed no remaining actions/checkout, setup-python, setup-node, upload-artifact, or download-artifact refs below the Node 24 major versions under /Users/lisiyi/Projects
- verified selected action.yml files use `runs.using: node24`
- git diff --check
