### PR TITLE
[codex] Update Tencent Cloud SMS SDK compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk18on:1.84'
     implementation 'com.alipay.sdk:alipay-sdk-java:3.6.0.ALL'
     implementation 'com.aliyun:aliyun-java-sdk-core:4.7.8'
-    implementation 'com.tencentcloudapi:tencentcloud-sdk-java:3.1.628'
+    implementation 'com.tencentcloudapi:tencentcloud-sdk-java:4.0.11'
     implementation 'com.qcloud:cos_api:5.6.269'
     implementation 'com.google.appengine:appengine-api-1.0-sdk:5.0.4'
     implementation 'com.google.cloud:google-cloud-logging-logback:0.142.0-alpha'

--- a/src/main/java/cn/gdeiassistant/core/capability/impl/MultiProviderSmsVerificationSender.java
+++ b/src/main/java/cn/gdeiassistant/core/capability/impl/MultiProviderSmsVerificationSender.java
@@ -9,10 +9,10 @@ import com.tencentcloudapi.common.Credential;
 import com.tencentcloudapi.common.exception.TencentCloudSDKException;
 import com.tencentcloudapi.common.profile.ClientProfile;
 import com.tencentcloudapi.common.profile.HttpProfile;
-import com.tencentcloudapi.sms.v20210111.SmsClient;
-import com.tencentcloudapi.sms.v20210111.models.SendSmsRequest;
-import com.tencentcloudapi.sms.v20210111.models.SendSmsResponse;
-import com.tencentcloudapi.sms.v20210111.models.SendStatus;
+import com.tencentcloudapi.sms.v20190711.SmsClient;
+import com.tencentcloudapi.sms.v20190711.models.SendSmsRequest;
+import com.tencentcloudapi.sms.v20190711.models.SendSmsResponse;
+import com.tencentcloudapi.sms.v20190711.models.SendStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -205,9 +205,9 @@ public class MultiProviderSmsVerificationSender implements SmsVerificationSender
             SmsClient client = new SmsClient(cred, tencentRegion, clientProfile);
 
             SendSmsRequest req = new SendSmsRequest();
-            req.setSmsSdkAppId(tencentAppId);
-            req.setSignName(tencentSignName);
-            req.setTemplateId(templateId);
+            req.setSmsSdkAppid(tencentAppId);
+            req.setSign(tencentSignName);
+            req.setTemplateID(templateId);
             req.setPhoneNumberSet(new String[]{phoneE164});
             req.setTemplateParamSet(new String[]{String.valueOf(code)});
 


### PR DESCRIPTION
## Summary
- upgrade Tencent Cloud Java SDK to 4.0.11
- switch the SMS client import to the SDK v4 bundled `sms.v20190711` API
- map SMS request setters to the v20190711 model names

## Why
Dependabot's SDK v4 PR failed because `sms.v20210111` is no longer packaged in `tencentcloud-sdk-java:4.0.11`. The bundled SMS API version exposes equivalent fields under `sms.v20190711` with older setter names.

## Validation
- `./gradlew test --no-daemon`
- `./gradlew classes -x test --no-daemon`
