### PR TITLE
[codex] Fix mock login smoke flow and improve Web readability

### DIFF
--- a/frontend/e2e/mock-smoke.spec.js
+++ b/frontend/e2e/mock-smoke.spec.js
@@ -21,9 +21,10 @@ test.beforeEach(async ({ page }) => {
 
 async function loginAsMockUser(page) {
   await page.goto('/login')
-  await expect(page.getByText('模拟数据模式')).toBeVisible()
-  await page.locator('input[type="text"]').fill(MOCK_USERNAME)
-  await page.locator('input[type="password"]').fill(MOCK_PASSWORD)
+  await expect(page.getByText('本地示例数据')).toBeVisible()
+  await expect(page.locator('input[type="text"]')).toHaveValue(MOCK_USERNAME)
+  await expect(page.locator('input[type="password"]')).toHaveValue(MOCK_PASSWORD)
+  await page.locator('input[type="checkbox"]').check()
   await page.getByRole('button', { name: '登录' }).click()
   await expect(page).toHaveURL(/\/home$/)
   await expect(page.getByText('校园服务')).toBeVisible()
@@ -56,6 +57,7 @@ test.describe('mock 模式 UI smoke', () => {
 
     await page.goto('/info')
 
+    await expect(page.getByText('校园新闻', { exact: true })).toBeVisible()
     await expect(page.getByText('查看学校公开发布的校园新闻')).toBeVisible()
     await expect(page.getByText('系统公告', { exact: true })).toBeVisible()
     await expect(page.getByText('互动消息', { exact: true })).toBeVisible()

--- a/frontend/src/layout/AppLayout.vue
+++ b/frontend/src/layout/AppLayout.vue
@@ -42,7 +42,7 @@ onUnmounted(() => {
         @open-command-palette="showCommandPalette = true"
       />
 
-      <main class="p-7 max-w-[1160px]">
+      <main class="p-7 w-full max-w-[1160px] mx-auto">
         <router-view />
       </main>
     </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -349,6 +349,8 @@
   },
   "info": {
     "news": "News",
+    "newsBadge": "Campus",
+    "newsEntryTitle": "Campus News",
     "newsDesc": "View publicly released campus news",
     "systemNotice": "System Notices",
     "noNotice": "No system notices",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -125,6 +125,8 @@
   },
   "info": {
     "news": "ニュース",
+    "newsBadge": "キャンパス",
+    "newsEntryTitle": "キャンパスニュース",
     "newsDesc": "学校が公開したキャンパスニュースを閲覧",
     "systemNotice": "システム通知",
     "noNotice": "システム通知はありません",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -125,6 +125,8 @@
   },
   "info": {
     "news": "뉴스",
+    "newsBadge": "캠퍼스",
+    "newsEntryTitle": "캠퍼스 뉴스",
     "newsDesc": "학교에서 공개한 캠퍼스 뉴스를 확인하세요",
     "systemNotice": "시스템 공지",
     "noNotice": "시스템 공지가 없습니다",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -349,6 +349,8 @@
   },
   "info": {
     "news": "新闻",
+    "newsBadge": "校园",
+    "newsEntryTitle": "校园新闻",
     "newsDesc": "查看学校公开发布的校园新闻",
     "systemNotice": "系统公告",
     "noNotice": "暂无系统公告",

--- a/frontend/src/locales/zh-HK.json
+++ b/frontend/src/locales/zh-HK.json
@@ -125,6 +125,8 @@
   },
   "info": {
     "news": "新聞",
+    "newsBadge": "校園",
+    "newsEntryTitle": "校園新聞",
     "newsDesc": "查看學校公開發佈的校園新聞",
     "systemNotice": "系統公告",
     "noNotice": "暫無系統公告",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -125,6 +125,8 @@
   },
   "info": {
     "news": "新聞",
+    "newsBadge": "校園",
+    "newsEntryTitle": "校園新聞",
     "newsDesc": "查看學校公開發布的校園新聞",
     "systemNotice": "系統公告",
     "noNotice": "暫無系統公告",

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -147,7 +147,7 @@ function iconColorStyle(id) {
     >
       <div class="bg-[var(--c-surface)] border border-[var(--c-border)] rounded-[14px] p-5">
         <h2 class="text-lg font-extrabold mb-1">{{ section.title }}</h2>
-        <p class="text-sm text-[var(--c-text-3)] mb-4">{{ section.description }}</p>
+        <p class="text-sm text-[var(--c-text-2)] mb-4">{{ section.description }}</p>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
           <button
             v-for="(item, index) in section.items"
@@ -167,7 +167,7 @@ function iconColorStyle(id) {
               />
             </div>
             <div class="text-sm font-bold text-[var(--c-text-1)]">{{ item.title }}</div>
-            <div class="text-[11px] text-[var(--c-text-3)] mt-0.5 line-clamp-2">{{ item.description }}</div>
+            <div class="text-[11px] text-[var(--c-text-2)] mt-0.5 line-clamp-2">{{ item.description }}</div>
           </button>
         </div>
       </div>

--- a/frontend/src/views/Info.vue
+++ b/frontend/src/views/Info.vue
@@ -14,11 +14,11 @@
           <div
             class="w-[42px] h-[42px] rounded-xl bg-[#e8f7ef] text-[var(--c-primary)] flex items-center justify-center text-[13px] font-bold shrink-0"
           >
-            {{ $t('info.news') }}
+            {{ $t('info.newsBadge') }}
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-[15px] font-semibold text-[var(--c-text-1)]">{{ $t('info.news') }}</div>
-            <div class="mt-1 text-[13px] text-[var(--c-text-3)]">{{ $t('info.newsDesc') }}</div>
+            <div class="text-[15px] font-semibold text-[var(--c-text-1)]">{{ $t('info.newsEntryTitle') }}</div>
+            <div class="mt-1 text-[13px] text-[var(--c-text-2)]">{{ $t('info.newsDesc') }}</div>
           </div>
           <div class="w-2 h-2 border-r border-t border-[#c8c8c8] rotate-45 shrink-0" />
         </button>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -16,12 +16,20 @@ const password = ref('')
 const mockMode = ref(isMockMode())
 const campusCredentialConsent = ref(false)
 
+function fillMockCredentials() {
+  username.value = MOCK_ACCOUNT_USERNAME
+  password.value = MOCK_ACCOUNT_PASSWORD
+}
+
+if (mockMode.value) {
+  fillMockCredentials()
+}
+
 function toggleMock() {
   toggleDataSourceMode()
   mockMode.value = isMockMode()
   if (mockMode.value) {
-    username.value = MOCK_ACCOUNT_USERNAME
-    password.value = MOCK_ACCOUNT_PASSWORD
+    fillMockCredentials()
   } else {
     username.value = ''
     password.value = ''


### PR DESCRIPTION
## Summary

- Fill mock username/password when mock mode is already enabled before the login page renders.
- Update Playwright mock smoke assertions to match the current UI copy and consent checkbox flow.
- Center the main desktop content container with `w-full mx-auto`.
- Increase home section/feature description text from `--c-text-3` to `--c-text-2` for better readability.
- Reduce repeated “News” hierarchy on the Info entry card with localized badge/title copy and improve its description contrast.

## Validation

- `npm ci`
- `npm run test:unit` — 26 files / 73 tests passed
- `npm run build`
- `npx playwright test --config=.codex-playwright.chrome.config.mjs mock-smoke.spec.js` — 4/4 passed with local Google Chrome
- `node` locale JSON parse — passed
- `npx playwright test --config=.codex-playwright.chrome.config.mjs` — 12/12 passed with local Google Chrome
- `./gradlew test --no-daemon --stacktrace` — backend tests passed
- `git diff --check`

Logs:

- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/web/test-unit-after-info-p1.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/web/build-after-info-p1.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/web/locales-json-parse-after-info-p1.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/web/e2e-mock-smoke-chrome.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/web/e2e-all-chrome-after-info-p1-rerun.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/main/backend-test.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/git-diff-check.log`

## Notes / Risks

- The local Node version is `v26.3.0`; `npm ci` warns the package expects Node `24.14.1`.
- `npm audit` reported 2 existing frontend vulnerabilities during install; this PR does not change dependencies.

## Codex review request

Please run/consider Codex review for UI/layout/architecture regressions before merge. This PR was prepared from the multi-repo UI architecture review and is intentionally limited to low-risk scope.
