### PR TITLE
Add charge order query APIs

### DIFF
--- a/docs/compliance-todo.md
+++ b/docs/compliance-todo.md
@@ -111,8 +111,8 @@
 ## 13. 充值订单状态表和状态流转
 
 - 当前状态：基础实现。后端新增 `charge_order` 表记录 `CREATED`、`PROCESSING`、`PAYMENT_SESSION_CREATED`、`FAILED`、`UNKNOWN`、`MANUAL_REVIEW` 等状态，并与 Redis 幂等记录关联订单摘要。`PAYMENT_SESSION_CREATED` 仅表示支付会话或跳转链接已生成，不代表校园卡余额最终到账。
-- 风险说明：当前阶段不提供订单查询 API、客户端订单状态 UI、UNKNOWN 自动补偿、人工处理后台或最终到账确认。学校侧是否提供稳定订单号、流水号和结果查询能力仍需确认。
-- 建议方案：后续分别推进用户订单查询 API、Android/iOS 订单状态展示、UNKNOWN 自动补偿、MANUAL_REVIEW 处理工具、兼容期后强制幂等键，以及更完整的外部流水号/到账状态确认；如继续依赖支付 URL 和 cookie，应评估安全中转方案，避免长期持久化敏感 cookie。
+- 风险说明：当前阶段已提供用户订单详情和近期列表查询 API，但不提供客户端订单状态 UI、UNKNOWN 自动补偿、人工处理后台或最终到账确认。学校侧是否提供稳定订单号、流水号和结果查询能力仍需确认。
+- 建议方案：后续分别推进 Android/iOS 订单状态展示、UNKNOWN 自动补偿、MANUAL_REVIEW 处理工具、兼容期后强制幂等键，以及更完整的外部流水号/到账状态确认；如继续依赖支付 URL 和 cookie，应评估安全中转方案，避免长期持久化敏感 cookie。
 - 优先级：高
 - 是否需要后端：是
 - 是否需要运营人工处理：是

