### PR TITLE
[codex] Polish campus dark mode and policy tables

### DIFF
--- a/frontend/e2e/mock-smoke.spec.js
+++ b/frontend/e2e/mock-smoke.spec.js
@@ -27,14 +27,14 @@ async function loginAsMockUser(page) {
   await page.locator('input[type="checkbox"]').check()
   await page.getByRole('button', { name: '登录' }).click()
   await expect(page).toHaveURL(/\/home$/)
-  await expect(page.getByText('校园服务')).toBeVisible()
+  await expect(page.getByRole('heading', { name: '校园服务' })).toBeVisible()
 }
 
 test.describe('mock 模式 UI smoke', () => {
   test('mock 登录后可以进入首页并看到主入口', async ({ page }) => {
     await loginAsMockUser(page)
 
-    await expect(page.getByText('校园生活')).toBeVisible()
+    await expect(page.getByRole('heading', { name: '校园生活' })).toBeVisible()
     await expect(page.getByRole('button', { name: '成绩查询' })).toBeVisible()
     await expect(page.getByRole('button', { name: '二手交易' })).toBeVisible()
   })

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -732,15 +732,30 @@ function todayItemStyle(item) {
 [data-theme="dark"] .today-panel,
 [data-theme="dark"] .feature-section,
 [data-theme="dark"] .home-empty {
-  border-color: rgba(45, 58, 73, 0.86);
+  border-color: rgba(58, 74, 92, 0.9);
+  box-shadow: 0 22px 58px rgba(0, 0, 0, 0.32);
+}
+
+[data-theme="dark"] .home-hero-card {
+  background-color: rgba(14, 22, 32, 0.92);
+  background-image: url('/img/landing/campus-hero.jpg');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+[data-theme="dark"] .today-panel,
+[data-theme="dark"] .feature-section,
+[data-theme="dark"] .home-empty {
   background: rgba(20, 27, 37, 0.78);
-  box-shadow: 0 20px 46px rgba(0, 0, 0, 0.28);
 }
 
 [data-theme="dark"] .home-hero-card__shade {
   background:
-    linear-gradient(90deg, rgba(10, 15, 22, 0.9) 0%, rgba(10, 15, 22, 0.62) 36%, rgba(10, 15, 22, 0.16) 74%),
-    linear-gradient(180deg, rgba(10, 15, 22, 0.02), rgba(15, 23, 42, 0.46));
+    linear-gradient(90deg, rgba(6, 11, 18, 0.92) 0%, rgba(8, 14, 22, 0.78) 34%, rgba(8, 14, 22, 0.34) 64%, rgba(8, 14, 22, 0.12) 100%),
+    linear-gradient(180deg, rgba(12, 19, 28, 0.08), rgba(12, 19, 28, 0.52)),
+    radial-gradient(circle at 78% 22%, rgba(83, 187, 255, 0.16), transparent 38%),
+    radial-gradient(circle at 25% 88%, rgba(16, 185, 129, 0.14), transparent 34%);
 }
 
 [data-theme="dark"] .home-hero-card h1 {
@@ -758,8 +773,23 @@ function todayItemStyle(item) {
   background: rgba(24, 32, 43, 0.76);
 }
 
-[data-theme="dark"] .feature-section--service,
+[data-theme="dark"] .home-hero-card__secondary {
+  border-color: rgba(93, 230, 184, 0.38);
+  background: rgba(8, 24, 27, 0.72);
+  color: #72e6bb;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .feature-section--service {
+  background:
+    linear-gradient(135deg, rgba(20, 27, 37, 0.86), rgba(13, 22, 30, 0.82)),
+    radial-gradient(circle at 100% 0, rgba(45, 212, 191, 0.13), transparent 36%);
+}
+
 [data-theme="dark"] .feature-section--life {
-  background: rgba(20, 27, 37, 0.78);
+  background:
+    linear-gradient(135deg, rgba(20, 27, 37, 0.86), rgba(18, 20, 31, 0.82)),
+    radial-gradient(circle at 0 0, rgba(245, 158, 11, 0.1), transparent 30%),
+    radial-gradient(circle at 100% 100%, rgba(139, 92, 246, 0.12), transparent 36%);
 }
 </style>

--- a/frontend/src/views/about/PrivacyPolicy.vue
+++ b/frontend/src/views/about/PrivacyPolicy.vue
@@ -242,54 +242,58 @@ const retentionRows = [
 
           <h3>第三条 敏感个人信息处理说明</h3>
           <p><strong>3.1</strong> 平台处理的部分信息可能属于敏感个人信息或具有较高隐私风险。我们会结合功能必要性、风险等级、处理场景和法律要求采取更严格的控制措施。</p>
-          <table>
-            <thead>
-              <tr>
-                <th>信息类型</th>
-                <th>使用场景</th>
-                <th>是否可能属于敏感个人信息</th>
-                <th>必要性</th>
-                <th>用户可否拒绝或删除</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="row in sensitiveInfoRows" :key="row.type">
-                <td>{{ row.type }}</td>
-                <td>{{ row.scenario }}</td>
-                <td>{{ row.sensitive }}</td>
-                <td>{{ row.necessity }}</td>
-                <td>{{ row.control }}</td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="policy-table-scroll">
+            <table>
+              <thead>
+                <tr>
+                  <th>信息类型</th>
+                  <th>使用场景</th>
+                  <th>是否可能属于敏感个人信息</th>
+                  <th>必要性</th>
+                  <th>用户可否拒绝或删除</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in sensitiveInfoRows" :key="row.type">
+                  <td>{{ row.type }}</td>
+                  <td>{{ row.scenario }}</td>
+                  <td>{{ row.sensitive }}</td>
+                  <td>{{ row.necessity }}</td>
+                  <td>{{ row.control }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
           <h3>第四条 第三方服务清单</h3>
           <p><strong>4.1</strong> 为实现校园认证、消息发送、图片上传、验证码识别、服务部署、安全审计和故障排查，平台可能根据实际部署选择第三方服务。是否启用、启用哪些服务以及是否发生跨境或境外处理，通常取决于实际部署、服务商区域和配置。</p>
           <p><strong>4.2</strong> 详细清单可进一步参阅 <a href="/policy/third-party-services">《第三方服务清单》</a>。</p>
-          <table>
-            <thead>
-              <tr>
-                <th>服务类型</th>
-                <th>可能服务商</th>
-                <th>使用目的</th>
-                <th>涉及信息</th>
-                <th>是否可关闭</th>
-                <th>是否可能跨境或境外处理</th>
-                <th>备注</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="row in thirdPartyRows" :key="row.type">
-                <td>{{ row.type }}</td>
-                <td>{{ row.providers }}</td>
-                <td>{{ row.purpose }}</td>
-                <td>{{ row.data }}</td>
-                <td>{{ row.disable }}</td>
-                <td>{{ row.crossBorder }}</td>
-                <td>{{ row.note }}</td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="policy-table-scroll policy-table-scroll--wide">
+            <table>
+              <thead>
+                <tr>
+                  <th>服务类型</th>
+                  <th>可能服务商</th>
+                  <th>使用目的</th>
+                  <th>涉及信息</th>
+                  <th>是否可关闭</th>
+                  <th>是否可能跨境或境外处理</th>
+                  <th>备注</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in thirdPartyRows" :key="row.type">
+                  <td>{{ row.type }}</td>
+                  <td>{{ row.providers }}</td>
+                  <td>{{ row.purpose }}</td>
+                  <td>{{ row.data }}</td>
+                  <td>{{ row.disable }}</td>
+                  <td>{{ row.crossBorder }}</td>
+                  <td>{{ row.note }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
           <h3>第五条 个人信息共享、委托处理与公开展示</h3>
           <p><strong>5.1</strong> 我们不会出售您的个人信息。</p>
@@ -299,24 +303,26 @@ const retentionRows = [
 
           <h3>第六条 个人信息保存期限</h3>
           <p><strong>6.1</strong> 我们仅在实现处理目的所必需的最短期限内保存个人信息。超过保存期限后，我们会根据适用法律和实际情况进行删除、匿名化、去标识化、限制处理或归档脱敏。</p>
-          <table>
-            <thead>
-              <tr>
-                <th>信息类型</th>
-                <th>保存期限</th>
-                <th>删除或匿名化方式</th>
-                <th>例外情况</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="row in retentionRows" :key="row.type">
-                <td>{{ row.type }}</td>
-                <td>{{ row.duration }}</td>
-                <td>{{ row.deletion }}</td>
-                <td>{{ row.exception }}</td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="policy-table-scroll">
+            <table>
+              <thead>
+                <tr>
+                  <th>信息类型</th>
+                  <th>保存期限</th>
+                  <th>删除或匿名化方式</th>
+                  <th>例外情况</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in retentionRows" :key="row.type">
+                  <td>{{ row.type }}</td>
+                  <td>{{ row.duration }}</td>
+                  <td>{{ row.deletion }}</td>
+                  <td>{{ row.exception }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
           <h3>第七条 您的权利与操作路径</h3>
           <p><strong>7.1</strong> 在符合法律法规规定的前提下，您可以申请查询、更正、补充、删除个人信息，关闭快速认证或申请删除校园凭证，撤回部分授权，注销账号，删除发布内容，申请导出个人信息，以及投诉举报或联系平台处理隐私问题。</p>
@@ -348,3 +354,21 @@ const retentionRows = [
     </div>
   </div>
 </template>
+
+<style scoped>
+.policy-table-scroll {
+  max-width: 100%;
+  margin-bottom: 1rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.policy-table-scroll table {
+  min-width: 680px;
+  margin-bottom: 0;
+}
+
+.policy-table-scroll--wide table {
+  min-width: 760px;
+}
+</style>

--- a/frontend/src/views/about/ThirdPartyServices.vue
+++ b/frontend/src/views/about/ThirdPartyServices.vue
@@ -97,32 +97,52 @@ const rows = [
             <p class="!mb-0"><strong>配套阅读：</strong>涉及个人信息处理时，请与 <a href="/policy/privacy">《隐私政策》</a> 一并阅读；涉及安全配置要求时，请同时参阅 <a href="/about/security">《安全说明》</a>。</p>
           </div>
 
-          <table>
-            <thead>
-              <tr>
-                <th>服务类型</th>
-                <th>可能服务商</th>
-                <th>使用目的</th>
-                <th>涉及信息</th>
-                <th>是否可关闭</th>
-                <th>是否可能跨境或境外处理</th>
-                <th>备注</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="row in rows" :key="row.type">
-                <td>{{ row.type }}</td>
-                <td>{{ row.providers }}</td>
-                <td>{{ row.purpose }}</td>
-                <td>{{ row.data }}</td>
-                <td>{{ row.disable }}</td>
-                <td>{{ row.crossBorder }}</td>
-                <td>{{ row.note }}</td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="policy-table-scroll policy-table-scroll--wide">
+            <table>
+              <thead>
+                <tr>
+                  <th>服务类型</th>
+                  <th>可能服务商</th>
+                  <th>使用目的</th>
+                  <th>涉及信息</th>
+                  <th>是否可关闭</th>
+                  <th>是否可能跨境或境外处理</th>
+                  <th>备注</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in rows" :key="row.type">
+                  <td>{{ row.type }}</td>
+                  <td>{{ row.providers }}</td>
+                  <td>{{ row.purpose }}</td>
+                  <td>{{ row.data }}</td>
+                  <td>{{ row.disable }}</td>
+                  <td>{{ row.crossBorder }}</td>
+                  <td>{{ row.note }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.policy-table-scroll {
+  max-width: 100%;
+  margin-bottom: 1rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.policy-table-scroll table {
+  min-width: 680px;
+  margin-bottom: 0;
+}
+
+.policy-table-scroll--wide table {
+  min-width: 760px;
+}
+</style>


### PR DESCRIPTION
## Summary
- Restore the campus hero image in dark mode by preventing the dark theme background shorthand from dropping the hero `background-image`.
- Improve dark-mode home surfaces and secondary CTA contrast for a more consistent campus-life visual style.
- Make privacy and third-party service policy tables horizontally scrollable on mobile to avoid page-level overflow.
- Tighten mock smoke E2E selectors to target section headings instead of ambiguous substring text.

## Validation
- `git diff --check`
- `npm run build`
- `npm run test:unit`
- `npx playwright test --config /Users/lisiyi/Documents/Codex/2026-06-21-build-web-apps-gdeiassistant-vue-html/artifacts/global-design-review/e2e-local-chrome.config.mjs`
- Playwright route audit: 90 routes × desktop/mobile × light/dark = 360 checks, 0 blocking issues after fixes.

## Notes
- The repository's default `npm run test:e2e` still expects a Playwright-managed Chromium binary in the local cache. On this machine that binary is missing, so browser validation was run with the installed local Chrome through a temporary external config instead.
