### PR TITLE
docs: P2 audit remediation — Docker, OpenAPI, production security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ worktrees/
 docs/**
 !docs/compliance-todo.md
 !docs/environment-matrix.md
+!docs/openapi.yaml
 
 # ==================================
 # Spring Boot & Java

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -14,8 +14,8 @@ WORKDIR /app
 RUN addgroup -g 1000 appgroup && \
     adduser -u 1000 -G appgroup -s /bin/sh -D appuser
 
-# 从 builder 阶段拷贝打好的 Spring Boot 3 jar 包
-# 注意：SpringBoot3 默认生成的通常在 build/libs/ 目录下
+# 从 builder 阶段拷贝打好的 Spring Boot 4 jar 包
+# 注意：Spring Boot 4 默认生成的通常在 build/libs/ 目录下
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 # 赋予权限并切换到非 root 用户

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ GdeiAssistant/                 # 仓库根目录
 
 ---
 
+## Docker 一键启动
+
+无需单独安装 Tomcat 或手动部署 WAR 包。Spring Boot 4 内嵌 Web 容器，Docker Compose 会一并启动后端、前端与数据库依赖。
+
+```bash
+cp .env.template .env
+# 编辑 .env，至少填写 DB_PASSWORD 与 JWT_SECRET（见模板注释）
+docker compose up -d
+```
+
+启动后：
+
+- 后端 API：`http://localhost:8080/api`
+- 前端：`http://localhost:5173`（由 compose 中的前端服务提供）
+
+查看日志：`docker compose logs -f backend`。停止：`docker compose down`。
+
+---
+
 ## 快速入门
 
 **1. 环境**  
@@ -60,13 +79,15 @@ cp .env.template .env
 >
 > 当前 MySQL 仍默认使用三套 schema：`DB_NAME`、`DB_NAME_LOG`、`DB_NAME_DATA`。
 
-> **生产环境必填变量：**
+> **生产 / 预发环境必填变量（缺一不可，否则 fail-fast 拒绝启动）：**
+> - `DB_PASSWORD` — 数据库密码
 > - `JWT_SECRET` — JWT 签名密钥（至少 32 位随机串）
 > - `CRON_SECRET` — 定时任务触发密钥（任意随机串）
-> - `ENCRYPT_ENABLE=true` — 启用敏感字段加密
+> - `ENCRYPT_ENABLE=true` — **必须**启用敏感字段加密（校园凭证等）
 > - `ENCRYPT_PRIVATE_KEY` — AES 加密密钥
+> - `REDIS_SSL_ENABLED=true` — 连接外部 Redis 时启用 TLS
 >
-> 缺少以上变量时，生产环境会拒绝启动。
+> **密钥轮换：** 定期轮换 `JWT_SECRET`、`CRON_SECRET`、`ENCRYPT_PRIVATE_KEY`；轮换前请评估已签发 Token 与已加密数据的兼容策略。详见 `docs/environment-matrix.md`。
 
 **3. 运行**
 
@@ -90,6 +111,8 @@ npm run dev
 > 如果你要在本机临时直连演示环境，请不要改仓库根目录 `.env` 的默认语义；更稳妥的做法是单独导出一次环境变量，或在 IDE / 部署平台里覆盖 `SPRING_PROFILES_ACTIVE`、数据库连接串和 `CORS_ALLOWED_ORIGIN_PATTERNS`。
 
 更完整的环境矩阵见：`docs/environment-matrix.md`。
+
+多端 API 契约（OpenAPI 骨架，作为 Android / iOS / 小程序与后端的统一参考）：[`docs/openapi.yaml`](docs/openapi.yaml)。
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,14 @@
 - 是否公开修复细节、何时发布补丁、是否回溯旧版本，由维护者结合风险和维护成本判断。
 - 本项目当前不承诺奖金、赏金计划或固定 SLA。
 
+## 开发环境默认加密关闭的风险
+
+本地 `development` profile 默认 `ENCRYPT_ENABLE=false`，便于快速联调，但会带来以下风险：
+
+- 校园凭证等敏感字段以明文或弱保护形式落库，**不得**将此类配置用于 staging / production 或任何可公网访问的实例。
+- 若开发机 `.env` 含真实凭据，请勿提交到 Git、勿共享截图、勿在不可信网络暴露 `8080` 端口。
+- 演示 / 生产部署前务必确认 `ENCRYPT_ENABLE=true` 且已配置 `ENCRYPT_PRIVATE_KEY`；详见 `docs/environment-matrix.md`。
+
 ## 敏感信息处理
 
 请不要在公开 Issue、PR、评论或讨论中粘贴以下内容：

--- a/docs/environment-matrix.md
+++ b/docs/environment-matrix.md
@@ -20,13 +20,24 @@ GdeiAssistant 统一使用以下三套环境语义：
 
 ## Security expectations
 
-- `development` 默认允许 `ENCRYPT_ENABLE=false`
-- `staging` / `production` 必须显式提供：
+- `development` 默认允许 `ENCRYPT_ENABLE=false`（仅限本机联调；见 [SECURITY.md](../SECURITY.md) 风险说明）
+- `staging` / `production` **必须**显式提供并启用：
   - `DB_PASSWORD`
   - `JWT_SECRET`
   - `CRON_SECRET`
-  - `ENCRYPT_ENABLE=true`
+  - `ENCRYPT_ENABLE=true` — 校园凭证等敏感字段加密，**禁止**在生产关闭
   - `ENCRYPT_PRIVATE_KEY`
+  - `REDIS_SSL_ENABLED=true` — 使用托管 Redis（Azure Cache、云厂商 Redis 等）时启用 TLS
+
+### 密钥轮换建议
+
+| 密钥 | 建议周期 | 说明 |
+| --- | --- | --- |
+| `JWT_SECRET` | 90–180 天 | 轮换后旧 Token 失效，需客户端重新登录 |
+| `CRON_SECRET` | 90–180 天 | 更新定时任务触发端配置 |
+| `ENCRYPT_PRIVATE_KEY` | 按合规要求 | 需规划密文重加密或双密钥过渡期；勿在未备份的情况下直接替换 |
+
+轮换操作应在维护窗口进行，并先在 `staging` 验证 fail-fast 与加密读写正常。
 
 ## Notes
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,173 @@
+openapi: 3.1.0
+info:
+  title: GdeiAssistant API
+  description: |
+    多端（Web / Android / iOS / 微信小程序）共享的后端 REST 契约骨架。
+    本文件为**真相源（source of truth）**的初版索引；请求/响应 schema 将随实现迭代补充。
+    鉴权：除 `/api/auth/*` 等白名单外，需在 Header 携带 `Authorization: Bearer <JWT>`。
+  version: 2.0.0
+  contact:
+    name: GdeiAssistant
+    url: https://github.com/GdeiAssistant/GdeiAssistant
+
+servers:
+  - url: http://localhost:8080
+    description: development
+  - url: https://gdeiassistant.azurewebsites.net
+    description: staging
+  - url: https://gdeiassistant.cn
+    description: production
+
+tags:
+  - name: auth
+    description: 登录、登出、Token 校验
+  - name: campus-credential
+    description: 校园凭证授权、撤回与快速认证
+  - name: profile
+    description: 用户资料与头像
+  - name: academic
+    description: 教务查询（成绩、课表、四六级等）
+  - name: campus-service
+    description: 校园服务（校园卡、图书馆、教室等）
+  - name: community
+    description: 社区功能（树洞、二手、快递等）
+  - name: information
+    description: 资讯与消息
+
+paths:
+  /api/auth/login:
+    post:
+      tags: [auth]
+      summary: 用户登录
+      security: []
+  /api/auth/logout:
+    post:
+      tags: [auth]
+      summary: 用户登出
+  /api/auth/validate:
+    get:
+      tags: [auth]
+      summary: 校验当前 Token
+
+  /api/campus-credential/status:
+    get:
+      tags: [campus-credential]
+      summary: 查询校园凭证绑定与授权状态
+  /api/campus-credential/consent:
+    post:
+      tags: [campus-credential]
+      summary: 记录用户授权同意
+  /api/campus-credential/revoke:
+    post:
+      tags: [campus-credential]
+      summary: 撤回授权
+  /api/campus-credential:
+    delete:
+      tags: [campus-credential]
+      summary: 删除已保存的校园凭证
+  /api/campus-credential/quick-auth:
+    post:
+      tags: [campus-credential]
+      summary: 更新快速认证开关
+
+  /api/user/profile:
+    get:
+      tags: [profile]
+      summary: 获取当前用户资料
+  /api/profile/avatar:
+    get:
+      tags: [profile]
+      summary: 获取头像
+    post:
+      tags: [profile]
+      summary: 上传头像
+    delete:
+      tags: [profile]
+      summary: 删除头像
+
+  /api/grade:
+    get:
+      tags: [academic]
+      summary: 查询成绩
+  /api/schedule:
+    get:
+      tags: [academic]
+      summary: 查询课表
+  /api/cet/query:
+    get:
+      tags: [academic]
+      summary: 四六级成绩查询
+  /api/graduate-exam/query:
+    post:
+      tags: [academic]
+      summary: 考研成绩查询
+
+  /api/card/info:
+    get:
+      tags: [campus-service]
+      summary: 校园卡信息
+  /api/card/query:
+    post:
+      tags: [campus-service]
+      summary: 校园卡交易查询
+  /api/card/charge:
+    post:
+      tags: [campus-service]
+      summary: 校园卡充值
+  /api/library/search:
+    get:
+      tags: [campus-service]
+      summary: 图书馆检索
+  /api/spare/query:
+    post:
+      tags: [campus-service]
+      summary: 空教室查询
+
+  /api/secret/info/start/{start}/size/{size}:
+    get:
+      tags: [community]
+      summary: 树洞列表（分页）
+  /api/secret/info:
+    post:
+      tags: [community]
+      summary: 发布树洞
+  /api/ershou/item/start/{start}:
+    get:
+      tags: [community]
+      summary: 二手商品列表
+  /api/express/start/{start}/size/{size}:
+    get:
+      tags: [community]
+      summary: 全民快递列表
+  /api/lostandfound/lostitem/start/{start}:
+    get:
+      tags: [community]
+      summary: 失物招领列表
+
+  /api/information/overview:
+    get:
+      tags: [information]
+      summary: 资讯概览
+  /api/information/news/type/{type}/start/{start}/size/{size}:
+    get:
+      tags: [information]
+      summary: 新闻列表
+  /api/information/message/unread:
+    get:
+      tags: [information]
+      summary: 未读消息数
+
+  /api/module/state:
+    get:
+      tags: [campus-service]
+      summary: 功能模块开关状态
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+security:
+  - bearerAuth: []


### PR DESCRIPTION
## Summary
- README: Docker 一键启动章节（无需 Tomcat）、生产加密/TLS/密钥轮换强调、OpenAPI 链接
- 新增 `docs/openapi.yaml` 作为多端 API 契约骨架
- `docs/environment-matrix.md` 补充 Redis TLS 与密钥轮换表
- `SECURITY.md` 说明 dev 默认 `ENCRYPT_ENABLE=false` 风险
- `Dockerfile.backend` 注释修正为 Spring Boot 4

## Test plan
- [x] 文档审阅，无代码逻辑变更

Made with [Cursor](https://cursor.com)