--- a/src/main/java/cn/gdeiassistant/core/charge/mapper/ChargeOrderMapper.java
+++ b/src/main/java/cn/gdeiassistant/core/charge/mapper/ChargeOrderMapper.java
@@ -4,9 +4,12 @@ import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderEntity;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
+
+import java.util.List;
 
 public interface ChargeOrderMapper {
 
@@ -45,6 +48,9 @@ public interface ChargeOrderMapper {
             + "from charge_order where order_id=#{orderId}")
     @Results(id = "ChargeOrder", value = {
             @Result(property = "orderId", column = "order_id"),
+            @Result(property = "username", column = "username"),
+            @Result(property = "amount", column = "amount"),
+            @Result(property = "status", column = "status"),
             @Result(property = "idempotencyKeyHash", column = "idempotency_key_hash"),
             @Result(property = "payloadFingerprint", column = "payload_fingerprint"),
             @Result(property = "requestId", column = "request_id"),
@@ -63,7 +69,8 @@ public interface ChargeOrderMapper {
             @Result(property = "lastCheckedAt", column = "last_checked_at"),
             @Result(property = "checkCount", column = "check_count"),
             @Result(property = "manualReviewAt", column = "manual_review_at"),
-            @Result(property = "manualReviewNote", column = "manual_review_note")
+            @Result(property = "manualReviewNote", column = "manual_review_note"),
+            @Result(property = "version", column = "version")
     })
     ChargeOrderEntity findByOrderId(String orderId);
 
@@ -71,30 +78,40 @@ public interface ChargeOrderMapper {
             + "device_id_hash,external_order_no,external_trade_no,school_trade_no,payment_url_hash,"
             + "error_code,error_message_sanitized,unknown_reason,created_at,updated_at,submitted_at,"
             + "completed_at,last_checked_at,check_count,manual_review_at,manual_review_note,version "
+            + "from charge_order where order_id=#{orderId} and username=#{username}")
+    @ResultMap("ChargeOrder")
+    ChargeOrderEntity findByOrderIdAndUsername(@Param("orderId") String orderId,
+                                               @Param("username") String username);
+
+    @Select("select order_id,username,amount,status,idempotency_key_hash,payload_fingerprint,request_id,"
+            + "device_id_hash,external_order_no,external_trade_no,school_trade_no,payment_url_hash,"
+            + "error_code,error_message_sanitized,unknown_reason,created_at,updated_at,submitted_at,"
+            + "completed_at,last_checked_at,check_count,manual_review_at,manual_review_note,version "
+            + "from charge_order where username=#{username} order by created_at desc limit #{start},#{size}")
+    @ResultMap("ChargeOrder")
+    List<ChargeOrderEntity> findRecentByUsername(@Param("username") String username,
+                                                 @Param("start") int start,
+                                                 @Param("size") int size);
+
+    @Select("select order_id,username,amount,status,idempotency_key_hash,payload_fingerprint,request_id,"
+            + "device_id_hash,external_order_no,external_trade_no,school_trade_no,payment_url_hash,"
+            + "error_code,error_message_sanitized,unknown_reason,created_at,updated_at,submitted_at,"
+            + "completed_at,last_checked_at,check_count,manual_review_at,manual_review_note,version "
+            + "from charge_order where username=#{username} and status=#{status} "
+            + "order by created_at desc limit #{start},#{size}")
+    @ResultMap("ChargeOrder")
+    List<ChargeOrderEntity> findRecentByUsernameAndStatus(@Param("username") String username,
+                                                          @Param("status") String status,
+                                                          @Param("start") int start,
+                                                          @Param("size") int size);
+
+    @Select("select order_id,username,amount,status,idempotency_key_hash,payload_fingerprint,request_id,"
+            + "device_id_hash,external_order_no,external_trade_no,school_trade_no,payment_url_hash,"
+            + "error_code,error_message_sanitized,unknown_reason,created_at,updated_at,submitted_at,"
+            + "completed_at,last_checked_at,check_count,manual_review_at,manual_review_note,version "
             + "from charge_order where username=#{username} and idempotency_key_hash=#{idempotencyKeyHash} "
             + "and payload_fingerprint=#{payloadFingerprint} order by created_at desc limit 1")
-    @Results(id = "ChargeOrderByIdempotency", value = {
-            @Result(property = "orderId", column = "order_id"),
-            @Result(property = "idempotencyKeyHash", column = "idempotency_key_hash"),
-            @Result(property = "payloadFingerprint", column = "payload_fingerprint"),
-            @Result(property = "requestId", column = "request_id"),
-            @Result(property = "deviceIdHash", column = "device_id_hash"),
-            @Result(property = "externalOrderNo", column = "external_order_no"),
-            @Result(property = "externalTradeNo", column = "external_trade_no"),
-            @Result(property = "schoolTradeNo", column = "school_trade_no"),
-            @Result(property = "paymentUrlHash", column = "payment_url_hash"),
-            @Result(property = "errorCode", column = "error_code"),
-            @Result(property = "errorMessageSanitized", column = "error_message_sanitized"),
-            @Result(property = "unknownReason", column = "unknown_reason"),
-            @Result(property = "createdAt", column = "created_at"),
-            @Result(property = "updatedAt", column = "updated_at"),
-            @Result(property = "submittedAt", column = "submitted_at"),
-            @Result(property = "completedAt", column = "completed_at"),
-            @Result(property = "lastCheckedAt", column = "last_checked_at"),
-            @Result(property = "checkCount", column = "check_count"),
-            @Result(property = "manualReviewAt", column = "manual_review_at"),
-            @Result(property = "manualReviewNote", column = "manual_review_note")
-    })
+    @ResultMap("ChargeOrder")
     ChargeOrderEntity findByIdempotencyKeyHash(@Param("username") String username,
                                                @Param("idempotencyKeyHash") String idempotencyKeyHash,
                                                @Param("payloadFingerprint") String payloadFingerprint);

--- a/src/main/java/cn/gdeiassistant/core/charge/pojo/vo/ChargeOrderVO.java
+++ b/src/main/java/cn/gdeiassistant/core/charge/pojo/vo/ChargeOrderVO.java
@@ -1,0 +1,110 @@
+package cn.gdeiassistant.core.charge.pojo.vo;
+
+import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChargeOrderVO implements Serializable {
+
+    @JSONField(ordinal = 1)
+    private String orderId;
+
+    @JSONField(ordinal = 2)
+    private Integer amount;
+
+    @JSONField(ordinal = 3)
+    private String status;
+
+    @JSONField(ordinal = 4)
+    private String message;
+
+    @JSONField(ordinal = 5)
+    private Date createdAt;
+
+    @JSONField(ordinal = 6)
+    private Date updatedAt;
+
+    @JSONField(ordinal = 7)
+    private Date submittedAt;
+
+    @JSONField(ordinal = 8)
+    private Date completedAt;
+
+    @JSONField(ordinal = 9)
+    private Integer retryAfter;
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public Integer getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Integer amount) {
+        this.amount = amount;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Date getSubmittedAt() {
+        return submittedAt;
+    }
+
+    public void setSubmittedAt(Date submittedAt) {
+        this.submittedAt = submittedAt;
+    }
+
+    public Date getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(Date completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    public Integer getRetryAfter() {
+        return retryAfter;
+    }
+
+    public void setRetryAfter(Integer retryAfter) {
+        this.retryAfter = retryAfter;
+    }
+}

--- a/src/main/java/cn/gdeiassistant/core/charge/service/ChargeOrderService.java
+++ b/src/main/java/cn/gdeiassistant/core/charge/service/ChargeOrderService.java
@@ -1,9 +1,12 @@
 package cn.gdeiassistant.core.charge.service;
 
 import cn.gdeiassistant.common.exception.ChargeException.ChargeIdempotencyException;
+import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
+import cn.gdeiassistant.common.tools.Utils.PageUtils;
 import cn.gdeiassistant.core.charge.mapper.ChargeOrderMapper;
 import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderEntity;
 import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderStatus;
+import cn.gdeiassistant.core.charge.pojo.vo.ChargeOrderVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +15,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class ChargeOrderService {
@@ -95,6 +101,48 @@ public class ChargeOrderService {
         return chargeOrderMapper.findByIdempotencyKeyHash(username, idempotencyKeyHash, payloadFingerprint);
     }
 
+    public ChargeOrderVO queryOrder(String orderId, String username) throws DataNotExistException {
+        ChargeOrderEntity order = chargeOrderMapper.findByOrderIdAndUsername(orderId, username);
+        if (order == null) {
+            throw new DataNotExistException("充值订单不存在或无权访问");
+        }
+        return toSafeVO(order);
+    }
+
+    public List<ChargeOrderVO> queryRecentOrders(String username, Integer page, Integer size, String status) {
+        int safePage = page == null ? 0 : PageUtils.requireNonNegativeStart(page);
+        int safeSize = size == null ? 20 : PageUtils.normalizePageSize(0, size.intValue());
+        if (safePage > Integer.MAX_VALUE / safeSize) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+        int start = safePage * safeSize;
+        String normalizedStatus = normalizeStatus(status);
+        List<ChargeOrderEntity> orders = normalizedStatus == null
+                ? chargeOrderMapper.findRecentByUsername(username, start, safeSize)
+                : chargeOrderMapper.findRecentByUsernameAndStatus(username, normalizedStatus, start, safeSize);
+        return orders.stream().map(this::toSafeVO).collect(Collectors.toList());
+    }
+
+    public ChargeOrderVO toSafeVO(ChargeOrderEntity order) {
+        if (order == null) {
+            return null;
+        }
+        ChargeOrderVO vo = new ChargeOrderVO();
+        vo.setOrderId(order.getOrderId());
+        vo.setAmount(order.getAmount());
+        vo.setStatus(order.getStatus());
+        vo.setMessage(statusMessage(order.getStatus()));
+        vo.setCreatedAt(order.getCreatedAt());
+        vo.setUpdatedAt(order.getUpdatedAt());
+        vo.setSubmittedAt(order.getSubmittedAt());
+        vo.setCompletedAt(order.getCompletedAt());
+        if (ChargeOrderStatus.PROCESSING.name().equals(order.getStatus())
+                || ChargeOrderStatus.UNKNOWN.name().equals(order.getStatus())) {
+            vo.setRetryAfter(60);
+        }
+        return vo;
+    }
+
     private String hashNullable(String value) {
         if (value == null || value.isBlank()) {
             return null;
@@ -128,5 +176,39 @@ public class ChargeOrderService {
             return trimmed;
         }
         return trimmed.substring(0, maxLength);
+    }
+
+    private String normalizeStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+        String normalized = status.trim().toUpperCase(Locale.ROOT);
+        try {
+            return ChargeOrderStatus.valueOf(normalized).name();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("请求参数不合法");
+        }
+    }
+
+    private String statusMessage(String status) {
+        if (ChargeOrderStatus.CREATED.name().equals(status)) {
+            return "充值请求已创建。";
+        }
+        if (ChargeOrderStatus.PROCESSING.name().equals(status)) {
+            return "充值请求正在处理中，请稍后查看结果。";
+        }
+        if (ChargeOrderStatus.PAYMENT_SESSION_CREATED.name().equals(status)) {
+            return "支付请求已生成，请完成支付并刷新余额。该状态不代表最终到账。";
+        }
+        if (ChargeOrderStatus.FAILED.name().equals(status)) {
+            return "充值请求失败，请确认信息后重新提交。";
+        }
+        if (ChargeOrderStatus.UNKNOWN.name().equals(status)) {
+            return "充值状态暂无法确认，请稍后查看订单状态，避免重复提交。";
+        }
+        if (ChargeOrderStatus.MANUAL_REVIEW.name().equals(status)) {
+            return "充值状态需要进一步核实，请等待处理。";
+        }
+        return "充值订单状态暂无法确认，请稍后查看。";
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/chargerequest/controller/ChargeOrderController.java
+++ b/src/main/java/cn/gdeiassistant/core/chargerequest/controller/ChargeOrderController.java
@@ -1,0 +1,54 @@
+package cn.gdeiassistant.core.chargerequest.controller;
+
+import cn.gdeiassistant.common.annotation.RestAuthentication;
+import cn.gdeiassistant.common.pojo.Entity.User;
+import cn.gdeiassistant.common.pojo.Result.DataJsonResult;
+import cn.gdeiassistant.core.charge.pojo.vo.ChargeOrderVO;
+import cn.gdeiassistant.core.charge.service.ChargeOrderService;
+import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RestController
+public class ChargeOrderController {
+
+    @Autowired
+    private ChargeOrderService chargeOrderService;
+
+    @Autowired
+    private UserCertificateService userCertificateService;
+
+    @RequestMapping(value = "/api/card/charge/orders/{orderId}", method = RequestMethod.GET)
+    @RestAuthentication
+    public DataJsonResult<ChargeOrderVO> queryChargeOrder(HttpServletRequest request,
+                                                          @PathVariable("orderId") String orderId) throws Exception {
+        String username = currentUsername(request);
+        return new DataJsonResult<>(true, chargeOrderService.queryOrder(orderId, username));
+    }
+
+    @RequestMapping(value = "/api/card/charge/orders", method = RequestMethod.GET)
+    @RestAuthentication
+    public DataJsonResult<List<ChargeOrderVO>> queryChargeOrderList(HttpServletRequest request,
+                                                                    @RequestParam(value = "page", required = false)
+                                                                    Integer page,
+                                                                    @RequestParam(value = "size", required = false)
+                                                                    Integer size,
+                                                                    @RequestParam(value = "status", required = false)
+                                                                    String status) {
+        String username = currentUsername(request);
+        return new DataJsonResult<>(true, chargeOrderService.queryRecentOrders(username, page, size, status));
+    }
+
+    private String currentUsername(HttpServletRequest request) {
+        String sessionId = (String) request.getAttribute("sessionId");
+        User user = userCertificateService.getUserLoginCertificate(sessionId);
+        return user.getUsername();
+    }
+}

--- a/src/test/java/cn/gdeiassistant/core/charge/service/ChargeOrderServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/charge/service/ChargeOrderServiceTest.java
@@ -1,9 +1,12 @@
 package cn.gdeiassistant.core.charge.service;
 
 import cn.gdeiassistant.common.exception.CommonException.NetWorkTimeoutException;
+import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
 import cn.gdeiassistant.core.charge.mapper.ChargeOrderMapper;
 import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderEntity;
 import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderStatus;
+import cn.gdeiassistant.core.charge.pojo.vo.ChargeOrderVO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,11 +16,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,6 +37,7 @@ class ChargeOrderServiceTest {
     private static final String IDEMPOTENCY_KEY = "synthetic-idempotency-key";
     private static final String DEVICE_ID = "synthetic-device-id";
     private static final String FINGERPRINT = "synthetic-fingerprint";
+    private static final String ORDER_ID = "synthetic-order-id";
 
     @Mock
     private ChargeOrderMapper chargeOrderMapper;
@@ -117,5 +123,109 @@ class ChargeOrderServiceTest {
         assertFalse(first.contains("password"));
         assertFalse(first.contains(DEVICE_ID));
         assertTrue(first.matches("[0-9a-f]+"));
+    }
+
+    @Test
+    void shouldQueryOwnOrderAsSafeVO() throws Exception {
+        ChargeOrderEntity order = syntheticOrder(ChargeOrderStatus.PAYMENT_SESSION_CREATED.name());
+        order.setIdempotencyKeyHash("synthetic-idempotency-hash");
+        order.setPayloadFingerprint("synthetic-payload-fingerprint");
+        order.setDeviceIdHash("synthetic-device-hash");
+        order.setPaymentUrlHash("synthetic-payment-url-hash");
+        order.setErrorMessageSanitized("synthetic sanitized internal error");
+        order.setManualReviewNote("synthetic manual note");
+        when(chargeOrderMapper.findByOrderIdAndUsername(ORDER_ID, USERNAME)).thenReturn(order);
+
+        ChargeOrderVO vo = service.queryOrder(ORDER_ID, USERNAME);
+        String json = new ObjectMapper().writeValueAsString(vo);
+
+        assertEquals(ORDER_ID, vo.getOrderId());
+        assertEquals(ChargeOrderStatus.PAYMENT_SESSION_CREATED.name(), vo.getStatus());
+        assertEquals("支付请求已生成，请完成支付并刷新余额。该状态不代表最终到账。", vo.getMessage());
+        assertFalse(json.contains("idempotencyKeyHash"));
+        assertFalse(json.contains("payloadFingerprint"));
+        assertFalse(json.contains("deviceIdHash"));
+        assertFalse(json.contains("paymentUrlHash"));
+        assertFalse(json.contains("errorMessageSanitized"));
+        assertFalse(json.contains("manualReviewNote"));
+        assertFalse(json.contains("最终到账成功"));
+    }
+
+    @Test
+    void shouldRejectMissingOrOtherUserOrderWithSameSafeError() {
+        when(chargeOrderMapper.findByOrderIdAndUsername(ORDER_ID, USERNAME)).thenReturn(null);
+
+        DataNotExistException exception = assertThrows(DataNotExistException.class,
+                () -> service.queryOrder(ORDER_ID, USERNAME));
+
+        assertEquals("充值订单不存在或无权访问", exception.getMessage());
+    }
+
+    @Test
+    void shouldQueryRecentOrdersWithStatusFilterInDescendingOrder() {
+        ChargeOrderEntity newer = syntheticOrder(ChargeOrderStatus.UNKNOWN.name());
+        newer.setOrderId("synthetic-newer-order-id");
+        ChargeOrderEntity older = syntheticOrder(ChargeOrderStatus.UNKNOWN.name());
+        older.setOrderId("synthetic-older-order-id");
+        when(chargeOrderMapper.findRecentByUsernameAndStatus(USERNAME, ChargeOrderStatus.UNKNOWN.name(), 0, 20))
+                .thenReturn(List.of(newer, older));
+
+        List<ChargeOrderVO> orders = service.queryRecentOrders(USERNAME, 0, 20, "unknown");
+
+        assertEquals("synthetic-newer-order-id", orders.get(0).getOrderId());
+        assertEquals("synthetic-older-order-id", orders.get(1).getOrderId());
+        assertEquals("充值状态暂无法确认，请稍后查看订单状态，避免重复提交。", orders.get(0).getMessage());
+        assertEquals(60, orders.get(0).getRetryAfter());
+        verify(chargeOrderMapper).findRecentByUsernameAndStatus(USERNAME, ChargeOrderStatus.UNKNOWN.name(), 0, 20);
+    }
+
+    @Test
+    void shouldQueryRecentOrdersWithoutStatusFilterAndCapPageSize() {
+        when(chargeOrderMapper.findRecentByUsername(USERNAME, 50, 50)).thenReturn(List.of());
+
+        List<ChargeOrderVO> orders = service.queryRecentOrders(USERNAME, 1, 100, null);
+
+        assertTrue(orders.isEmpty());
+        verify(chargeOrderMapper).findRecentByUsername(USERNAME, 50, 50);
+    }
+
+    @Test
+    void shouldRejectInvalidStatusFilter() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> service.queryRecentOrders(USERNAME, 0, 20, "not-a-status"));
+
+        assertEquals("请求参数不合法", exception.getMessage());
+    }
+
+    @Test
+    void shouldUseSafeMessagesForUnknownAndManualReview() throws Exception {
+        ChargeOrderEntity unknown = syntheticOrder(ChargeOrderStatus.UNKNOWN.name());
+        unknown.setUnknownReason("synthetic password token session cookie reason");
+        ChargeOrderVO unknownVO = service.toSafeVO(unknown);
+
+        ChargeOrderEntity manualReview = syntheticOrder(ChargeOrderStatus.MANUAL_REVIEW.name());
+        manualReview.setManualReviewNote("synthetic password token session cookie note");
+        ChargeOrderVO manualReviewVO = service.toSafeVO(manualReview);
+
+        String json = new ObjectMapper().writeValueAsString(List.of(unknownVO, manualReviewVO));
+        assertTrue(unknownVO.getMessage().contains("暂无法确认"));
+        assertTrue(manualReviewVO.getMessage().contains("需要进一步核实"));
+        assertFalse(json.contains("password"));
+        assertFalse(json.contains("token"));
+        assertFalse(json.contains("session"));
+        assertFalse(json.contains("cookie"));
+    }
+
+    private ChargeOrderEntity syntheticOrder(String status) {
+        ChargeOrderEntity order = new ChargeOrderEntity();
+        order.setOrderId(ORDER_ID);
+        order.setUsername(USERNAME);
+        order.setAmount(50);
+        order.setStatus(status);
+        order.setCreatedAt(new Date(1000L));
+        order.setUpdatedAt(new Date(2000L));
+        order.setSubmittedAt(new Date(3000L));
+        order.setCompletedAt(new Date(4000L));
+        return order;
     }
 }

--- a/src/test/java/cn/gdeiassistant/core/chargerequest/controller/ChargeOrderControllerTest.java
+++ b/src/test/java/cn/gdeiassistant/core/chargerequest/controller/ChargeOrderControllerTest.java
@@ -1,0 +1,141 @@
+package cn.gdeiassistant.core.chargerequest.controller;
+
+import cn.gdeiassistant.common.exception.DatabaseException.DataNotExistException;
+import cn.gdeiassistant.common.exceptionhandler.GlobalRestExceptionHandler;
+import cn.gdeiassistant.common.interceptor.ApiAuthInterceptor;
+import cn.gdeiassistant.common.pojo.Entity.User;
+import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderStatus;
+import cn.gdeiassistant.core.charge.pojo.vo.ChargeOrderVO;
+import cn.gdeiassistant.core.charge.service.ChargeOrderService;
+import cn.gdeiassistant.core.userLogin.service.UserCertificateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ChargeOrderControllerTest {
+
+    private static final String SESSION_ID = "synthetic-session-for-charge-order-query";
+    private static final String USERNAME = "synthetic_charge_user";
+    private static final String ORDER_ID = "synthetic-order-id";
+
+    @Mock
+    private ChargeOrderService chargeOrderService;
+
+    @Mock
+    private UserCertificateService userCertificateService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        ChargeOrderController controller = new ChargeOrderController();
+        ReflectionTestUtils.setField(controller, "chargeOrderService", chargeOrderService);
+        ReflectionTestUtils.setField(controller, "userCertificateService", userCertificateService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .addInterceptors(new ApiAuthInterceptor(List.of()))
+                .setControllerAdvice(new GlobalRestExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void shouldQueryOwnChargeOrderDetail() throws Exception {
+        mockAuthenticatedUser();
+        ChargeOrderVO order = syntheticOrder(ORDER_ID, ChargeOrderStatus.PAYMENT_SESSION_CREATED.name());
+        when(chargeOrderService.queryOrder(ORDER_ID, USERNAME)).thenReturn(order);
+
+        mockMvc.perform(get("/api/card/charge/orders/{orderId}", ORDER_ID)
+                        .requestAttr("sessionId", SESSION_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderId").value(ORDER_ID))
+                .andExpect(jsonPath("$.data.amount").value(50))
+                .andExpect(jsonPath("$.data.status").value(ChargeOrderStatus.PAYMENT_SESSION_CREATED.name()))
+                .andExpect(jsonPath("$.data.message").value("支付请求已生成，请完成支付并刷新余额。该状态不代表最终到账。"))
+                .andExpect(jsonPath("$.data.idempotencyKeyHash").doesNotExist())
+                .andExpect(jsonPath("$.data.payloadFingerprint").doesNotExist())
+                .andExpect(jsonPath("$.data.deviceIdHash").doesNotExist())
+                .andExpect(jsonPath("$.data.paymentUrlHash").doesNotExist())
+                .andExpect(jsonPath("$.data.errorMessageSanitized").doesNotExist())
+                .andExpect(jsonPath("$.data.manualReviewNote").doesNotExist());
+
+        verify(chargeOrderService).queryOrder(ORDER_ID, USERNAME);
+    }
+
+    @Test
+    void shouldReturnSafeNotFoundForMissingOrOtherUserOrder() throws Exception {
+        mockAuthenticatedUser();
+        when(chargeOrderService.queryOrder(ORDER_ID, USERNAME))
+                .thenThrow(new DataNotExistException("充值订单不存在或无权访问"));
+
+        mockMvc.perform(get("/api/card/charge/orders/{orderId}", ORDER_ID)
+                        .requestAttr("sessionId", SESSION_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("充值订单不存在或无权访问"));
+    }
+
+    @Test
+    void shouldQueryRecentChargeOrdersForCurrentUserOnly() throws Exception {
+        mockAuthenticatedUser();
+        ChargeOrderVO order = syntheticOrder(ORDER_ID, ChargeOrderStatus.PROCESSING.name());
+        when(chargeOrderService.queryRecentOrders(USERNAME, 0, 20, ChargeOrderStatus.PROCESSING.name()))
+                .thenReturn(List.of(order));
+
+        mockMvc.perform(get("/api/card/charge/orders")
+                        .requestAttr("sessionId", SESSION_ID)
+                        .param("page", "0")
+                        .param("size", "20")
+                        .param("status", ChargeOrderStatus.PROCESSING.name()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].orderId").value(ORDER_ID))
+                .andExpect(jsonPath("$.data[0].status").value(ChargeOrderStatus.PROCESSING.name()))
+                .andExpect(jsonPath("$.data[0].retryAfter").value(60))
+                .andExpect(jsonPath("$.data[0].username").doesNotExist());
+
+        verify(chargeOrderService).queryRecentOrders(USERNAME, 0, 20, ChargeOrderStatus.PROCESSING.name());
+    }
+
+    @Test
+    void shouldRejectUnauthenticatedOrderQueries() throws Exception {
+        mockMvc.perform(get("/api/card/charge/orders/{orderId}", ORDER_ID))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(userCertificateService, chargeOrderService);
+    }
+
+    private void mockAuthenticatedUser() {
+        when(userCertificateService.getUserLoginCertificate(SESSION_ID)).thenReturn(new User(USERNAME, "synthetic"));
+    }
+
+    private ChargeOrderVO syntheticOrder(String orderId, String status) {
+        ChargeOrderVO order = new ChargeOrderVO();
+        order.setOrderId(orderId);
+        order.setAmount(50);
+        order.setStatus(status);
+        if (ChargeOrderStatus.PAYMENT_SESSION_CREATED.name().equals(status)) {
+            order.setMessage("支付请求已生成，请完成支付并刷新余额。该状态不代表最终到账。");
+        } else {
+            order.setMessage("充值请求正在处理中，请稍后查看结果。");
+            order.setRetryAfter(60);
+        }
+        return order;
+    }
+}

--- a/src/test/java/cn/gdeiassistant/mapper/MapperIntegrationTest.java
+++ b/src/test/java/cn/gdeiassistant/mapper/MapperIntegrationTest.java
@@ -12,6 +12,9 @@ import cn.gdeiassistant.core.secret.mapper.SecretMapper;
 import cn.gdeiassistant.core.secret.pojo.entity.SecretContentEntity;
 import cn.gdeiassistant.core.topic.mapper.TopicMapper;
 import cn.gdeiassistant.core.topic.pojo.entity.TopicEntity;
+import cn.gdeiassistant.core.charge.mapper.ChargeOrderMapper;
+import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderEntity;
+import cn.gdeiassistant.core.charge.pojo.entity.ChargeOrderStatus;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -50,6 +53,9 @@ class MapperIntegrationTest {
             stmt.execute("INSERT INTO delivery_order (username,name,number,phone,price,company,address,state) VALUES ('testuser','张三','12345678901','13800138000',5.00,'顺丰','C栋',0)");
             stmt.execute("INSERT INTO secret_content (username,content,theme,type,timer,state) VALUES ('testuser','匿名内容',1,0,0,0)");
             stmt.execute("INSERT INTO topic (username,topic,content,count) VALUES ('testuser','校园话题','讨论内容',0)");
+            stmt.execute("INSERT INTO charge_order (order_id,username,amount,status,created_at,updated_at,check_count,version) VALUES ('synthetic-order-old','testuser',30,'PROCESSING','2026-04-28 10:00:00','2026-04-28 10:00:00',0,0)");
+            stmt.execute("INSERT INTO charge_order (order_id,username,amount,status,created_at,updated_at,check_count,version) VALUES ('synthetic-order-new','testuser',50,'PAYMENT_SESSION_CREATED','2026-04-28 11:00:00','2026-04-28 11:00:00',0,0)");
+            stmt.execute("INSERT INTO charge_order (order_id,username,amount,status,created_at,updated_at,check_count,version) VALUES ('synthetic-other-order','otheruser',20,'PAYMENT_SESSION_CREATED','2026-04-28 12:00:00','2026-04-28 12:00:00',0,0)");
             stmt.close();
             session.commit();
         }
@@ -150,6 +156,35 @@ class MapperIntegrationTest {
             assertNotNull(items);
             assertFalse(items.isEmpty());
             assertEquals("校园话题", items.get(0).getTopic());
+        }
+    }
+
+    @Test
+    void chargeOrderSelectByOwner() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            ChargeOrderMapper mapper = session.getMapper(ChargeOrderMapper.class);
+            ChargeOrderEntity order = mapper.findByOrderIdAndUsername("synthetic-order-new", "testuser");
+            ChargeOrderEntity otherUserOrder = mapper.findByOrderIdAndUsername("synthetic-order-new", "otheruser");
+
+            assertNotNull(order);
+            assertEquals("synthetic-order-new", order.getOrderId());
+            assertEquals("testuser", order.getUsername());
+            assertEquals(50, order.getAmount());
+            assertEquals(ChargeOrderStatus.PAYMENT_SESSION_CREATED.name(), order.getStatus());
+            assertNull(otherUserOrder);
+        }
+    }
+
+    @Test
+    void chargeOrderSelectRecentByStatus() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            ChargeOrderMapper mapper = session.getMapper(ChargeOrderMapper.class);
+            List<ChargeOrderEntity> items = mapper.findRecentByUsernameAndStatus("testuser",
+                    ChargeOrderStatus.PAYMENT_SESSION_CREATED.name(), 0, 10);
+
+            assertEquals(1, items.size());
+            assertEquals("synthetic-order-new", items.get(0).getOrderId());
+            assertEquals(ChargeOrderStatus.PAYMENT_SESSION_CREATED.name(), items.get(0).getStatus());
         }
     }
 }

--- a/src/test/resources/mybatis-test-config.xml
+++ b/src/test/resources/mybatis-test-config.xml
@@ -23,5 +23,6 @@
         <mapper class="cn.gdeiassistant.core.delivery.mapper.DeliveryMapper"/>
         <mapper class="cn.gdeiassistant.core.secret.mapper.SecretMapper"/>
         <mapper class="cn.gdeiassistant.core.topic.mapper.TopicMapper"/>
+        <mapper class="cn.gdeiassistant.core.charge.mapper.ChargeOrderMapper"/>
     </mappers>
 </configuration>

--- a/src/test/resources/schema-mappertest.sql
+++ b/src/test/resources/schema-mappertest.sql
@@ -128,3 +128,30 @@ CREATE TABLE IF NOT EXISTS topic_like (
   username VARCHAR(24) NOT NULL,
   create_time DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS charge_order (
+  order_id VARCHAR(36) PRIMARY KEY,
+  username VARCHAR(24) NOT NULL,
+  amount INT NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  idempotency_key_hash VARCHAR(64),
+  payload_fingerprint VARCHAR(64),
+  request_id VARCHAR(64),
+  device_id_hash VARCHAR(64),
+  external_order_no VARCHAR(128),
+  external_trade_no VARCHAR(128),
+  school_trade_no VARCHAR(128),
+  payment_url_hash VARCHAR(64),
+  error_code VARCHAR(64),
+  error_message_sanitized VARCHAR(255),
+  unknown_reason VARCHAR(255),
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  submitted_at DATETIME,
+  completed_at DATETIME,
+  last_checked_at DATETIME,
+  check_count INT DEFAULT 0 NOT NULL,
+  manual_review_at DATETIME,
+  manual_review_note VARCHAR(255),
+  version INT DEFAULT 0 NOT NULL
+);


### PR DESCRIPTION
Summary:
- Add authenticated APIs for users to query their own charge order details and recent charge orders.
- Return only safe order status fields and avoid exposing internal identifiers, hashes, payment URLs, cookies, or raw error details.
- Preserve the distinction between PAYMENT_SESSION_CREATED and final balance settlement.
- Add tests for ownership checks, safe response fields, and list filtering.
- Update internal compliance TODOs for remaining charge order follow-ups.

Validation:
- Backend compileJava: PASS (export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64; ./gradlew --no-daemon clean compileJava)
- Backend tests: PASS (export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64; ./gradlew --no-daemon test)
- git diff --check: PASS

Notes:
- This PR does not implement UNKNOWN reconciliation, manual review tools, or client order-status UI.
- This PR does not modify Android/iOS clients.
- This PR does not change policy dates, legal-subject information, or filing information.