### PR TITLE
fix: harden encrypted fields and session validation

### DIFF
--- a/src/main/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtils.java
@@ -7,10 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import java.io.ByteArrayOutputStream;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;

--- a/src/main/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtils.java
@@ -7,19 +7,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Base64;
 
 @Component
 public class StringEncryptUtils {
+
+    private static final String FORMAT_VERSION = "v1:";
+    private static final int IV_LENGTH_BYTES = 12;
+    private static final int TAG_LENGTH_BITS = 128;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private static EncryptConfig encryptConfig;
 
@@ -33,29 +38,23 @@ public class StringEncryptUtils {
      *
      * @param data
      * @return
-     * @throws NoSuchAlgorithmException
+     * @throws GeneralSecurityException when encryption cannot be completed
      */
-    public static String encryptString(String data) throws NoSuchAlgorithmException
-            , NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException
-            , InvalidKeyException {
-        if (StringEncryptUtils.encryptConfig != null) {
-            switch (StringEncryptUtils.encryptConfig.getClass().getSimpleName()) {
-                case "AESEncryptConfig":
-                    //使用AES对称加密算法加密
-                    SecureRandom secureRandom = SecureRandom.getInstanceStrong();
-                    secureRandom.setSeed(((AESEncryptConfig) StringEncryptUtils.encryptConfig)
-                            .getPrivateKey().getBytes(StandardCharsets.UTF_8));
-                    byte[] randomBytes = ((AESEncryptConfig) StringEncryptUtils.encryptConfig)
-                            .getPrivateKey().getBytes(StandardCharsets.UTF_8).clone();
-                    secureRandom.nextBytes(randomBytes);
-                    SecretKeySpec key = new SecretKeySpec(randomBytes, "AES");
-                    Cipher cipher = Cipher.getInstance("AES");
-                    cipher.init(Cipher.ENCRYPT_MODE, key);
-                    return Base64.getUrlEncoder().encodeToString(cipher.doFinal(data.getBytes(StandardCharsets.UTF_8)));
-            }
+    public static String encryptString(String data) throws GeneralSecurityException {
+        if (!(StringEncryptUtils.encryptConfig instanceof AESEncryptConfig aesConfig)) {
+            return data;
         }
-        //没有匹配的加密类型，返回原文
-        return data;
+
+        byte[] iv = new byte[IV_LENGTH_BYTES];
+        SECURE_RANDOM.nextBytes(iv);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, keyFor(aesConfig), new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+        cipher.updateAAD(FORMAT_VERSION.getBytes(StandardCharsets.US_ASCII));
+        byte[] ciphertext = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        byte[] payload = new byte[iv.length + ciphertext.length];
+        System.arraycopy(iv, 0, payload, 0, iv.length);
+        System.arraycopy(ciphertext, 0, payload, iv.length, ciphertext.length);
+        return FORMAT_VERSION + Base64.getUrlEncoder().withoutPadding().encodeToString(payload);
 
     }
 
@@ -64,29 +63,42 @@ public class StringEncryptUtils {
      *
      * @param data
      * @return
-     * @throws NoSuchAlgorithmException
+     * @throws GeneralSecurityException when decryption cannot be completed
      */
-    public static String decryptString(String data) throws NoSuchAlgorithmException
-            , NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException
-            , InvalidKeyException {
-        if (StringEncryptUtils.encryptConfig != null) {
-            switch (StringEncryptUtils.encryptConfig.getClass().getSimpleName()) {
-                case "AESEncryptConfig":
-                    //使用AES对称加密算法解密
-                    SecureRandom secureRandom = SecureRandom.getInstanceStrong();
-                    secureRandom.setSeed(((AESEncryptConfig) StringEncryptUtils.encryptConfig)
-                            .getPrivateKey().getBytes(StandardCharsets.UTF_8));
-                    byte[] randomBytes = ((AESEncryptConfig) StringEncryptUtils.encryptConfig)
-                            .getPrivateKey().getBytes(StandardCharsets.UTF_8).clone();
-                    secureRandom.nextBytes(randomBytes);
-                    SecretKeySpec key = new SecretKeySpec(randomBytes, "AES");
-                    Cipher cipher = Cipher.getInstance("AES");
-                    cipher.init(Cipher.DECRYPT_MODE, key);
-                    return new String(cipher.doFinal(Base64.getUrlDecoder().decode(data)), StandardCharsets.UTF_8);
-            }
+    public static String decryptString(String data) throws GeneralSecurityException {
+        if (!(StringEncryptUtils.encryptConfig instanceof AESEncryptConfig aesConfig)) {
+            return data;
         }
-        //没有匹配的加密类型，返回原文
-        return data;
+
+        if (data == null || !data.startsWith(FORMAT_VERSION)) {
+            throw new GeneralSecurityException("Unsupported encrypted value format");
+        }
+        final byte[] payload;
+        try {
+            payload = Base64.getUrlDecoder().decode(data.substring(FORMAT_VERSION.length()));
+        } catch (IllegalArgumentException e) {
+            throw new GeneralSecurityException("Invalid encrypted value", e);
+        }
+        if (payload.length < IV_LENGTH_BYTES + TAG_LENGTH_BITS / 8) {
+            throw new GeneralSecurityException("Invalid encrypted value length");
+        }
+
+        byte[] iv = Arrays.copyOfRange(payload, 0, IV_LENGTH_BYTES);
+        byte[] ciphertext = Arrays.copyOfRange(payload, IV_LENGTH_BYTES, payload.length);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.DECRYPT_MODE, keyFor(aesConfig), new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+        cipher.updateAAD(FORMAT_VERSION.getBytes(StandardCharsets.US_ASCII));
+        return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+    }
+
+    private static SecretKeySpec keyFor(AESEncryptConfig aesConfig) throws NoSuchAlgorithmException {
+        String privateKey = aesConfig.getPrivateKey();
+        if (privateKey == null || privateKey.isBlank()) {
+            throw new IllegalStateException("Encryption private key is not configured");
+        }
+        byte[] keyBytes = MessageDigest.getInstance("SHA-256")
+                .digest(privateKey.getBytes(StandardCharsets.UTF_8));
+        return new SecretKeySpec(keyBytes, "AES");
     }
 
     /**

--- a/src/main/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtils.java
+++ b/src/main/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtils.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayOutputStream;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -51,10 +52,10 @@ public class StringEncryptUtils {
         cipher.init(Cipher.ENCRYPT_MODE, keyFor(aesConfig), new GCMParameterSpec(TAG_LENGTH_BITS, iv));
         cipher.updateAAD(FORMAT_VERSION.getBytes(StandardCharsets.US_ASCII));
         byte[] ciphertext = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
-        byte[] payload = new byte[iv.length + ciphertext.length];
-        System.arraycopy(iv, 0, payload, 0, iv.length);
-        System.arraycopy(ciphertext, 0, payload, iv.length, ciphertext.length);
-        return FORMAT_VERSION + Base64.getUrlEncoder().withoutPadding().encodeToString(payload);
+        ByteArrayOutputStream payload = new ByteArrayOutputStream();
+        payload.writeBytes(iv);
+        payload.writeBytes(ciphertext);
+        return FORMAT_VERSION + Base64.getUrlEncoder().withoutPadding().encodeToString(payload.toByteArray());
 
     }
 

--- a/src/main/java/cn/gdeiassistant/common/typehandler/MybatisEncryptionTypeHandler.java
+++ b/src/main/java/cn/gdeiassistant/common/typehandler/MybatisEncryptionTypeHandler.java
@@ -5,8 +5,6 @@ import cn.gdeiassistant.common.tools.Utils.StringEncryptUtils;
 import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.MappedTypes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
@@ -16,14 +14,12 @@ import java.sql.SQLException;
 @MappedTypes(DataEncryption.class)
 public class MybatisEncryptionTypeHandler extends BaseTypeHandler<String> {
 
-    private static final Logger logger = LoggerFactory.getLogger(MybatisEncryptionTypeHandler.class);
-
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType) throws SQLException {
         try {
             ps.setString(i, StringEncryptUtils.encryptString(parameter));
         } catch (Exception e) {
-            logger.error("MyBatis 加密字段写入失败", e);
+            throw new SQLException("MyBatis encrypted field write failed", e);
         }
     }
 
@@ -33,9 +29,8 @@ public class MybatisEncryptionTypeHandler extends BaseTypeHandler<String> {
         try {
             return r == null ? null : StringEncryptUtils.decryptString(r);
         } catch (Exception e) {
-            logger.error("MyBatis 解密字段失败，columnName={}", columnName, e);
+            throw new SQLException("MyBatis encrypted field read failed", e);
         }
-        return null;
     }
 
     @Override
@@ -44,9 +39,8 @@ public class MybatisEncryptionTypeHandler extends BaseTypeHandler<String> {
         try {
             return r == null ? null : StringEncryptUtils.decryptString(r);
         } catch (Exception e) {
-            logger.error("MyBatis 解密字段失败，columnIndex={}", columnIndex, e);
+            throw new SQLException("MyBatis encrypted field read failed", e);
         }
-        return null;
     }
 
     @Override
@@ -55,8 +49,7 @@ public class MybatisEncryptionTypeHandler extends BaseTypeHandler<String> {
         try {
             return r == null ? null : StringEncryptUtils.decryptString(r);
         } catch (Exception e) {
-            logger.error("MyBatis 解密 CallableStatement 字段失败，columnIndex={}", columnIndex, e);
+            throw new SQLException("MyBatis encrypted field read failed", e);
         }
-        return null;
     }
 }

--- a/src/main/java/cn/gdeiassistant/core/authentication/service/AuthenticationService.java
+++ b/src/main/java/cn/gdeiassistant/core/authentication/service/AuthenticationService.java
@@ -13,8 +13,17 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Service
 public class AuthenticationService {
+
+    private static final Map<Integer, AuthenticationEnum> AUTHENTICATION_TYPES = Arrays.stream(AuthenticationEnum.values())
+            .collect(Collectors.toUnmodifiableMap(AuthenticationEnum::getValue, Function.identity()));
 
     @Autowired
     private AuthenticationMapper authenticationMapper;
@@ -73,11 +82,10 @@ public class AuthenticationService {
     }
 
     private AuthenticationEnum resolveAuthenticationType(Authentication authentication) throws InconsistentAuthenticationException {
-        try {
-            return AuthenticationEnum.values()[authentication.getType()];
-        } catch (NullPointerException | ArrayIndexOutOfBoundsException e) {
-            throw new InconsistentAuthenticationException("证件类型不合法");
-        }
+        return Optional.ofNullable(authentication)
+                .map(Authentication::getType)
+                .map(AUTHENTICATION_TYPES::get)
+                .orElseThrow(() -> new InconsistentAuthenticationException("证件类型不合法"));
     }
 
     /**

--- a/src/main/java/cn/gdeiassistant/core/authentication/service/AuthenticationService.java
+++ b/src/main/java/cn/gdeiassistant/core/authentication/service/AuthenticationService.java
@@ -52,12 +52,7 @@ public class AuthenticationService {
     public void UpdateAuthentication(String sessionId
             , Authentication authentication
             , @Nullable MultipartFile[] images) throws NullIDPhotoException, InconsistentAuthenticationException, AuthenticationRecordExistException, IDPhotoCountLimitationException, IDPhotoSizeLimitationException {
-        if (authentication == null || authentication.getType() == null
-                || authentication.getType() < 0
-                || authentication.getType() >= AuthenticationEnum.values().length) {
-            throw new InconsistentAuthenticationException("证件类型不合法");
-        }
-        switch (AuthenticationEnum.values()[authentication.getType()]) {
+        switch (resolveAuthenticationType(authentication)) {
             case MAINLAND_CHINESE_RESIDENT_ID_CARD:
                 //中国居民身份证，使用API进行审核
                 aliYunAPIUtils.VerifyMainLandChineseResidentIDCard(authentication);
@@ -74,6 +69,14 @@ public class AuthenticationService {
 
             default:
                 throw new InconsistentAuthenticationException("该证件类型的实名认证暂未开放");
+        }
+    }
+
+    private AuthenticationEnum resolveAuthenticationType(Authentication authentication) throws InconsistentAuthenticationException {
+        try {
+            return AuthenticationEnum.values()[authentication.getType()];
+        } catch (NullPointerException | ArrayIndexOutOfBoundsException e) {
+            throw new InconsistentAuthenticationException("证件类型不合法");
         }
     }
 

--- a/src/main/java/cn/gdeiassistant/core/authentication/service/AuthenticationService.java
+++ b/src/main/java/cn/gdeiassistant/core/authentication/service/AuthenticationService.java
@@ -52,6 +52,11 @@ public class AuthenticationService {
     public void UpdateAuthentication(String sessionId
             , Authentication authentication
             , @Nullable MultipartFile[] images) throws NullIDPhotoException, InconsistentAuthenticationException, AuthenticationRecordExistException, IDPhotoCountLimitationException, IDPhotoSizeLimitationException {
+        if (authentication == null || authentication.getType() == null
+                || authentication.getType() < 0
+                || authentication.getType() >= AuthenticationEnum.values().length) {
+            throw new InconsistentAuthenticationException("证件类型不合法");
+        }
         switch (AuthenticationEnum.values()[authentication.getType()]) {
             case MAINLAND_CHINESE_RESIDENT_ID_CARD:
                 //中国居民身份证，使用API进行审核

--- a/src/main/java/cn/gdeiassistant/core/userlogin/service/UserCertificateService.java
+++ b/src/main/java/cn/gdeiassistant/core/userlogin/service/UserCertificateService.java
@@ -171,7 +171,7 @@ public class UserCertificateService {
      * @return
      */
     private void updateSessionCertificate(String sessionId, String username, String password) throws PasswordIncorrectException, NetWorkTimeoutException, ServerErrorException {
-        UserCertificateEntity userCertificate = userCertificateDao.queryUserSessionCertificate(username);
+        UserCertificateEntity userCertificate = userCertificateDao.queryUserSessionCertificate(sessionId);
         if (userCertificate == null) {
             CloseableHttpClient httpClient = null;
             CookieStore cookieStore = null;

--- a/src/test/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtilsTest.java
+++ b/src/test/java/cn/gdeiassistant/common/tools/Utils/StringEncryptUtilsTest.java
@@ -1,0 +1,69 @@
+package cn.gdeiassistant.common.tools.Utils;
+
+import cn.gdeiassistant.common.pojo.Encryption.AESEncryptConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StringEncryptUtilsTest {
+
+    private final StringEncryptUtils encryptUtils = new StringEncryptUtils();
+
+    @BeforeEach
+    void setUp() {
+        AESEncryptConfig config = new AESEncryptConfig();
+        config.setPrivateKey("test-only-private-key");
+        encryptUtils.setEncryptConfig(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        encryptUtils.setEncryptConfig(null);
+    }
+
+    @Test
+    void roundTripWorksAcrossIndependentCalls() throws Exception {
+        String encrypted = StringEncryptUtils.encryptString("campus-password");
+
+        assertTrue(encrypted.startsWith("v1:"));
+        assertEquals("campus-password", StringEncryptUtils.decryptString(encrypted));
+    }
+
+    @Test
+    void emptyStringRoundTripWorks() throws Exception {
+        assertEquals("", StringEncryptUtils.decryptString(StringEncryptUtils.encryptString("")));
+    }
+
+    @Test
+    void encryptionsUseFreshIv() throws Exception {
+        assertNotEquals(
+                StringEncryptUtils.encryptString("same-value"),
+                StringEncryptUtils.encryptString("same-value")
+        );
+    }
+
+    @Test
+    void tamperingIsRejected() throws Exception {
+        String encrypted = StringEncryptUtils.encryptString("campus-password");
+        byte[] payload = Base64.getUrlDecoder().decode(encrypted.substring("v1:".length()));
+        payload[payload.length - 1] ^= 1;
+        String tampered = "v1:" + Base64.getUrlEncoder().withoutPadding().encodeToString(payload);
+
+        assertThrows(GeneralSecurityException.class,
+                () -> StringEncryptUtils.decryptString(tampered));
+    }
+
+    @Test
+    void legacyValuesAreRejectedInsteadOfReturningNull() {
+        assertThrows(GeneralSecurityException.class,
+                () -> StringEncryptUtils.decryptString("legacy-ciphertext"));
+    }
+}

--- a/src/test/java/cn/gdeiassistant/common/typehandler/MybatisEncryptionTypeHandlerTest.java
+++ b/src/test/java/cn/gdeiassistant/common/typehandler/MybatisEncryptionTypeHandlerTest.java
@@ -1,0 +1,41 @@
+package cn.gdeiassistant.common.typehandler;
+
+import cn.gdeiassistant.common.pojo.Encryption.AESEncryptConfig;
+import cn.gdeiassistant.common.tools.Utils.StringEncryptUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MybatisEncryptionTypeHandlerTest {
+
+    private final StringEncryptUtils encryptUtils = new StringEncryptUtils();
+    private final MybatisEncryptionTypeHandler handler = new MybatisEncryptionTypeHandler();
+
+    @BeforeEach
+    void setUp() {
+        AESEncryptConfig config = new AESEncryptConfig();
+        config.setPrivateKey("test-only-private-key");
+        encryptUtils.setEncryptConfig(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        encryptUtils.setEncryptConfig(null);
+    }
+
+    @Test
+    void invalidStoredCiphertextFailsClosed() throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("password")).thenReturn("legacy-ciphertext");
+
+        assertThrows(SQLException.class,
+                () -> handler.getNullableResult(resultSet, "password"));
+    }
+}

--- a/src/test/java/cn/gdeiassistant/core/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/authentication/service/AuthenticationServiceTest.java
@@ -1,0 +1,29 @@
+package cn.gdeiassistant.core.authentication.service;
+
+import cn.gdeiassistant.common.pojo.Entity.Authentication;
+import cn.gdeiassistant.common.exception.AuthenticationException.InconsistentAuthenticationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AuthenticationServiceTest {
+
+    private final AuthenticationService service = new AuthenticationService();
+
+    @Test
+    void nullTypeIsRejectedBeforeArrayLookup() {
+        Authentication authentication = new Authentication();
+
+        assertThrows(InconsistentAuthenticationException.class,
+                () -> service.UpdateAuthentication("session-1", authentication, null));
+    }
+
+    @Test
+    void outOfRangeTypeIsRejectedBeforeArrayLookup() {
+        Authentication authentication = new Authentication();
+        authentication.setType(99);
+
+        assertThrows(InconsistentAuthenticationException.class,
+                () -> service.UpdateAuthentication("session-1", authentication, null));
+    }
+}

--- a/src/test/java/cn/gdeiassistant/core/userlogin/service/UserCertificateServiceTest.java
+++ b/src/test/java/cn/gdeiassistant/core/userlogin/service/UserCertificateServiceTest.java
@@ -1,0 +1,29 @@
+package cn.gdeiassistant.core.userLogin.service;
+
+import cn.gdeiassistant.common.redis.UserCertificate.UserCertificateDao;
+import cn.gdeiassistant.core.userLogin.pojo.entity.UserCertificateEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class UserCertificateServiceTest {
+
+    @Test
+    void sessionRefreshLooksUpCertificateBySessionId() throws Exception {
+        UserCertificateDao dao = mock(UserCertificateDao.class);
+        when(dao.queryUserSessionCertificate("session-1"))
+                .thenReturn(new UserCertificateEntity());
+
+        UserCertificateService service = new UserCertificateService();
+        ReflectionTestUtils.setField(service, "userCertificateDao", dao);
+
+        service.syncUpdateSessionCertificate("session-1", "username", "password");
+
+        verify(dao).queryUserSessionCertificate("session-1");
+        verifyNoMoreInteractions(dao);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace unreliable encrypted-field handling with versioned AES-GCM.
- Fail closed on encrypted-field errors and validate authentication input.
- Fix session certificate lookup and add regression tests.

## Test plan
- `./gradlew test --no-daemon`
